### PR TITLE
Fix linking to sections in schedules

### DIFF
--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -46,7 +46,7 @@ class TOCBuilderBase(LocaleBasedMatcher):
     """ The locale this TOC builder is suited for, as ``(country, language, locality)``.
     """
 
-    toc_elements = ['coverpage', 'preface', 'preamble', 'part', 'chapter', 'section', 'conclusions']
+    toc_elements = ['coverpage', 'preface', 'preamble', 'part', 'chapter', 'section', 'conclusions', 'doc']
     """ Elements we include in the table of contents, without their XML namespace. Subclasses must
     provide this.
     """

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import re
 from itertools import chain
 from lxml.html import _collect_string_content
@@ -235,6 +237,7 @@ class TOCElement(object):
         self.children = children
         self.subcomponent = subcomponent
         self.title = None
+        self.qualified_id = id_ if component == 'main' else "{}/{}".format(component, id_)
 
     def as_dict(self):
         info = {

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -114,13 +114,7 @@ class TOCBuilderBase(LocaleBasedMatcher):
     def build_table_of_contents(self):
         toc = []
         for component, element in self.act.components().iteritems():
-            if component != "main":
-                # non-main components are items in their own right
-                item = self.make_toc_entry(element, component)
-                item.children = self.process_elements(component, [element])
-                toc += [item]
-            else:
-                toc += self.process_elements(component, [element])
+            toc += self.process_elements(component, [element])
 
         return toc
 

--- a/indigo/documents.py
+++ b/indigo/documents.py
@@ -15,16 +15,25 @@ class ResolvedAnchor(object):
         self.resolve()
 
     def resolve(self):
-        anchor_id = self.anchor['id'].replace("'", "\'")
-        root = self.document.doc.root
+        anchor_id = self.anchor['id']
 
-        elems = root.xpath("//*[@id='%s']" % anchor_id)
+        if '/' in anchor_id:
+            component, anchor_id = anchor_id.split('/', 1)
+        else:
+            component = 'main'
+
+        component = self.document.doc.components().get(component)
+        if component is None:
+            return
+
+        anchor_id = anchor_id.replace("'", "\'")
+        elems = component.xpath("//*[@id='%s']" % anchor_id)
         if elems:
             self.resolve_element(elems[0])
         elif anchor_id in ['preface', 'preamble']:
             # HACK HACK HACK
             # We sometimes use 'preamble' and 'preface' even though they aren't IDs
-            elems = root.xpath("//a:%s" % anchor_id, namespaces={'a': self.document.doc.namespace})
+            elems = component.xpath("//a:%s" % anchor_id, namespaces={'a': self.document.doc.namespace})
             if elems:
                 self.resolve_element(elems[0])
 

--- a/indigo/documents.py
+++ b/indigo/documents.py
@@ -44,7 +44,7 @@ class ResolvedAnchor(object):
         builder = plugins.for_document('toc', self.document)
         if builder:
             self.toc_entry = builder.table_of_contents_entry_for_element(self.document, self.element)
-            self.is_toc_element = self.toc_entry.element == self.element
+            self.is_toc_element = self.toc_entry and self.toc_entry.element == self.element
 
     def element_html(self):
         if not self.element:

--- a/indigo_app/static/javascript/indigo/views/document_toc.js
+++ b/indigo_app/static/javascript/indigo/views/document_toc.js
@@ -81,12 +81,19 @@
 
       function generate_toc(node) {
         var $node = $(node);
+        var $component = $node.parent().closest('doc');
+        var qualified_id = node.id;
+
+        if ($component.length > 0) {
+          qualified_id = $component.attr('name') + '/' + qualified_id;
+        }
+
         var item = {
           'num': $node.children('num').text(),
           'heading': $node.children('heading').text(),
           'element': node,
           'type': node.localName,
-          'id': node.id,
+          'id': qualified_id,
         };
         item.title = tradition.toc_element_title(item);
         return item;

--- a/indigo_app/templates/indigo_api/task_detail.html
+++ b/indigo_app/templates/indigo_api/task_detail.html
@@ -60,7 +60,7 @@
           <li class="activity-item">
             {% with task.resolve_anchor as anchor %}
               {% if anchor.element %}
-                Here is <a href="{% url 'document' doc_id=task.document.pk %}?toc={{ anchor.toc_entry.id|default:'' }}&anntn={{ task.annotation.id }}">{{ anchor.toc_entry.title }}</a> as it appears currently:
+                Here is <a href="{% url 'document' doc_id=task.document.pk %}?toc={{ anchor.toc_entry.qualified_id|default:'' }}&anntn={{ task.annotation.id }}">{{ anchor.toc_entry.title }}</a> as it appears currently:
                 <div class="sheet-outer" {% if not anchor.is_toc_element %}data-highlight="{{ task.anchor.id }}"{% endif %}>
                   <div class="sheet-inner is-fragment">
                     <div class="akoma-ntoso country-{{ anchor.document.country }}">{{ anchor.toc_element_html|safe }}</div>

--- a/indigo_za/toc.py
+++ b/indigo_za/toc.py
@@ -23,7 +23,7 @@ def section_title(item):
 class TOCBuilderZA(TOCBuilderBase):
     locale = ('za', None, None)
 
-    toc_elements = ['coverpage', 'preface', 'preamble', 'part', 'chapter', 'section', 'conclusions']
+    toc_elements = ['coverpage', 'preface', 'preamble', 'part', 'chapter', 'section', 'conclusions', 'doc']
     toc_non_unique_components = ['chapter', 'part']
 
     titles = {


### PR DESCRIPTION
This fixes linking to sections in schedules. Before this, if a document had a section (or part or chapter) numbered the same in the main body and a schedule, linking to it from the task detail view wouldn't work correctly.

This fixes how we generate and resolve anchors, both in the TOC view in the document view, and on the server when looking up an annotation.