### PR TITLE
Some performance tweaks

### DIFF
--- a/indigo_api/fixtures/work.json
+++ b/indigo_api/fixtures/work.json
@@ -9,6 +9,7 @@
       "updated_at": "2015-02-17T10:57:47.779Z",
       "created_by_user": 1,
       "updated_by_user": 1,
+      "publication_date": "2014-04-02",
       "frbr_uri": "/za/act/2014/10"
     }
   },

--- a/indigo_api/migrations/0021_document_expression_date.py
+++ b/indigo_api/migrations/0021_document_expression_date.py
@@ -7,7 +7,7 @@ from indigo_api.models import Document
 
 
 def forwards(apps, schema_editor):
-    for doc in Document.objects.only('document_xml', 'expression_date').all():
+    for doc in Document.objects.select_related(None).only('document_xml', 'expression_date').all():
         doc.expression_date = doc.publication_date or arrow.now().date()
         doc.save()
 

--- a/indigo_api/models.py
+++ b/indigo_api/models.py
@@ -145,7 +145,7 @@ class WorkManager(models.Manager):
         # defer expensive or unnecessary fields
         return super(WorkManager, self)\
             .get_queryset()\
-            .prefetch_related('country', 'country__country', 'locality', 'publication_document')
+            .select_related('country', 'country__country', 'locality', 'publication_document')
 
 
 class Work(models.Model):
@@ -328,7 +328,7 @@ class Work(models.Model):
         """
         content_type = ContentType.objects.get_for_model(self)
         return reversion.models.Version.objects\
-            .prefetch_related('revision', 'revision__user')\
+            .select_related('revision', 'revision__user')\
             .filter(content_type=content_type)\
             .filter(object_id_int=self.id)\
             .order_by('-id')
@@ -482,7 +482,7 @@ class DocumentManager(models.Manager):
         # defer expensive or unnecessary fields
         return super(DocumentManager, self)\
             .get_queryset()\
-            .prefetch_related('work')\
+            .select_related('work')\
             .defer("search_text", "search_vector")
 
 
@@ -803,7 +803,7 @@ class Document(models.Model):
         """
         content_type = ContentType.objects.get_for_model(self)
         return reversion.models.Version.objects\
-            .prefetch_related('revision')\
+            .select_related('revision')\
             .filter(content_type=content_type)\
             .filter(object_id_int=self.id)\
             .order_by('-id')
@@ -1028,7 +1028,9 @@ class TaskQuerySet(models.QuerySet):
 class TaskManager(models.Manager):
     def get_queryset(self):
         return super(TaskManager, self).get_queryset()\
-            .prefetch_related('labels', 'work', 'document', 'created_by_user', 'assigned_to')
+            .select_related('work', 'document', 'created_by_user', 'assigned_to', 'document__language', 'document__language__language')\
+            .defer('document__document_xml', 'document__search_vector', 'document__search_text')\
+            .prefetch_related('labels')
 
 
 class Task(models.Model):
@@ -1219,7 +1221,7 @@ class WorkflowQuerySet(models.QuerySet):
 class WorkflowManager(models.Manager):
     def get_queryset(self):
         return super(WorkflowManager, self).get_queryset()\
-            .prefetch_related('tasks', 'created_by_user')
+            .select_related('created_by_user')
 
 
 class Workflow(models.Model):

--- a/indigo_api/models.py
+++ b/indigo_api/models.py
@@ -141,6 +141,8 @@ class WorkQuerySet(models.QuerySet):
 
 
 class WorkManager(models.Manager):
+    use_for_related_fields = True
+
     def get_queryset(self):
         # defer expensive or unnecessary fields
         return super(WorkManager, self)\
@@ -1026,6 +1028,8 @@ class TaskQuerySet(models.QuerySet):
 
 
 class TaskManager(models.Manager):
+    use_for_related_fields = True
+
     def get_queryset(self):
         return super(TaskManager, self).get_queryset()\
             .select_related('created_by_user', 'assigned_to')\
@@ -1220,6 +1224,8 @@ class WorkflowQuerySet(models.QuerySet):
 
 
 class WorkflowManager(models.Manager):
+    use_for_related_fields = True
+
     def get_queryset(self):
         return super(WorkflowManager, self).get_queryset()\
             .select_related('created_by_user')

--- a/indigo_api/models.py
+++ b/indigo_api/models.py
@@ -1091,14 +1091,15 @@ class Task(models.Model):
 
         potential_assignees = User.objects\
             .filter(editor__permitted_countries=country, user_permissions=submit_task_permission)\
-            .order_by('first_name', 'last_name')
-        potential_reviewers = potential_assignees.filter(user_permissions=close_task_permission)
+            .order_by('first_name', 'last_name')\
+            .all()
+        potential_reviewers = potential_assignees.filter(user_permissions=close_task_permission).all()
 
         for task in tasks:
             if task.state == 'open':
-                task.potential_assignees = [u for u in potential_assignees.all() if task.assigned_to_id != u.id]
+                task.potential_assignees = [u for u in potential_assignees if task.assigned_to_id != u.id]
             elif task.state == 'pending_review':
-                task.potential_assignees = [u for u in potential_reviewers.all() if task.assigned_to_id != u.id and task.last_assigned_to_id != u.id]
+                task.potential_assignees = [u for u in potential_reviewers if task.assigned_to_id != u.id and task.last_assigned_to_id != u.id]
 
         return tasks
 

--- a/indigo_api/models.py
+++ b/indigo_api/models.py
@@ -482,7 +482,7 @@ class DocumentManager(models.Manager):
         # defer expensive or unnecessary fields
         return super(DocumentManager, self)\
             .get_queryset()\
-            .select_related('work')\
+            .prefetch_related('work')\
             .defer("search_text", "search_vector")
 
 

--- a/indigo_api/renderers.py
+++ b/indigo_api/renderers.py
@@ -39,7 +39,7 @@ def file_candidates(document, prefix='', suffix=''):
     * doctype-language
     * doctype
     """
-    uri = document.doc.frbr_uri
+    uri = document.expression_uri
     doctype = uri.doctype
     language = uri.language
     country = uri.country
@@ -414,7 +414,7 @@ class EPUBRenderer(HTMLRenderer):
     def render(self, document, element=None):
         self.create_book()
 
-        self.book.set_identifier(document.doc.frbr_uri.expression_uri())
+        self.book.set_identifier(document.expression_uri.expression_uri())
         self.book.set_title(document.title)
         self.book.set_language(document.language.language.iso)
         self.book.add_author(settings.INDIGO_ORGANISATION)
@@ -428,7 +428,7 @@ class EPUBRenderer(HTMLRenderer):
     def render_many(self, documents):
         self.create_book()
 
-        self.book.set_identifier(':'.join(d.doc.frbr_uri.expression_uri() for d in documents))
+        self.book.set_identifier(':'.join(d.expression_uri.expression_uri() for d in documents))
         self.book.add_author(settings.INDIGO_ORGANISATION)
         self.book.set_title('%d documents' % len(documents))
 

--- a/indigo_app/templates/indigo_api/_task_cards.html
+++ b/indigo_app/templates/indigo_api/_task_cards.html
@@ -35,7 +35,7 @@
                   <a href="{% url 'document' doc_id=task.document.id %}" class="text-muted d-block mb-1">
                     {{ task.document.title }} @ {{ task.document.expression_date|date:'Y-m-d' }} · {{ task.document.language }}
                   </a>
-                  <span class="text-muted wb-all">{{ task.document.work.frbr_uri }}</span>
+                  <span class="text-muted wb-all">{{ task.work.frbr_uri }}</span>
                 </div>
               {% elif task.work %}
                 <div>

--- a/indigo_app/templates/indigo_api/_task_list.html
+++ b/indigo_app/templates/indigo_api/_task_list.html
@@ -28,7 +28,7 @@
             {% if task.document %}
               <div>
                 <a href="{% url 'document' doc_id=task.document.id %}" class="text-muted">{{ task.document.title }} @ {{ task.document.expression_date|date:'Y-m-d' }} · {{ task.document.language }}</a><br>
-                <span class="text-muted">{{ task.document.work.frbr_uri }}</span>
+                <span class="text-muted">{{ task.work.frbr_uri }}</span>
               </div>
             {% elif task.work %}
               <div>

--- a/indigo_app/templates/indigo_api/task_detail.html
+++ b/indigo_app/templates/indigo_api/task_detail.html
@@ -29,7 +29,7 @@
       {% if task.document %}
         <div class="mb-2">
           <a href="{% url 'document' doc_id=task.document.id %}">{{ task.document.title }} @ {{ task.document.expression_date|date:'Y-m-d' }} · {{ task.document.language }}</a><br>
-          <span class="text-muted">{{ task.document.work.frbr_uri }}</span>
+          <span class="text-muted">{{ task.work.frbr_uri }}</span>
         </div>
       {% elif task.work %}
         <div class="mb-2">
@@ -145,31 +145,30 @@
         {% endwith %}
       </ul>
 
+      {% with task.workflows.all as workflows %}
+        <form action="{% url 'task_workflows' place=place.place_code pk=task.pk %}" method="POST" data-submit="ajax">
+          {% csrf_token %}
 
-      <form action="{% url 'task_workflows' place=place.place_code pk=task.pk %}" method="POST" data-submit="ajax">
-        {% csrf_token %}
+          <select class="selectpicker" multiple name="workflows" onchange="$(this.form).trigger('submit')"
+              data-dropdown-align-right="true" data-style="btn-link pl-0 text-dark"
+              {% if not perms.indigo_api.change_task %}disabled{% endif %}
+              data-none-selected-text="Workflows" data-selected-text-format="static">
 
-        <select class="selectpicker" multiple name="workflows" onchange="$(this.form).trigger('submit')"
-            data-dropdown-align-right="true" data-style="btn-link pl-0 text-dark"
-            {% if not perms.indigo_api.change_task %}disabled{% endif %}
-            data-none-selected-text="Workflows" data-selected-text-format="static">
-
-          {% for workflow in possible_workflows|dictsort:'title' %}
-            <option value="{{ workflow.id }}" {% if workflow in task.workflows.all %}selected{% endif %}>#{{ workflow.pk }} – {{ workflow.title }}</option>
-          {% endfor %}
-        </select>
-      </form>
-      <ul class="list-unstyled mb-2">
-        {% with task.workflows.all as workflows %}
-        {% if workflows %}
-          {% for workflow in workflows|dictsort:'title' %}
-            <li><a href="{% url 'workflow_detail' place=place.place_code pk=workflow.pk %}">#{{ workflow.pk }} – {{ workflow.title }}</a></li>
-          {% endfor %}
-        {% else %}
-          <li><em>None</em></li>
-        {% endif %}
-        {% endwith %}
-      </ul>
+            {% for workflow in possible_workflows|dictsort:'title' %}
+              <option value="{{ workflow.id }}" {% if workflow in workflows %}selected{% endif %}>#{{ workflow.pk }} – {{ workflow.title }}</option>
+            {% endfor %}
+          </select>
+        </form>
+        <ul class="list-unstyled mb-2">
+          {% if workflows %}
+            {% for workflow in workflows|dictsort:'title' %}
+              <li><a href="{% url 'workflow_detail' place=place.place_code pk=workflow.pk %}">#{{ workflow.pk }} – {{ workflow.title }}</a></li>
+            {% endfor %}
+          {% else %}
+            <li><em>None</em></li>
+          {% endif %}
+        </ul>
+      {% endwith %}
 
     </div>
   </div>

--- a/indigo_app/views/tasks.py
+++ b/indigo_app/views/tasks.py
@@ -63,7 +63,10 @@ class TaskListView(TaskViewBase, ListView):
         return super(TaskListView, self).get(request, *args, **kwargs)
 
     def get_queryset(self):
-        tasks = Task.objects.filter(country=self.country, locality=self.locality).order_by('-updated_at')
+        tasks = Task.objects\
+            .filter(country=self.country, locality=self.locality)\
+            .select_related('document__language', 'document__language__language')\
+            .order_by('-updated_at')
         return self.form.filter_queryset(tasks)
 
     def get_context_data(self, **kwargs):

--- a/indigo_app/views/tasks.py
+++ b/indigo_app/views/tasks.py
@@ -65,7 +65,8 @@ class TaskListView(TaskViewBase, ListView):
     def get_queryset(self):
         tasks = Task.objects\
             .filter(country=self.country, locality=self.locality)\
-            .select_related('document__language', 'document__language__language')\
+            .select_related('document__language', 'document__language__language') \
+            .defer('document__document_xml', 'document__search_text', 'document__search_vector')\
             .order_by('-updated_at')
         return self.form.filter_queryset(tasks)
 

--- a/indigo_app/views/workflows.py
+++ b/indigo_app/views/workflows.py
@@ -75,18 +75,19 @@ class WorkflowDetailView(WorkflowViewBase, DetailView):
         self.object.pct_done = self.object.n_done / (self.object.n_tasks or 1) * 100.0
 
         context['form'] = self.form
-        tasks = self.form.filter_queryset(Task.objects.filter(workflows=self.object)) \
+        tasks = self.form.filter_queryset(self.object.tasks) \
             .select_related('document__language', 'document__language__language')\
+            .defer('document__document_xml', 'document__search_text', 'document__search_vector')\
             .all()
 
         context['tasks'] = tasks
         context['has_tasks'] = self.object.n_tasks > 0
         context['task_groups'] = Task.task_columns(['open', 'pending_review', 'assigned'], tasks)
-        context['possible_tasks'] = Task.objects\
-            .filter(country=self.country, locality=self.locality) \
+        context['possible_tasks'] = self.place.tasks\
             .unclosed()\
             .exclude(workflows=self.object) \
-            .select_related('document__language', 'document__language__language')\
+            .select_related('document__language', 'document__language__language') \
+            .defer('document__document_xml', 'document__search_text', 'document__search_vector')\
             .all()
 
         Task.decorate_potential_assignees(tasks, self.country)

--- a/indigo_app/views/workflows.py
+++ b/indigo_app/views/workflows.py
@@ -75,15 +75,18 @@ class WorkflowDetailView(WorkflowViewBase, DetailView):
         self.object.pct_done = self.object.n_done / (self.object.n_tasks or 1) * 100.0
 
         context['form'] = self.form
-        tasks = self.form.filter_queryset(Task.objects.filter(workflows=self.object)).all()
+        tasks = self.form.filter_queryset(Task.objects.filter(workflows=self.object)) \
+            .select_related('document__language', 'document__language__language')\
+            .all()
 
         context['tasks'] = tasks
         context['has_tasks'] = self.object.n_tasks > 0
         context['task_groups'] = Task.task_columns(['open', 'pending_review', 'assigned'], tasks)
         context['possible_tasks'] = Task.objects\
-            .filter(country=self.country, locality=self.locality)\
+            .filter(country=self.country, locality=self.locality) \
             .unclosed()\
-            .exclude(workflows=self.object)\
+            .exclude(workflows=self.object) \
+            .select_related('document__language', 'document__language__language')\
             .all()
 
         Task.decorate_potential_assignees(tasks, self.country)

--- a/indigo_app/views/workflows.py
+++ b/indigo_app/views/workflows.py
@@ -75,12 +75,16 @@ class WorkflowDetailView(WorkflowViewBase, DetailView):
         self.object.pct_done = self.object.n_done / (self.object.n_tasks or 1) * 100.0
 
         context['form'] = self.form
-        tasks = self.form.filter_queryset(self.object.tasks).all()
+        tasks = self.form.filter_queryset(Task.objects.filter(workflows=self.object)).all()
 
         context['tasks'] = tasks
         context['has_tasks'] = self.object.n_tasks > 0
         context['task_groups'] = Task.task_columns(['open', 'pending_review', 'assigned'], tasks)
-        context['possible_tasks'] = self.place.tasks.unclosed().exclude(pk__in=[t.id for t in self.object.tasks.all()]).all()
+        context['possible_tasks'] = Task.objects\
+            .filter(country=self.country, locality=self.locality)\
+            .unclosed()\
+            .exclude(workflows=self.object)\
+            .all()
 
         Task.decorate_potential_assignees(tasks, self.country)
 

--- a/indigo_app/views/workflows.py
+++ b/indigo_app/views/workflows.py
@@ -69,20 +69,20 @@ class WorkflowDetailView(WorkflowViewBase, DetailView):
     def get_context_data(self, *args, **kwargs):
         context = super(WorkflowDetailView, self).get_context_data(**kwargs)
 
-        context['form'] = self.form
-        tasks = self.form.filter_queryset(self.object.tasks).all()
-
-        context['has_tasks'] = self.object.tasks.count() > 0
-        context['tasks'] = tasks
-        context['task_groups'] = Task.task_columns(['open', 'pending_review', 'assigned'], tasks)
-        context['possible_tasks'] = self.place.tasks.unclosed().exclude(pk__in=[t.id for t in self.object.tasks.all()]).all()
-
-        Task.decorate_potential_assignees(tasks, self.country)
-
         # stats
         self.object.n_tasks = self.object.tasks.count()
         self.object.n_done = self.object.tasks.closed().count()
         self.object.pct_done = self.object.n_done / (self.object.n_tasks or 1) * 100.0
+
+        context['form'] = self.form
+        tasks = self.form.filter_queryset(self.object.tasks).all()
+
+        context['tasks'] = tasks
+        context['has_tasks'] = self.object.n_tasks > 0
+        context['task_groups'] = Task.task_columns(['open', 'pending_review', 'assigned'], tasks)
+        context['possible_tasks'] = self.place.tasks.unclosed().exclude(pk__in=[t.id for t in self.object.tasks.all()]).all()
+
+        Task.decorate_potential_assignees(tasks, self.country)
 
         context['may_close'] = not self.object.closed and self.object.n_tasks == self.object.n_done
         context['may_reopen'] = self.object.closed
@@ -143,8 +143,7 @@ class WorkflowDetailView(WorkflowViewBase, DetailView):
         if len(stash) == 1:
             return first
         else:
-            workflow = self.get_object()
-            action = Action(actor=first.actor, verb='added %d tasks to' % len(stash), action_object=workflow)
+            action = Action(actor=first.actor, verb='added %d tasks to' % len(stash), action_object=self.object)
             action.timestamp = first.timestamp
             return action
 


### PR DESCRIPTION
Things I learnt:

* select_related is useful for 1-1 or 1-n relationships, prefetch_related is for many-to-many
* prefetch_related ignores `defer()`
* using `workflow.tasks` ignores the predefined `select_related` and `defer` on `Task.objects` UNLESS the manager's `use_for_related_fields` is True.
* if a prefetch-related field uses `defer`, that is ignored when using something like `select_related('document__language')`

Guidelines for future:

* don't use `.all()` in a loop, evaluate the queryset before the loop by calling `.all()`
* be conscious of what nested fields are required in a view/template. If you call `task.work.document_set.work.frbr_uri`, there's a good chance the second `work` (and maybe the `document_set`) won't be preloaded
* use `select_related` on managers for commonly used fields