### PR TITLE
Preserve whitespace for certain elements

### DIFF
--- a/indigo_api/static/xsl/act_text.xsl
+++ b/indigo_api/static/xsl/act_text.xsl
@@ -4,7 +4,10 @@
   exclude-result-prefixes="a">
 
   <xsl:output method="text" indent="no" omit-xml-declaration="yes" />
+
+  <!-- strip whitespace from most elements, but preserve whitespace in inline elements that can contain text -->
   <xsl:strip-space elements="*"/>
+  <xsl:preserve-space elements="a:a a:affectedDocument a:b a:block a:caption a:change a:concept a:courtType a:date a:def a:del a:docCommittee a:docDate a:docIntroducer a:docJurisdiction a:docNumber a:docProponent a:docPurpose a:docStage a:docStatus a:docTitle a:docType a:docketNumber a:entity a:event a:extractText a:fillIn a:from a:heading a:i a:inline a:ins a:judge a:lawyer a:legislature a:li a:listConclusion a:listIntroduction a:location a:mmod a:mod a:mref a:narrative a:neutralCitation a:num a:object a:omissis a:opinion a:organization a:outcome a:p a:party a:person a:placeholder a:process a:quantity a:quotedText a:recordedTime a:ref a:relatedDocument a:remark a:rmod a:role a:rref a:scene a:session a:shortTitle a:signature a:span a:sub a:subheading a:summary a:sup a:term a:tocItem a:u a:vote"/>
 
   <!-- adds a backslash to the start of the value param, if necessary -->
   <xsl:template name="escape">
@@ -274,7 +277,7 @@
 
   <!-- for most nodes, just dump their text content -->
   <xsl:template match="*">
-    <xsl:text/><xsl:apply-templates /><xsl:text/>
+    <xsl:apply-templates />
   </xsl:template>
   
 </xsl:stylesheet>

--- a/indigo_api/tests/data_migrations/test_article_to_hcontainer.py
+++ b/indigo_api/tests/data_migrations/test_article_to_hcontainer.py
@@ -182,7 +182,6 @@ class MigrationTestCase(TestCase):
                 <p>None</p>
               </content>
             </paragraph>"""
-        print expected
         self.assertMultiLineEqual(act.to_xml().decode('utf-8'), expected)
 
     def test_migration_without_heading(self):

--- a/indigo_api/tests/data_migrations/test_article_to_hcontainer.py
+++ b/indigo_api/tests/data_migrations/test_article_to_hcontainer.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 from cobalt.act import Act
+from lxml import etree
 
 from indigo_api.data_migrations import ScheduleArticleToHcontainer
 
@@ -182,7 +183,9 @@ class MigrationTestCase(TestCase):
                 <p>None</p>
               </content>
             </paragraph>"""
-        self.assertMultiLineEqual(act.to_xml().decode('utf-8'), expected)
+        self.assertMultiLineEqual(
+            etree.tostring(act.root, encoding='utf-8', pretty_print=True).decode('utf-8'),
+            expected)
 
     def test_migration_without_heading(self):
         migration = ScheduleArticleToHcontainer()
@@ -202,5 +205,6 @@ class MigrationTestCase(TestCase):
                 <p>None</p>
               </content>
             </paragraph>"""
-        self.assertMultiLineEqual(act.to_xml().decode('utf-8'), expected)
-
+        self.assertMultiLineEqual(
+            etree.tostring(act.root, encoding='utf-8', pretty_print=True).decode('utf-8'),
+            expected)

--- a/indigo_api/tests/test_convert_api.py
+++ b/indigo_api/tests/test_convert_api.py
@@ -100,31 +100,6 @@ class RenderParseAPITest(APITestCase):
         })
         assert_equal(response.status_code, 200)
         self.maxDiff = None
-        self.assertEqual(u"""<akomaNtoso xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.akomantoso.org/2.0" xsi:schemaLocation="http://www.akomantoso.org/2.0 akomantoso20.xsd">
-  <chapter id="chapter-2">
-    <num>2</num>
-    <heading>The Beginning</heading>
-    <section id="section-1">
-      <num>1.</num>
-      <heading>First Verse</heading>
-      <paragraph id="section-1.paragraph0">
-        <content>
-          <p>κόσμε</p>
-        </content>
-      </paragraph>
-      <subsection id="section-1.1">
-        <num>(1)</num>
-        <content>
-          <p>In the beginning</p>
-        </content>
-      </subsection>
-      <subsection id="section-1.2">
-        <num>(2)</num>
-        <content>
-          <p>There was nothing and an Act no 2 of 2010.</p>
-        </content>
-      </subsection>
-    </section>
-  </chapter>
-</akomaNtoso>
-""", response.data['output'].decode('utf-8'))
+        self.assertEqual(
+            u'<akomaNtoso xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.akomantoso.org/2.0" xsi:schemaLocation="http://www.akomantoso.org/2.0 akomantoso20.xsd"><chapter id="chapter-2"><num>2</num><heading>The Beginning</heading><section id="section-1"><num>1.</num><heading>First Verse</heading><paragraph id="section-1.paragraph0"><content><p>κόσμε</p></content></paragraph><subsection id="section-1.1"><num>(1)</num><content><p>In the beginning</p></content></subsection><subsection id="section-1.2"><num>(2)</num><content><p>There was nothing and an Act no 2 of 2010.</p></content></subsection></section></chapter></akomaNtoso>',
+            response.data['output'].decode('utf-8'))

--- a/indigo_api/tests/xslt_fixtures/act_text-general-input.xml
+++ b/indigo_api/tests/xslt_fixtures/act_text-general-input.xml
@@ -810,9 +810,7 @@
           <heading>Delegations</heading>
           <paragraph id="section-12.paragraph-0">
             <content>
-              <p>
-                <remark status="editorial">[Section 12 repealed by amendment on 2009-08-19]</remark>
-              </p>
+              <p><remark status="editorial">[Section 12 repealed by amendment on 2009-08-19]</remark></p>
             </content>
           </paragraph>
         </section>

--- a/indigo_app/static/javascript/prettyprint.js
+++ b/indigo_app/static/javascript/prettyprint.js
@@ -1,17 +1,77 @@
 (function(exports) {
   var xsltSource =
     '<?xml version="1.0"?>' +
-    '<!-- template to pretty-print XML -->' +
-    '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">' +
-    '  <xsl:output method="xml" indent="yes"/>' +
-    '  <xsl:strip-space elements="*"/>' +
+    '<!--' +
+    '  Pretty-print Akoma Ntoso XML. Indents only nodes that cannot contain significant whitespace.' +
+    '  Derived from https://www.xml.com/pub/a/2006/11/29/xslt-xml-pretty-printer.html' +
+    '-->' +
     '' +
-    '  <xsl:template match="node() | @*">' +
-    '    <xsl:copy>' +
-    '      <xsl:apply-templates select="node() | @*" />' +
-    '    </xsl:copy>' +
+    '<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"' +
+    '  xmlns:a="http://www.akomantoso.org/2.0">' +
+    '  ' +
+    '  <xsl:output method="xml" indent="no" encoding="UTF-8"/>' +
+    '  <xsl:strip-space elements="*"/>' +
+    '  <xsl:preserve-space elements="a:a a:affectedDocument a:b a:block a:caption a:change a:concept a:courtType a:date a:def a:del a:docCommittee a:docDate a:docIntroducer a:docJurisdiction a:docNumber a:docProponent a:docPurpose a:docStage a:docStatus a:docTitle a:docType a:docketNumber a:entity a:event a:extractText a:fillIn a:from a:heading a:i a:inline a:ins a:judge a:lawyer a:legislature a:li a:listConclusion a:listIntroduction a:location a:mmod a:mod a:mref a:narrative a:neutralCitation a:num a:object a:omissis a:opinion a:organization a:outcome a:p a:party a:person a:placeholder a:process a:quantity a:quotedText a:recordedTime a:ref a:relatedDocument a:remark a:rmod a:role a:rref a:scene a:session a:shortTitle a:signature a:span a:sub a:subheading a:summary a:sup a:term a:tocItem a:u a:vote"/>' +
+    '' +
+    '  <!-- dont indent children of these elements -->' +
+    '  <xsl:template match="a:a|a:affectedDocument|a:b|a:block|a:caption|a:change|a:concept|a:courtType|a:date|a:def|a:del|a:docCommittee|a:docDate|a:docIntroducer|a:docJurisdiction|a:docNumber|a:docProponent|a:docPurpose|a:docStage|a:docStatus|a:docTitle|a:docType|a:docketNumber|a:entity|a:event|a:extractText|a:fillIn|a:from|a:heading|a:i|a:inline|a:ins|a:judge|a:lawyer|a:legislature|a:li|a:listConclusion|a:listIntroduction|a:location|a:mmod|a:mod|a:mref|a:narrative|a:neutralCitation|a:num|a:object|a:omissis|a:opinion|a:organization|a:outcome|a:p|a:party|a:person|a:placeholder|a:process|a:quantity|a:quotedText|a:recordedTime|a:ref|a:relatedDocument|a:remark|a:rmod|a:role|a:rref|a:scene|a:session|a:shortTitle|a:signature|a:span|a:sub|a:subheading|a:summary|a:sup|a:term|a:tocItem|a:u|a:vote">' +
+    '    <xsl:param name="depth">0</xsl:param>' +
+    '' +
+    '    <xsl:text>&#xA;</xsl:text>' +
+    '    <xsl:call-template name="indent">' +
+    '      <xsl:with-param name="depth" select="$depth"/>' +
+    '    </xsl:call-template>' +
+    '' +
+    '    <xsl:copy-of select="." />' +
     '  </xsl:template>' +
     '' +
+    '  <!-- Indent children of these elements -->' +
+    '  <xsl:template match="*|comment()">' +
+    '    <xsl:param name="depth">0</xsl:param>' +
+    '' +
+    '    <xsl:if test="$depth &gt; 0">' +
+    '      <xsl:text>&#xA;</xsl:text>' +
+    '    </xsl:if>' +
+    '' +
+    '    <xsl:call-template name="indent">' +
+    '      <xsl:with-param name="depth" select="$depth"/>' +
+    '    </xsl:call-template>' +
+    '' +
+    '    <xsl:copy>' +
+    '      <xsl:if test="self::*">' +
+    '        <xsl:copy-of select="@*"/>' +
+    '' +
+    '        <xsl:apply-templates>' +
+    '          <xsl:with-param name="depth" select="$depth + 1"/>' +
+    '        </xsl:apply-templates>' +
+    '' +
+    '        <xsl:if test="count(*) &gt; 0">' +
+    '          <xsl:text>&#xA;</xsl:text>' +
+    '' +
+    '          <xsl:call-template name="indent">' +
+    '            <xsl:with-param name="depth" select="$depth"/>' +
+    '          </xsl:call-template>' +
+    '        </xsl:if>' +
+    '      </xsl:if>' +
+    '    </xsl:copy>' +
+    '' +
+    '    <xsl:variable name="isLastNode" select="count(../..) = 0 and position() = last()"/>' +
+    '    <xsl:if test="$isLastNode">' +
+    '      <xsl:text>&#xA;</xsl:text>' +
+    '    </xsl:if>' +
+    '  </xsl:template>' +
+    '' +
+    '  <xsl:template name="indent">' +
+    '    <xsl:param name="depth"/>' +
+    '' +
+    '    <xsl:if test="$depth &gt; 0">' +
+    '      <xsl:text>  </xsl:text>' +
+    '' +
+    '      <xsl:call-template name="indent">' +
+    '        <xsl:with-param name="depth" select="$depth - 1"/>' +
+    '      </xsl:call-template>' +
+    '    </xsl:if>' +
+    '  </xsl:template>' +
     '</xsl:stylesheet>';
 
   var serializer = new XMLSerializer();

--- a/indigo_za/importer.py
+++ b/indigo_za/importer.py
@@ -130,7 +130,7 @@ class ImporterZA(Importer):
         if toc_start:
             # grab the first section-link line after that, it will be our end-of-TOC marker
             # eg '1. Definitions'
-            first_toc_entry = re.search(r'^\s*([0-9]+\..+)$', text[toc_start.end():], re.MULTILINE)
+            first_toc_entry = re.search(r'^\s*(((CHAPTER|PART) +[0-9]+)|[0-9]+\. +\w+)', text[toc_start.end():], re.MULTILINE | re.IGNORECASE)
 
             if first_toc_entry:
                 marker = first_toc_entry.group(1).strip()

--- a/indigo_za/tests/test_importer_za.py
+++ b/indigo_za/tests/test_importer_za.py
@@ -126,7 +126,9 @@ Definitions and interpretation
         assert_equal(self.importer.strip_toc(s), s)
 
     def test_strip_table_of_contents(self):
-        assert_equal(self.importer.strip_toc("""City of Johannesburg Metropolitan Municipality
+        self.maxDiff = None
+        self.assertMultiLineEqual(
+            self.importer.strip_toc("""City of Johannesburg Metropolitan Municipality
 CULTURE AND RECREATION BY-LAWS ( )PUBLISHED IN PROVINCIAL GAZETTE EXTRAORDINARY NO 179 DATED 21 MAY 2004 UNDER NOTICE NUMBER 825
 
 CITY OF JOHANNESBURG METROPOLITAN MUNICIPALITY
@@ -158,7 +160,8 @@ Repeal
 SCHEDULE 1 BY-LAWS REPEALED
 CHAPTER 1 LIBRARY AND INFORMATION SERVICES
 Definitions and interpretation
-1. (1) In this Chapter, unless the context otherwise indicates-"""), """City of Johannesburg Metropolitan Municipality
+1. (1) In this Chapter, unless the context otherwise indicates-"""),
+              """City of Johannesburg Metropolitan Municipality
 CULTURE AND RECREATION BY-LAWS ( )PUBLISHED IN PROVINCIAL GAZETTE EXTRAORDINARY NO 179 DATED 21 MAY 2004 UNDER NOTICE NUMBER 825
 
 CITY OF JOHANNESBURG METROPOLITAN MUNICIPALITY

--- a/indigo_za/tests/test_terms_eng.py
+++ b/indigo_za/tests/test_terms_eng.py
@@ -202,3 +202,43 @@ class TermsFinderENGTestCase(APITestCase):
   </section>
 </body>
 ''', etree.tostring(doc.doc.body, pretty_print=True, encoding='UTF-8'))
+
+    def test_whitespace_between_adjacent_terms(self):
+        doc = Document(content=document_fixture(xml=u"""
+<section id="section-1">
+  <num>1.</num>
+  <heading>Definitions</heading>
+  <paragraph id="section-1.paragraph-0">
+    <content>
+      <p>"fire" means a combustion;</p>
+      <p>"truck" means a vehicle;</p>
+    </content>
+  </paragraph>
+  <paragraph id="section-1.paragraph-0">
+    <content>
+      <p>Do not park near a fire truck.</p>
+    </content>
+  </paragraph>
+</section>
+        """))
+
+        self.maxDiff = None
+        self.finder.find_terms_in_document(doc)
+        self.assertMultiLineEqual('''<body xmlns="http://www.akomantoso.org/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <section id="section-1">
+    <num>1.</num>
+    <heading>Definitions</heading>
+    <paragraph id="section-1.paragraph-0">
+      <content>
+        <p refersTo="#term-fire">"<def refersTo="#term-fire">fire</def>" means a combustion;</p>
+        <p refersTo="#term-truck">"<def refersTo="#term-truck">truck</def>" means a vehicle;</p>
+      </content>
+    </paragraph>
+    <paragraph id="section-1.paragraph-0">
+      <content>
+        <p>Do not park near a <term refersTo="#term-fire" id="trm0">fire</term> <term refersTo="#term-truck" id="trm1">truck</term>.</p>
+      </content>
+    </paragraph>
+  </section>
+</body>
+''', etree.tostring(doc.doc.body, pretty_print=True, encoding='UTF-8'))

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'django>=1.11.15,<2',
         'arrow>=0.5',
         'boto3>=1.7',
-        'cobalt>=1.0.0',
+        'cobalt>=2.0.0',
         'django-ckeditor>=5.3.1',
         'dj-database-url>=0.3.0',
         'django-activity-stream>=0.7.0',


### PR DESCRIPTION
This ensures we don't drop whitespace between terms, eg: `<term>fire</term> <term>truck</term>`