### PR TITLE
Best effort to resolve task anchors.

### DIFF
--- a/indigo/documents.py
+++ b/indigo/documents.py
@@ -47,7 +47,7 @@ class ResolvedAnchor(object):
                     self.resolve_element(elems[0])
                     break
 
-            # no match
+            # no match, try further up the anchor id chain
             if not exact and '.' in anchor_id:
                 self.exact_match = False
                 anchor_id = anchor_id.rsplit('.', 1)[0]

--- a/indigo/documents.py
+++ b/indigo/documents.py
@@ -7,14 +7,19 @@ class ResolvedAnchor(object):
     element = None
     toc_entry = None
     is_toc_element = False
+    exact_match = False
 
-    def __init__(self, anchor, document):
+    def __init__(self, anchor, document, exact=False):
+        """ Try to resolve an anchor in a document. If exact is False (the default),
+        then if the exact anchor can't be resolved, try to resolve as close as possible.
+        The exact_match attribute will be set accordingly.
+        """
         self.anchor = anchor
         self.document = document
 
-        self.resolve()
+        self.resolve(exact)
 
-    def resolve(self):
+    def resolve(self, exact):
         anchor_id = self.anchor['id']
 
         if '/' in anchor_id:
@@ -26,16 +31,29 @@ class ResolvedAnchor(object):
         if component is None:
             return
 
-        anchor_id = anchor_id.replace("'", "\'")
-        elems = component.xpath("//*[@id='%s']" % anchor_id)
-        if elems:
-            self.resolve_element(elems[0])
-        elif anchor_id in ['preface', 'preamble']:
-            # HACK HACK HACK
-            # We sometimes use 'preamble' and 'preface' even though they aren't IDs
-            elems = component.xpath("//a:%s" % anchor_id, namespaces={'a': self.document.doc.namespace})
+        self.exact_match = True
+
+        while anchor_id:
+            escaped = anchor_id.replace("'", "\'")
+            elems = component.xpath("//*[@id='%s']" % escaped)
             if elems:
                 self.resolve_element(elems[0])
+                break
+            elif anchor_id in ['preface', 'preamble']:
+                # HACK HACK HACK
+                # We sometimes use 'preamble' and 'preface' even though they aren't IDs
+                elems = component.xpath("//a:%s" % escaped, namespaces={'a': self.document.doc.namespace})
+                if elems:
+                    self.resolve_element(elems[0])
+                    break
+
+            # no match
+            if not exact and '.' in anchor_id:
+                self.exact_match = False
+                anchor_id = anchor_id.rsplit('.', 1)[0]
+            else:
+                # give up
+                anchor_id = None
 
     def resolve_element(self, element):
         self.element = element

--- a/indigo_app/templates/indigo_api/task_detail.html
+++ b/indigo_app/templates/indigo_api/task_detail.html
@@ -60,14 +60,16 @@
           <li class="activity-item">
             {% with task.resolve_anchor as anchor %}
               {% if anchor.element %}
-                Here is <a href="{% url 'document' doc_id=task.document.pk %}?toc={{ anchor.toc_entry.qualified_id|default:'' }}&anntn={{ task.annotation.id }}">{{ anchor.toc_entry.title }}</a> as it appears currently:
+                Here is <a href="{% url 'document' doc_id=task.document.pk %}?toc={{ anchor.toc_entry.qualified_id|default:'' }}&anntn={{ task.annotation.id }}">{{ anchor.toc_entry.title }}</a>
+                as it appears currently
+                {% if not anchor.exact_match %}(<b>{{ anchor. }}{{ task.anchor.id }}</b> may have been moved or removed){% endif %}
                 <div class="sheet-outer" {% if not anchor.is_toc_element %}data-highlight="{{ task.anchor.id }}"{% endif %}>
                   <div class="sheet-inner is-fragment">
                     <div class="akoma-ntoso country-{{ anchor.document.country }}">{{ anchor.toc_element_html|safe }}</div>
                   </div>
                 </div>
               {% else %}
-                The content at <b>{{ anchor.toc_entry.title|default:task.anchor.id }}</b> is not available and may have been removed.
+                The content at <b>{{ anchor.toc_entry.title|default:task.anchor.id }}</b> is not available and may have been moved or removed.
               {% endif %}
             {% endwith %}
           </li>

--- a/indigo_app/templates/indigo_api/task_detail.html
+++ b/indigo_app/templates/indigo_api/task_detail.html
@@ -62,7 +62,7 @@
               {% if anchor.element %}
                 Here is <a href="{% url 'document' doc_id=task.document.pk %}?toc={{ anchor.toc_entry.qualified_id|default:'' }}&anntn={{ task.annotation.id }}">{{ anchor.toc_entry.title }}</a>
                 as it appears currently
-                {% if not anchor.exact_match %}(<b>{{ anchor. }}{{ task.anchor.id }}</b> may have been moved or removed){% endif %}
+                {% if not anchor.exact_match %}(<b>{{ task.anchor.id }}</b> may have been moved or removed){% endif %}
                 <div class="sheet-outer" {% if not anchor.is_toc_element %}data-highlight="{{ task.anchor.id }}"{% endif %}>
                   <div class="sheet-inner is-fragment">
                     <div class="akoma-ntoso country-{{ anchor.document.country }}">{{ anchor.toc_element_html|safe }}</div>


### PR DESCRIPTION
In the screenshot below, the document fragment would previously not have shown up since the "b" and "b1" don't match.

<img width="796" alt="Created from comment: aoeu uu – Laws Africa 2019-05-03 15-23-43" src="https://user-images.githubusercontent.com/4178542/57140234-90f61580-6db7-11e9-8274-feee22d164a8.png">

Fixes #527