### PR TITLE
Make usernames links to profile

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -277,6 +277,7 @@ REST_FRAMEWORK = {
 SUPPORT_EMAIL = os.environ.get('SUPPORT_EMAIL')
 INDIGO_ORGANISATION = os.environ.get('INDIGO_ORGANISATION', 'Indigo Platform')
 INDIGO_URL = os.environ.get('INDIGO_URL', 'http://localhost:8000')
+INDIGO_USER_PROFILE_URL = 'indigo_social:user_profile'
 RESOLVER_URL = os.environ.get('RESOLVER_URL', INDIGO_URL + "/resolver/resolve")
 
 DEFAULT_FROM_EMAIL = os.environ.get('DJANGO_DEFAULT_FROM_EMAIL', '%s %s' % (INDIGO_ORGANISATION, SUPPORT_EMAIL))

--- a/indigo_app/templates/indigo_api/_work_diff_card.html
+++ b/indigo_app/templates/indigo_api/_work_diff_card.html
@@ -1,11 +1,11 @@
-{% load account %}
+{% load indigo_app %}
 
 <div class="card mb-3">
   <div class="card-body">
     <a href="#changes-{{ version.id }}" data-toggle="collapse" class="float-right">{{ version.changes|length }} change{{ version.changes|length|pluralize}}</a>
     <div>
       <span class="time-ago" data-timestamp="{{ version.revision.date_created|date:'c' }}">{{ version.revision.date_created|date:"Y-m-d H:i" }}</span>
-      by {% user_display version.revision.user %}
+      by {% user_profile version.revision.user %}
       {% if version.revision.comment %}
         <span class="text-muted">· {{ version.revision.comment }}</span>
       {% endif %}

--- a/indigo_app/templatetags/indigo_app.py
+++ b/indigo_app/templatetags/indigo_app.py
@@ -1,0 +1,22 @@
+from django import template
+from django.urls import reverse
+from django.utils.html import format_html
+from django.conf import settings
+from allauth.account.utils import user_display
+
+register = template.Library()
+
+
+@register.simple_tag
+def user_profile(user):
+    """ Formatted link to a user's profile, using their display name.
+    """
+    username = user_display(user)
+    profile_url = settings.INDIGO_USER_PROFILE_URL
+    if profile_url:
+        url = reverse('indigo_social:user_profile', kwargs={'username': user.username})
+        html = format_html('<a href="{}">{}</a>', url, username)
+    else:
+        html = username
+
+    return html

--- a/indigo_social/templates/indigo_social/badge_detail.html
+++ b/indigo_social/templates/indigo_social/badge_detail.html
@@ -1,5 +1,5 @@
 {% extends "main.html" %}
-{% load account %}
+{% load indigo_app %}
 
 {% block title%}{{ badge.name }} {{ block.super }}{% endblock %}
 
@@ -23,7 +23,7 @@
             <ul>
             {% for award in awards %}
               <li>
-                <a href="{% url 'indigo_social:user_profile' username=award.user.username %}">{% user_display award.user %}</a> – <span class="text-muted">{{ award.awarded_at|timesince }} ago</span>
+                {% user_profile award.user %} – <span class="text-muted">{{ award.awarded_at|timesince }} ago</span>
               </li>
             {% endfor %}
             </ul>

--- a/indigo_social/templates/indigo_social/contributors.html
+++ b/indigo_social/templates/indigo_social/contributors.html
@@ -1,5 +1,5 @@
 {% extends "main.html" %}
-{% load account %}
+{% load indigo_app %}
 
 {% block title%}Contributors {{ block.super }}{% endblock %}
 {% block breadcrumbs %}
@@ -15,9 +15,7 @@
     {% for userprofile in object_list %}
       <div class="card">
         <div class="card-header">
-          <h4>
-            <a href="{% url 'indigo_social:user_profile' username=userprofile.user.username %}">{% user_display userprofile.user %}</a>
-          </h4>
+          <h4>{% user_profile userprofile.user %}</h4>
         </div>
         <div class="card-body">
           {% if userprofile.bio %}{{ userprofile.bio|default:'' | linebreaks }}{% endif %}


### PR DESCRIPTION
This gives us a mechanism for generically linking to a user's profile, without requiring that indigo_social is installed. Once we have this, we can make most references to a user's username use this, and ensure we start linking to contributor profiles.