### PR TITLE
catch refs to Acts with year included before number

### DIFF
--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -113,8 +113,17 @@ class RefsFinderENG(BaseRefsFinder):
     # country, language, locality
     locale = (None, 'eng', None)
 
-    # if this changes, update indigo_za/refs.py
-    act_re = re.compile(r'\bAct,?\s+(?:\d{4}\s+)?(?:\()?(([nN]o\.?\s*)?(\d+)\s+of\s+(\d{4}))')
+    act_re = re.compile(
+        r'''\bAct,?\s+
+            (?:\d{4}\s+)?
+            (?:\()?
+            (
+             ([nN]o\.?\s*)?
+             (\d+)\s+
+             of\s+
+             (\d{4})
+            )
+        ''', re.X)
     candidate_xpath = ".//text()[contains(., 'Act') and not(ancestor::a:ref)]"
 
     def make_href(self, match):

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -84,6 +84,7 @@ class RefsFinderENG(BaseRefsFinder):
 
         Act 52 of 2001
         Act no. 52 of 1998
+        Income Tax Act, 1962 (No 58 of 1962)
 
     """
 
@@ -91,8 +92,10 @@ class RefsFinderENG(BaseRefsFinder):
     locale = (None, 'eng', None)
 
     # if this changes, update indigo_za/refs.py
-    act_re = re.compile(r'\bAct,?\s+([nN]o\.?\s*)?(\d+)+\s+of\s+(\d{4})')
+    act_re = re.compile(r'\bAct,?\s+(\d{4}\s+)?(\()?([nN]o\.?\s*)?(\d+)\s+of\s+(\d{4})')
     candidate_xpath = ".//text()[contains(., 'Act') and not(ancestor::a:ref)]"
 
     def make_href(self, match):
-        return '/%s/act/%s/%s' % (self.frbr_uri.country, match.group(3), match.group(2))
+        year = match.group(4)
+        number = match.group(3)
+        return '/%s/act/%s/%s' % (self.frbr_uri.country, year, number)

--- a/indigo_za/refs.py
+++ b/indigo_za/refs.py
@@ -1,4 +1,5 @@
 import re
+from lxml import etree
 
 from indigo.analysis.refs.base import BaseRefsFinder
 from indigo.plugins import plugins
@@ -22,13 +23,13 @@ class RefsFinderENGza(BaseRefsFinder):
 
     # if Act part changes, update indigo/analysis/refs/global.py
     act_re = re.compile(
-        r'\bAct,?\s+(\d{4}\s+)?\(?([nN]o\.?\s*)?(\d+)\s+of\s+(\d{4})|\bConstitution\b(\s+of(\s+the\s+Republic\s+of)?\s+South\s+Africa)?((\s+Act)?,?\s+1996)?'
+        r'\b(Act,?\s+(\d{4}\s+)?\(?(([nN]o\.?\s*)?(\d+)\s+of\s+(\d{4})))|\bConstitution\b(\s+of(\s+the\s+Republic\s+of)?\s+South\s+Africa)?((\s+Act)?,?\s+1996)?'
     )
     candidate_xpath = ".//text()[(contains(., 'Act') or contains(., 'Constitution')) and not(ancestor::a:ref)]"
 
     def make_href(self, match):
-        year = match.group(4)
-        number = match.group(3)
+        year = match.group(6)
+        number = match.group(5)
         if 'Constitution' in match.group(0):
             return '/za/act/1996/constitution'
         elif self.frbr_uri.country == 'za' and year == '1996' and number == '108':
@@ -36,6 +37,19 @@ class RefsFinderENGza(BaseRefsFinder):
             return '/za/act/1996/constitution'
         else:
             return '/%s/act/%s/%s' % (self.frbr_uri.country, year, number)
+
+    def make_ref(self, match):
+        if 'Constitution' in match.group(0):
+            group = 0
+        elif match.group(2):
+            group = 3
+        else:
+            group = 1
+
+        ref = etree.Element(self.ref_tag)
+        ref.text = match.group(group)
+        ref.set('href', self.make_href(match))
+        return (ref, match.start(group), match.end(group))
 
 
 @plugins.register('refs')

--- a/indigo_za/refs.py
+++ b/indigo_za/refs.py
@@ -23,8 +23,18 @@ class RefsFinderENGza(BaseRefsFinder):
 
     # if Act part changes, update indigo/analysis/refs/global.py
     act_re = re.compile(
-        r'\b(Act,?\s+(\d{4}\s+)?\(?(([nN]o\.?\s*)?(\d+)\s+of\s+(\d{4})))|\bConstitution\b(\s+of(\s+the\s+Republic\s+of)?\s+South\s+Africa)?((\s+Act)?,?\s+1996)?'
-    )
+        r'''\b
+            (
+             Act,?\s+(\d{4}\s+)?                    # Act   or   Act, 1998
+              \(?                                   # Tax Act, 1962 (No 58 of 1962)
+              (
+               ([nN]o\.?\s*)?(\d+)\s+of\s+(\d{4})   # no. NN of NNNN
+                                                    #     NN of NNNN
+              )
+            )
+            |
+            \bConstitution\b(\s+of(\s+the\s+Republic\s+of)?\s+South\s+Africa)?((\s+Act)?,?\s+1996)?
+        ''', re.X)
     candidate_xpath = ".//text()[(contains(., 'Act') or contains(., 'Constitution')) and not(ancestor::a:ref)]"
 
     def make_href(self, match):

--- a/indigo_za/refs.py
+++ b/indigo_za/refs.py
@@ -10,6 +10,7 @@ class RefsFinderENGza(BaseRefsFinder):
 
         Act 52 of 2001
         Act no. 52 of 1998
+        Income Tax Act, 1962 (No 58 of 1962)
         Constitution [of [the Republic of] South Africa] [Act][,] [1996]
 
         If not in South Africa ('za'), should default to indigo/analysis/refs/global.py (doesn't include 'Constitution')
@@ -20,17 +21,21 @@ class RefsFinderENGza(BaseRefsFinder):
     locale = ('za', 'eng', None)
 
     # if Act part changes, update indigo/analysis/refs/global.py
-    act_re = re.compile(r'\bAct,?\s+([nN]o\.?\s*)?(\d+)+\s+of\s+(\d{4})|\bConstitution\b(\s+of(\s+the\s+Republic\s+of)?\s+South\s+Africa)?((\s+Act)?,?\s+1996)?')
+    act_re = re.compile(
+        r'\bAct,?\s+(\d{4}\s+)?\(?([nN]o\.?\s*)?(\d+)\s+of\s+(\d{4})|\bConstitution\b(\s+of(\s+the\s+Republic\s+of)?\s+South\s+Africa)?((\s+Act)?,?\s+1996)?'
+    )
     candidate_xpath = ".//text()[(contains(., 'Act') or contains(., 'Constitution')) and not(ancestor::a:ref)]"
 
     def make_href(self, match):
+        year = match.group(4)
+        number = match.group(3)
         if 'Constitution' in match.group(0):
             return '/za/act/1996/constitution'
-        elif self.frbr_uri.country == 'za' and match.group(3) == '1996' and match.group(2) == '108':
-            # Act 108 of 1996 was originally the constitution
+        elif self.frbr_uri.country == 'za' and year == '1996' and number == '108':
+            # the Constitution was originally Act 108 of 1996
             return '/za/act/1996/constitution'
         else:
-            return '/%s/act/%s/%s' % (self.frbr_uri.country, match.group(3), match.group(2))
+            return '/%s/act/%s/%s' % (self.frbr_uri.country, year, number)
 
 
 @plugins.register('refs')

--- a/indigo_za/tests/test_refs.py
+++ b/indigo_za/tests/test_refs.py
@@ -158,6 +158,34 @@ class RefsFinderENGzaTestCase(APITestCase):
 </body>
 ''', etree.tostring(doc.doc.body, pretty_print=True))
 
+    def test_find_without_act_in_parens(self):
+        doc = Document(content=document_fixture(xml=u"""
+<section id="section-1">
+  <num>1.</num>
+  <heading>Tester</heading>
+  <paragraph id="section-1.paragraph-0">
+    <content>
+      <p>Something to do with Income Tax Act, 1962 (No 58 of 1962).</p>
+    </content>
+  </paragraph>
+</section>
+        """))
+
+        self.finder.find_references_in_document(doc)
+        self.maxDiff = None
+        self.assertMultiLineEqual('''<body xmlns="http://www.akomantoso.org/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <section id="section-1">
+    <num>1.</num>
+    <heading>Tester</heading>
+    <paragraph id="section-1.paragraph-0">
+      <content>
+        <p>Something to do with Income Tax Act, 1962 (<ref href="/za/act/1962/58">No 58 of 1962</ref>).</p>
+      </content>
+    </paragraph>
+  </section>
+</body>
+''', etree.tostring(doc.doc.body, pretty_print=True))
+
 
 class RefsFinderAFRzaTestCase(APITestCase):
     def setUp(self):

--- a/indigo_za/tests/test_refs.py
+++ b/indigo_za/tests/test_refs.py
@@ -11,6 +11,7 @@ from indigo_api.models import Document
 
 class RefsFinderENGzaTestCase(APITestCase):
     def setUp(self):
+        self.maxDiff = None
         self.finder = RefsFinderENGza()
 
     def test_find_simple(self):
@@ -189,6 +190,7 @@ class RefsFinderENGzaTestCase(APITestCase):
 
 class RefsFinderAFRzaTestCase(APITestCase):
     def setUp(self):
+        self.maxDiff = None
         self.finder = RefsFinderAFRza()
 
     def test_find_simple(self):


### PR DESCRIPTION
but whole regex links which doesn't look great
would be cool if the link could start at match.group(3) instead of match.start()