### PR TITLE
use 'principal' rather than 'primary' where appropriate

### DIFF
--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -183,7 +183,7 @@ class BatchCreateWorkForm(forms.Form):
 Make sure the document's expression date correctly reflects this.''',
         },
     ]
-    primary_tasks = forms.MultipleChoiceField(choices=((t['key'], t['label']) for t in possible_tasks), required=False)
+    principal_tasks = forms.MultipleChoiceField(choices=((t['key'], t['label']) for t in possible_tasks), required=False)
     all_tasks = forms.MultipleChoiceField(choices=((t['key'], t['label']) for t in possible_tasks), required=False)
     workflows = forms.ModelMultipleChoiceField(queryset=Workflow.objects,
                                                required=False)

--- a/indigo_app/templates/indigo_api/work_new_batch.html
+++ b/indigo_app/templates/indigo_api/work_new_batch.html
@@ -107,17 +107,17 @@
         <div class="form-row">
 
           <div class="form-group col-6">
-            <h5>Tasks for primary works only</h5>
-            {% for p_task in form.primary_tasks %}
+            <h5>Tasks for principal works only</h5>
+            {% for p_task in form.principal_tasks %}
               <div class="form-check">
-                <input type="checkbox" class="form-check-input" id="{{ p_task.id_for_label }}" name="{{ form.primary_tasks.html_name }}" value="{{ p_task.data.value }}" {% if p_task.data.selected %}checked{% endif %}>
+                <input type="checkbox" class="form-check-input" id="{{ p_task.id_for_label }}" name="{{ form.principal_tasks.html_name }}" value="{{ p_task.data.value }}" {% if p_task.data.selected %}checked{% endif %}>
                 <label for="{{ p_task.id_for_label }}" class="form-check-label ml-1 mt-2">
                   {{ p_task.data.label }}
                 </label>
               </div>
             {% endfor %}
           </div>
-          {% for err in form.primary_tasks.errors %}
+          {% for err in form.principal_tasks.errors %}
             <div class="form-text text-danger">{{ err }}</div>
           {% endfor %}
 

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -544,7 +544,7 @@ class BatchAddWorkView(PlaceViewBase, AbstractAuthedIndigoView, FormView):
     permission_required = ('indigo_api.add_work',)
     form_class = BatchCreateWorkForm
     initial = {
-        'primary_tasks': ['import'],
+        'principal_tasks': ['import'],
     }
 
     def get_context_data(self, **kwargs):
@@ -618,7 +618,7 @@ class BatchAddWorkView(PlaceViewBase, AbstractAuthedIndigoView, FormView):
                     work.publication_number = row.get('publication_number')
                     work.created_by_user = self.request.user
                     work.updated_by_user = self.request.user
-                    work.stub = not row.get('primary')
+                    work.stub = not row.get('principal')
 
                     try:
                         work.publication_date = self.make_date(row.get('publication_date'), 'publication_date')
@@ -833,10 +833,10 @@ Otherwise, find it and upload it manually.'''
             tasks.append(task)
 
         # bulk create tasks on primary works
-        if form.cleaned_data.get('primary_tasks'):
+        if form.cleaned_data.get('principal_tasks'):
             for info in works:
                 if info['status'] == 'success' and not info['work'].stub:
-                    for chosen_task in form.cleaned_data.get('primary_tasks'):
+                    for chosen_task in form.cleaned_data.get('principal_tasks'):
                         make_task(chosen_task)
 
         # bulk create tasks on all works


### PR DESCRIPTION
'primary' is as opposed to 'subsidiary' – Acts vs Regulations
'principal' is as opposed to 'amending', 'commencing', etc (stubs)

*please note* the spreadsheet will need to be updated once this is deployed