### PR TITLE
Improved schedules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 ruby '2.3.3'
 
-gem 'slaw', '~> 1.0.4'
+gem 'slaw', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    json (1.8.6)
     log4r (1.1.10)
-    mime-types (1.25.1)
     mimemagic (0.2.1)
     mini_portile2 (2.3.0)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     polyglot (0.3.5)
-    slaw (1.0.4)
+    slaw (2.2.0)
       log4r (~> 1.1.10)
       mimemagic (~> 0.2.1)
       nokogiri (~> 1.8.5)
       thor (~> 0.19.1)
       treetop (~> 1.5)
-      twitter-text (~> 1.12.0)
-      yomu (~> 0.2.2)
     thor (0.19.4)
     treetop (1.6.10)
       polyglot (~> 0.3)
-    twitter-text (1.12.0)
-      unf (~> 0.1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.5)
-    yomu (0.2.4)
-      json (~> 1.8)
-      mime-types (~> 1.23)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  slaw (~> 1.0.4)
+  slaw (~> 2.2)
 
 RUBY VERSION
    ruby 2.3.3p222

--- a/indigo_api/static/xsl/act.xsl
+++ b/indigo_api/static/xsl/act.xsl
@@ -139,21 +139,32 @@
 
   <!-- components/schedules -->
   <xsl:template match="a:doc">
-    <!-- a:doc doesn't an id, so add one -->
+    <!-- a:doc doesn't have an id, so add one -->
     <article class="akn-doc" id="{@name}">
-      <xsl:apply-templates select="@*" />
-      <xsl:if test="a:meta/a:identification/a:FRBRWork/a:FRBRalias">
-        <h2>
-          <xsl:value-of select="a:meta/a:identification/a:FRBRWork/a:FRBRalias/@value" />
-        </h2>
-      </xsl:if>
+      <xsl:choose>
+        <xsl:when test="a:mainBody/a:hcontainer[@name='schedule']">
+          <!-- new style schedule -->
+          <xsl:apply-templates select="a:mainBody/a:hcontainer[@name='schedule']" />
+        </xsl:when>
 
-      <xsl:apply-templates select="a:coverPage" />
-      <xsl:apply-templates select="a:preface" />
-      <xsl:apply-templates select="a:preamble" />
-      <xsl:apply-templates select="a:mainBody" />
-      <xsl:apply-templates select="a:conclusions" />
+        <xsl:otherwise>
+          <!-- old style schedule -->
+          <xsl:apply-templates select="@*" />
+          <xsl:if test="a:meta/a:identification/a:FRBRWork/a:FRBRalias">
+            <h2>
+              <xsl:value-of select="a:meta/a:identification/a:FRBRWork/a:FRBRalias/@value" />
+            </h2>
+          </xsl:if>
+          <xsl:apply-templates select="a:mainBody" />
+        </xsl:otherwise>
+      </xsl:choose>
     </article>
+  </xsl:template>
+
+  <xsl:template match="a:hcontainer[@name='schedule']/a:heading | a:hcontainer[@name='schedule']/a:subheading">
+    <h2>
+      <xsl:apply-templates />
+    </h2>
   </xsl:template>
 
   <!-- for block elements, generate a span element with a class matching

--- a/indigo_api/static/xsl/act.xsl
+++ b/indigo_api/static/xsl/act.xsl
@@ -82,9 +82,9 @@
           <xsl:when test="$lang = 'zul'"><xsl:text>Ingxenye </xsl:text></xsl:when>
           <xsl:otherwise><xsl:text>Part </xsl:text></xsl:otherwise>
         </xsl:choose>
-        <xsl:value-of select="./a:num" />
+        <xsl:value-of select="a:num" />
         <xsl:text> - </xsl:text>
-        <xsl:value-of select="./a:heading" />
+        <xsl:apply-templates select="a:heading" mode="inline" />
       </h2>
       
       <xsl:apply-templates select="./*[not(self::a:num) and not(self::a:heading)]" />
@@ -108,9 +108,9 @@
           <xsl:when test="$lang = 'zul'"><xsl:text>Isahluko </xsl:text></xsl:when>
           <xsl:otherwise><xsl:text>Chapter </xsl:text></xsl:otherwise>
         </xsl:choose>
-        <xsl:value-of select="./a:num" />
+        <xsl:value-of select="a:num" />
         <br/>
-        <xsl:value-of select="./a:heading" />
+        <xsl:apply-templates select="a:heading" mode="inline" />
       </h2>
       
       <xsl:apply-templates select="./*[not(self::a:num) and not(self::a:heading)]" />
@@ -121,9 +121,9 @@
     <section class="akn-section">
       <xsl:apply-templates select="@*" />
       <h3>
-        <xsl:value-of select="./a:num" />
+        <xsl:value-of select="a:num" />
         <xsl:text> </xsl:text>
-        <xsl:value-of select="./a:heading" />
+        <xsl:apply-templates select="a:heading" mode="inline" />
       </h3>
       
       <xsl:apply-templates select="./*[not(self::a:num) and not(self::a:heading)]" />
@@ -236,6 +236,14 @@
       <xsl:apply-templates select="@*" />
       <xsl:apply-templates />
     </span>
+  </xsl:template>
+
+  <!-- Special inline mode which doesn't include the akn-foo marker.
+       This is used mostly by blocks that format their own headings, and
+       don't want akn-heading to be applied to heading elements. -->
+  <xsl:template match="*" mode="inline">
+    <xsl:apply-templates select="@*" />
+    <xsl:apply-templates />
   </xsl:template>
   
   <!-- For HTML table elements, copy them over then apply normal AN

--- a/indigo_api/static/xsl/act_text.xsl
+++ b/indigo_api/static/xsl/act_text.xsl
@@ -143,16 +143,17 @@
 
   <!-- old-style schedules, "article" elements -->
   <xsl:template match="a:doc/a:mainBody/a:article">
-    <xsl:text>Schedule - </xsl:text>
+    <xsl:text>SCHEDULE - </xsl:text>
     <xsl:value-of select="../../a:meta/a:identification/a:FRBRWork/a:FRBRalias/@value" />
     <xsl:text>&#10;</xsl:text>
 
-    <xsl:if test="not(a:mainBody/a:article/a:heading)">
-      <!-- ensure an extra blank line if there is no heading -->
+    <xsl:if test="a:heading">
+      <xsl:apply-templates select="a:heading" />
       <xsl:text>&#10;</xsl:text>
     </xsl:if>
 
-    <xsl:apply-templates select="a:mainBody" />
+    <xsl:text>&#10;</xsl:text>
+    <xsl:apply-templates select="./*[not(self::a:heading)]"/>
   </xsl:template>
 
 

--- a/indigo_api/static/xsl/act_text.xsl
+++ b/indigo_api/static/xsl/act_text.xsl
@@ -38,17 +38,15 @@
 
   <xsl:template match="a:preface">
     <xsl:text>PREFACE</xsl:text>
-    <xsl:text>
+    <xsl:text>&#10;&#10;</xsl:text>
 
-</xsl:text>
     <xsl:apply-templates />
   </xsl:template>
 
   <xsl:template match="a:preamble">
     <xsl:text>PREAMBLE</xsl:text>
-    <xsl:text>
+    <xsl:text>&#10;&#10;</xsl:text>
 
-</xsl:text>
     <xsl:apply-templates />
   </xsl:template>
 
@@ -57,6 +55,8 @@
     <xsl:value-of select="a:num" />
     <xsl:text> - </xsl:text>
     <xsl:apply-templates select="a:heading" />
+    <xsl:text>&#10;&#10;</xsl:text>
+
     <xsl:apply-templates select="./*[not(self::a:num) and not(self::a:heading)]" />
   </xsl:template>
 
@@ -65,6 +65,8 @@
     <xsl:value-of select="a:num" />
     <xsl:text> - </xsl:text>
     <xsl:apply-templates select="a:heading" />
+    <xsl:text>&#10;&#10;</xsl:text>
+
     <xsl:apply-templates select="./*[not(self::a:num) and not(self::a:heading)]" />
   </xsl:template>
 
@@ -72,6 +74,8 @@
     <xsl:value-of select="a:num" />
     <xsl:text> </xsl:text>
     <xsl:apply-templates select="a:heading" />
+    <xsl:text>&#10;&#10;</xsl:text>
+
     <xsl:apply-templates select="./*[not(self::a:num) and not(self::a:heading)]" />
   </xsl:template>
   
@@ -80,31 +84,20 @@
       <xsl:value-of select="a:num" />
       <xsl:text> </xsl:text>
     </xsl:if>
+
     <xsl:apply-templates select="./*[not(self::a:num) and not(self::a:heading)]" />
   </xsl:template>
 
-  <!-- these are block elements and have a newline at the end -->
-  <xsl:template match="a:heading">
-    <xsl:apply-templates />
-    <xsl:text>
-
-</xsl:text>
-  </xsl:template>
-
+  <!-- p tags must end with a blank line -->
   <xsl:template match="a:p">
     <xsl:apply-templates/>
-    <!-- p tags must end with a newline -->
-    <xsl:text>
-
-</xsl:text>
+    <xsl:text>&#10;&#10;</xsl:text>
   </xsl:template>
 
   <xsl:template match="a:blockList">
     <xsl:if test="a:listIntroduction != ''">
       <xsl:apply-templates select="a:listIntroduction" />
-      <xsl:text>
-
-</xsl:text>
+      <xsl:text>&#10;&#10;</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="./*[not(self::a:listIntroduction)]" />
   </xsl:template>
@@ -118,9 +111,7 @@
   <xsl:template match="a:list">
     <xsl:if test="a:intro != ''">
       <xsl:apply-templates select="a:intro" />
-      <xsl:text>
-
-</xsl:text>
+      <xsl:text>&#10;&#10;</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="./*[not(self::a:intro)]" />
   </xsl:template>
@@ -136,20 +127,16 @@
   <!-- components/schedules -->
   <!-- new-style schedules, "article" elements -->
   <xsl:template match="a:hcontainer[@name='schedule']">
-    <xsl:text>Schedule - </xsl:text>
-    <xsl:apply-templates select="a:heading" mode="nonewline" />
-    <xsl:text>
-</xsl:text>
+    <xsl:text>SCHEDULE - </xsl:text>
+    <xsl:apply-templates select="a:heading" />
+    <xsl:text>&#10;</xsl:text>
 
     <xsl:if test="a:subheading">
       <xsl:apply-templates select="a:subheading" />
-      <xsl:text>
-</xsl:text>
+      <xsl:text>&#10;</xsl:text>
     </xsl:if>
 
-    <xsl:text>
-
-</xsl:text>
+    <xsl:text>&#10;&#10;</xsl:text>
     <xsl:apply-templates select="./*[not(self::a:heading) and not(self::a:subheading)]" />
   </xsl:template>
 
@@ -158,13 +145,11 @@
   <xsl:template match="a:doc/a:mainBody/a:article">
     <xsl:text>Schedule - </xsl:text>
     <xsl:value-of select="../../a:meta/a:identification/a:FRBRWork/a:FRBRalias/@value" />
-    <xsl:text>
-</xsl:text>
+    <xsl:text>&#10;</xsl:text>
 
     <xsl:if test="not(a:mainBody/a:article/a:heading)">
       <!-- ensure an extra blank line if there is no heading -->
-      <xsl:text>
-</xsl:text>
+      <xsl:text>&#10;</xsl:text>
     </xsl:if>
 
     <xsl:apply-templates select="a:mainBody" />
@@ -254,8 +239,7 @@
   </xsl:template>
 
   <xsl:template match="a:eol">
-    <xsl:text>
-</xsl:text>
+    <xsl:text>&#10;</xsl:text>
   </xsl:template>
 
 

--- a/indigo_api/static/xsl/act_text.xsl
+++ b/indigo_api/static/xsl/act_text.xsl
@@ -132,10 +132,32 @@
     </xsl:call-template>
   </xsl:template>
 
+
   <!-- components/schedules -->
-  <xsl:template match="a:doc">
+  <!-- new-style schedules, "article" elements -->
+  <xsl:template match="a:hcontainer[@name='schedule']">
     <xsl:text>Schedule - </xsl:text>
-    <xsl:value-of select="a:meta/a:identification/a:FRBRWork/a:FRBRalias/@value" />
+    <xsl:apply-templates select="a:heading" mode="nonewline" />
+    <xsl:text>
+</xsl:text>
+
+    <xsl:if test="a:subheading">
+      <xsl:apply-templates select="a:subheading" />
+      <xsl:text>
+</xsl:text>
+    </xsl:if>
+
+    <xsl:text>
+
+</xsl:text>
+    <xsl:apply-templates select="./*[not(self::a:heading) and not(self::a:subheading)]" />
+  </xsl:template>
+
+
+  <!-- old-style schedules, "article" elements -->
+  <xsl:template match="a:doc/a:mainBody/a:article">
+    <xsl:text>Schedule - </xsl:text>
+    <xsl:value-of select="../../a:meta/a:identification/a:FRBRWork/a:FRBRalias/@value" />
     <xsl:text>
 </xsl:text>
 
@@ -147,6 +169,7 @@
 
     <xsl:apply-templates select="a:mainBody" />
   </xsl:template>
+
 
   <!-- tables -->
   <xsl:template match="a:table">

--- a/indigo_api/tests/xslt_fixtures/act_text-complex-headings-output.txt
+++ b/indigo_api/tests/xslt_fixtures/act_text-complex-headings-output.txt
@@ -4,7 +4,7 @@ Chapter 1 - Definitions and application [[Remark [Act No. 117 of 1998](/za/act/1
 
 In this By-law, unless the context otherwise indicates —
 
-Schedule - Schedule 3
+SCHEDULE - Schedule 3
 Schedule of fines
 
 [[Schedule 3 repealed by amendment on 2009-08-19]].

--- a/indigo_api/tests/xslt_fixtures/act_text-general-output.txt
+++ b/indigo_api/tests/xslt_fixtures/act_text-general-output.txt
@@ -390,7 +390,7 @@ shall be guilty of an offence.
 
 This By-Law is called City of Cape Town: Events By-Law.
 
-Schedule - Schedule 1
+SCHEDULE - Schedule 1
 Schedule of events application timeframes
 
 Subject to applicable criteria, the following timeframes below will apply:
@@ -442,7 +442,7 @@ NOTE:
 
 \3. Any event which involves an application for a land use approval and where the approval has not been granted must follow the appeal process as outlined in the relevant land use planning legislation.
 
-Schedule - Schedule 2
+SCHEDULE - Schedule 2
 
 Note: the City may request information additional to that listed as determined by the type and detail of the event
 
@@ -482,7 +482,7 @@ q. Written approval from venue owner/venue manager to the applicant authorising 
 
 r. Written confirmation of the appointment of a safety officer for the event.
 
-Schedule - Schedule 3
+SCHEDULE - Schedule 3
 Schedule of fines
 
 [[Schedule 3 repealed by amendment on 2009-08-19]].


### PR DESCRIPTION
Use hcontainer not article for schedules, include title as a heading.

This makes it much easier to treat schedules as a standalone entity.

Uses updated slaw, and brings XSL up to date.