### PR TITLE
Restrict charset for work numbers. Fixes #234.

### DIFF
--- a/indigo_app/static/javascript/indigo/views/work.js
+++ b/indigo_app/static/javascript/indigo/views/work.js
@@ -118,6 +118,7 @@
       this.listenTo(this.model, 'change:repealed_by', this.repealChanged);
       this.listenTo(this.model, 'change:commencing_work', this.commencingWorkChanged);
       this.listenTo(this.model, 'change:parent_work', this.parentChanged);
+      this.listenTo(this.model, 'change:number', this.numberChanged);
       this.listenTo(this.model, 'change:publication_document', this.publicationDocumentChanged);
       this.listenTo(this.model, 'change:publication_date change:publication_name change:publication_number',
                     _.debounce(this.publicationChanged, 1000));
@@ -140,6 +141,10 @@
       }
       this.$('.work-title').text(this.model.get('title') || '(untitled work)');
       this.$('.work-frbr-uri').text(this.model.get('frbr_uri'));
+    },
+
+    numberChanged: function(model, value, options) {
+      model.set('number', value.replace(/[^a-z\d-]+/gi, '-').replace(/--+/g, '-'));
     },
 
     setDirty: function() {

--- a/indigo_app/templates/indigo_api/work_detail.html
+++ b/indigo_app/templates/indigo_api/work_detail.html
@@ -55,7 +55,7 @@
           <div class="form-group col-md-6 offset-md-3">
             <label for="work_number" class="required">Number within year</label>
             <input type="text" class="form-control" id="work_number" required pattern="[^\s]+">
-            <p class="form-text text-muted">Number or short name that uniquely identifies this legislation within the year of introduction</p>
+            <p class="form-text text-muted">Number or short name that uniquely identifies this legislation within the year of introduction. Numbers, letters and '-' only.</p>
           </div>
         </div>
 


### PR DESCRIPTION
Otherwise we'll have numbers with spaces and underscores. Yuck.