### PR TITLE
Permissions badges use security groups, pull out default badges

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -296,6 +296,11 @@ INDIGO_USER_PROFILE_URL = 'indigo_social:user_profile'
 INDIGO_CONTENT_API_VERSIONED = True
 RESOLVER_URL = os.environ.get('RESOLVER_URL', INDIGO_URL + "/resolver/resolve")
 
+INDIGO_SOCIAL = {
+    # the badge module to load by default (optional)
+    'badges': 'indigo_social.default_badges',
+}
+
 DEFAULT_FROM_EMAIL = os.environ.get('DJANGO_DEFAULT_FROM_EMAIL', '%s <%s>' % (INDIGO_ORGANISATION, SUPPORT_EMAIL))
 EMAIL_HOST = os.environ.get('DJANGO_EMAIL_HOST')
 EMAIL_HOST_USER = os.environ.get('DJANGO_EMAIL_HOST_USER')

--- a/indigo_social/apps.py
+++ b/indigo_social/apps.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from importlib import import_module
+
 from django.apps import AppConfig
 from django.core.signals import request_started
+from django.conf import settings
 
 
 class IndigoSocialConfig(AppConfig):
@@ -13,6 +16,10 @@ class IndigoSocialConfig(AppConfig):
 
     def setup_country_badges(self):
         import indigo_social.badges  # noqa
+
+        # import default set of badges, if any
+        if settings.INDIGO_SOCIAL['badges']:
+            import_module(settings.INDIGO_SOCIAL['badges'])
 
         # Install a once-off signal handler to create country badges before the
         # first request comes through. This allows us to work around the fact

--- a/indigo_social/apps.py
+++ b/indigo_social/apps.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from importlib import import_module
 
 from django.apps import AppConfig
-from django.core.signals import request_started
 from django.conf import settings
 
 
@@ -21,16 +20,5 @@ class IndigoSocialConfig(AppConfig):
         if settings.INDIGO_SOCIAL['badges']:
             import_module(settings.INDIGO_SOCIAL['badges'])
 
-        # Install a once-off signal handler to create country badges before the
-        # first request comes through. This allows us to work around the fact
-        # that during testing, ready() is called before the database migrations
-        # are applied, so no db tables exist. There doesn't seem to be a better
-        # way to get code to run when the app starts up and AFTER the db has
-        # been set up.
-        uid = "indigo-social-country-setup"
-
-        def create_badges(sender, **kwargs):
-            request_started.disconnect(create_badges, dispatch_uid=uid)
-            indigo_social.badges.CountryBadge.create_all()
-
-        request_started.connect(create_badges, dispatch_uid=uid, weak=False)
+        # ensure country badges get created
+        indigo_social.badges.create_country_badges()

--- a/indigo_social/badges.py
+++ b/indigo_social/badges.py
@@ -250,6 +250,6 @@ def create_country_badges():
 
     def create_badges(sender, **kwargs):
         request_started.disconnect(create_badges, dispatch_uid=uid)
-        badges.CountryBadge.create_all()
+        CountryBadge.create_all()
 
     request_started.connect(create_badges, dispatch_uid=uid, weak=False)

--- a/indigo_social/badges.py
+++ b/indigo_social/badges.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 
 from pinax.badges.base import Badge, BadgeAwarded, BadgeDetail
 from pinax.badges.registry import badges
-from allauth.account.signals import user_signed_up
 from indigo_api.models import Country
 from indigo_app.models import Editor
 
@@ -237,52 +236,3 @@ def editor_countries_changed(sender, instance, action, reverse, model, pk_set, *
 def country_saved(sender, instance, created, raw, **kwargs):
     if created:
         CountryBadge.create_for_country(instance)
-
-
-# ------------------------------------------------------------------------
-# Badge definitions
-
-
-class ContributorBadge(PermissionBadge):
-    slug = 'contributor'
-    name = 'Contributor'
-    group_name = name + ' Badge'
-    description = 'Can view work details'
-    permissions = ('indigo_api.add_annotation', 'indigo_api.change_annotation', 'indigo_api.delete_annotation',
-                   'indigo_api.add_task')
-
-
-class DrafterBadge(PermissionBadge):
-    slug = 'drafter'
-    name = 'Drafter'
-    group_name = name + ' Badge'
-    description = 'Can create new works and edit the details of existing works'
-    permissions = ('indigo_api.add_work', 'indigo_api.change_work',
-                   'indigo_api.add_document', 'indigo_api.change_document',
-                   'indigo_api.add_amendment', 'indigo_api.change_amendment', 'indigo_api.delete_amendment',
-                   # required when restoring a document version
-                   'reversion.change_version',
-                   'indigo_api.change_task', 'indigo_api.submit_task', 'indigo_api.reopen_task',
-                   'indigo_api.add_workflow', 'indigo_api.change_workflow')
-
-
-class SeniorDrafterBadge(PermissionBadge):
-    slug = 'senior-drafter'
-    name = 'Senior Drafter'
-    group_name = name + ' Badge'
-    description = 'Can review work tasks and delete documents and works'
-    permissions = ('indigo_api.delete_work', 'indigo_api.review_work',
-                   'indigo_api.review_document', 'indigo_api.delete_document', 'indigo_api.publish_document',
-                   'indigo_api.cancel_task', 'indigo_api.unsubmit_task', 'indigo_api.close_task',
-                   'indigo_api.close_workflow', 'indigo_api.delete_workflow')
-
-
-badges.register(ContributorBadge)
-badges.register(DrafterBadge)
-badges.register(SeniorDrafterBadge)
-
-
-# when a user signs up, grant them the contributor badge immediately
-@receiver(user_signed_up, sender=User)
-def grant_contributor_new_user(sender, request, user, **kwargs):
-    badges.registry['contributor'].award(user=user)

--- a/indigo_social/default_badges.py
+++ b/indigo_social/default_badges.py
@@ -1,0 +1,58 @@
+from django.dispatch import receiver
+from django.contrib.auth.models import User
+from allauth.account.signals import user_signed_up
+
+from indigo_social.badges import PermissionBadge, badges
+
+
+# ------------------------------------------------------------------------
+# Default Badge definitions
+#
+# You can define your own badges, either in addition to these (in your
+# own module), or in favour of these (by changing settings.INDIGO_SOCIAL['badges']
+# to the module name. The badges will be imported when the app starts up.
+
+
+class ContributorBadge(PermissionBadge):
+    slug = 'contributor'
+    name = 'Contributor'
+    group_name = name + ' Badge'
+    description = 'Can view work details'
+    permissions = ('indigo_api.add_annotation', 'indigo_api.change_annotation', 'indigo_api.delete_annotation',
+                   'indigo_api.add_task')
+
+
+class DrafterBadge(PermissionBadge):
+    slug = 'drafter'
+    name = 'Drafter'
+    group_name = name + ' Badge'
+    description = 'Can create new works and edit the details of existing works'
+    permissions = ('indigo_api.add_work', 'indigo_api.change_work',
+                   'indigo_api.add_document', 'indigo_api.change_document',
+                   'indigo_api.add_amendment', 'indigo_api.change_amendment', 'indigo_api.delete_amendment',
+                   # required when restoring a document version
+                   'reversion.change_version',
+                   'indigo_api.change_task', 'indigo_api.submit_task', 'indigo_api.reopen_task',
+                   'indigo_api.add_workflow', 'indigo_api.change_workflow')
+
+
+class SeniorDrafterBadge(PermissionBadge):
+    slug = 'senior-drafter'
+    name = 'Senior Drafter'
+    group_name = name + ' Badge'
+    description = 'Can review work tasks and delete documents and works'
+    permissions = ('indigo_api.delete_work', 'indigo_api.review_work',
+                   'indigo_api.review_document', 'indigo_api.delete_document', 'indigo_api.publish_document',
+                   'indigo_api.cancel_task', 'indigo_api.unsubmit_task', 'indigo_api.close_task',
+                   'indigo_api.close_workflow', 'indigo_api.delete_workflow')
+
+
+badges.register(ContributorBadge)
+badges.register(DrafterBadge)
+badges.register(SeniorDrafterBadge)
+
+
+# when a user signs up, grant them the contributor badge immediately
+@receiver(user_signed_up, sender=User)
+def grant_contributor_new_user(sender, request, user, **kwargs):
+    badges.registry['contributor'].award(user=user)

--- a/indigo_social/forms.py
+++ b/indigo_social/forms.py
@@ -5,6 +5,7 @@ from django.core.validators import _lazy_re_compile, RegexValidator
 from indigo_api.models import Country, User
 from indigo_social.models import UserProfile
 from indigo_social.badges import badges
+from pinax.badges.models import BadgeAward
 
 
 class UserProfileForm(forms.ModelForm):
@@ -65,6 +66,13 @@ def badge_choices():
 class AwardBadgeForm(forms.Form):
     badge = forms.ChoiceField(choices=badge_choices)
     next = forms.CharField(required=False)
+
+    def __init__(self, user=None, *args, **kwargs):
+        super(AwardBadgeForm, self).__init__(*args, **kwargs)
+        if user:
+            # filter possible badges to only those that the user doesn't already have
+            awarded = [b.slug for b in BadgeAward.objects.filter(user=user)]
+            self.fields['badge'].choices = [b for b in self.fields['badge'].choices if b[0] not in awarded]
 
     def actual_badge(self):
         return badges.registry.get(self.cleaned_data.get('badge'))

--- a/indigo_social/templates/indigo_social/badge_detail.html
+++ b/indigo_social/templates/indigo_social/badge_detail.html
@@ -36,6 +36,8 @@
       {% if request.user.is_superuser %}
       <h4 class="mt-3">Permissions granted by this badge</h4>
 
+      <p>Users awarded this badge are added to the <a href="{% url 'admin:auth_group_change' badge.group.pk %}">{{ badge.group_name }} group</a>.</p>
+
       <ul>
         {% for perm in badge.permissions %}
         <li>{{ perm }}</li>

--- a/indigo_social/views.py
+++ b/indigo_social/views.py
@@ -38,7 +38,7 @@ class UserProfileView(DetailView):
 
         context['can_award'] = self.request.user.has_perm('auth.change_user')
         if context['can_award']:
-            context['award_form'] = AwardBadgeForm()
+            context['award_form'] = AwardBadgeForm(user=self.object)
 
         activity = self.object.actor_actions.all()[:20]
         context['activity_stream'] = self.coalesce_entries(activity)


### PR DESCRIPTION
This means it's easier to manage and understand badge permissions, and allows us to override the default set of badges.