### PR TITLE
tweak activity rendering to cater for earning points

### DIFF
--- a/indigo_app/templates/indigo_app/actions/_action.html
+++ b/indigo_app/templates/indigo_app/actions/_action.html
@@ -7,103 +7,13 @@
   {% user_profile action.actor %} {{ action.verb }}
 {% endif %}
 
-{% if action.verb == 'earned' and action.data.points %}
-  {{ action.data.points }} points for {{ action.data.reason }}
-{% endif %}
-
-{% if model == 'work' %}
-  {% with action.action_object as work %}
-    the work <a href="{% url 'work' frbr_uri=work.frbr_uri %}">{{ work.title }}</a>
-
-    {% if not ignore_place %}
-      in <a href="{% url 'place' place=work.place.place_code %}">{{ work.place }}</a>
-    {% endif %}
+{% if model %}
+  {% with "indigo_app/actions/_action_"|add:model|add:".html" as template_name %}
+    {% include template_name %}
   {% endwith %}
-
-{% elif model == 'amendment' %}
-  {% with action.action_object as amendment %}
-    an amendment on the work <a href="{% url 'work' frbr_uri=amendment.amended_work.frbr_uri %}">{{ amendment.amended_work.title }}</a>
-    by the work <a href="{% url 'work' frbr_uri=amendment.amending_work.frbr_uri %}">{{ amendment.amending_work.title }}</a>
-
-    {% if not ignore_place %}
-      in <a href="{% url 'place' place=amendment.amended_work.place.place_code %}">{{ amendment.amended_work.place }}</a>
-    {% endif %}
-  {% endwith %}
-
-{% elif model == 'document' %}
-  {% with action.action_object as document %}
-    {% if document.deleted %}
-      a document on the work <a href="{% url 'work' frbr_uri=document.work.frbr_uri %}">{{ document.work.title }}</a> @ {{ document.expression_date }}
-    {% else %}
-      the document <a href="{% url 'document' doc_id=document.id %}">{{ document.title }} @ {{ document.expression_date }}</a>
-    {% endif %}
-
-    {% if not ignore_place %}
-      in <a href="{% url 'place' place=document.work.place.place_code %}">{{ document.work.place }}</a>
-    {% endif %}
-  {% endwith %}
-
-{% elif model == 'task' %}
-  {% with action.action_object as task %}
-    {% if this_task %}
-      this task
-    {% else %}
-      the task <a href="{% url 'task_detail' place=task.place.place_code pk=task.pk %}">{{ task.title }}</a>
-
-      {% if not action.target %}
-        {% if task.work %}
-          on the work <a href="{% url 'work' frbr_uri=task.work.frbr_uri %}">{{ task.work.title }}</a>
-          {% if task.document %}
-            @ <a href="{% url 'document' doc_id=task.document.id %}">{{ task.document.expression_date }}</a>
-          {% endif %}
-        {% endif %}
-      {% endif %}
-    {% endif %}
-
-    {% if action.target.target_actions.content_type.model == 'user' %}
-      {% if action.verb == 'requested changes to' %}
-        from
-      {% else %}
-        to
-      {% endif %}
-      {% user_profile action.target %}
-    {% endif %}
-
-    {% if action.target.target_actions.content_type.model == 'workflow' %}
-      {% with action.target as workflow %}
-        {% if action.verb == 'added' %}
-          to
-        {% elif action.verb == 'removed' %}
-          from
-        {% endif %}
-        {% if this_workflow %}
-          this workflow
-        {% else %}
-          the workflow <a href="{% url 'workflow_detail' place=workflow.place.place_code pk=workflow.pk %}">{{ workflow.title }}</a>
-        {% endif %}
-      {% endwith %}
-    {% endif %}
-
-    {% if action.verb == 'submitted' %}
-      for review
-    {% endif %}
-
-    {% if not ignore_place %}
-      in <a href="{% url 'place' place=task.place.place_code %}">{{ task.place }}</a>
-    {% endif %}
- {% endwith %}
-
-{% elif model == 'workflow' %}
-  {% with action.action_object as workflow %}
-    {% if this_workflow %}
-      this workflow
-    {% else %}
-      the workflow <a href="{% url 'workflow_detail' place=workflow.place.place_code pk=workflow.pk %}">{{ workflow.title }}</a>
-    {% endif %}
-
-    {% if not ignore_place %}
-      in <a href="{% url 'place' place=workflow.place.place_code %}">{{ workflow.place }}</a>
-    {% endif %}
+{% else %}
+  {% with "indigo_app/actions/_action_verb_"|add:action.verb|add:".html" as template_name %}
+    {% include template_name %}
   {% endwith %}
 {% endif %}
 

--- a/indigo_app/templates/indigo_app/actions/_action.html
+++ b/indigo_app/templates/indigo_app/actions/_action.html
@@ -7,6 +7,10 @@
   {% user_profile action.actor %} {{ action.verb }}
 {% endif %}
 
+{% if action.verb == 'earned' and action.data.points %}
+  {{ action.data.points }} points for {{ action.data.reason }}
+{% endif %}
+
 {% if model == 'work' %}
   {% with action.action_object as work %}
     the work <a href="{% url 'work' frbr_uri=work.frbr_uri %}">{{ work.title }}</a>

--- a/indigo_app/templates/indigo_app/actions/_action_amendment.html
+++ b/indigo_app/templates/indigo_app/actions/_action_amendment.html
@@ -1,0 +1,8 @@
+{% with action.action_object as amendment %}
+  an amendment on the work <a href="{% url 'work' frbr_uri=amendment.amended_work.frbr_uri %}">{{ amendment.amended_work.title }}</a>
+  by the work <a href="{% url 'work' frbr_uri=amendment.amending_work.frbr_uri %}">{{ amendment.amending_work.title }}</a>
+
+  {% if not ignore_place %}
+    in <a href="{% url 'place' place=amendment.amended_work.place.place_code %}">{{ amendment.amended_work.place }}</a>
+  {% endif %}
+{% endwith %}

--- a/indigo_app/templates/indigo_app/actions/_action_document.html
+++ b/indigo_app/templates/indigo_app/actions/_action_document.html
@@ -1,0 +1,11 @@
+{% with action.action_object as document %}
+  {% if document.deleted %}
+    a document on the work <a href="{% url 'work' frbr_uri=document.work.frbr_uri %}">{{ document.work.title }}</a> @ {{ document.expression_date }}
+  {% else %}
+    the document <a href="{% url 'document' doc_id=document.id %}">{{ document.title }} @ {{ document.expression_date }}</a>
+  {% endif %}
+
+  {% if not ignore_place %}
+    in <a href="{% url 'place' place=document.work.place.place_code %}">{{ document.work.place }}</a>
+  {% endif %}
+{% endwith %}

--- a/indigo_app/templates/indigo_app/actions/_action_task.html
+++ b/indigo_app/templates/indigo_app/actions/_action_task.html
@@ -1,0 +1,50 @@
+{% load indigo_app %}
+
+{% with action.action_object as task %}
+  {% if this_task %}
+    this task
+  {% else %}
+    the task <a href="{% url 'task_detail' place=task.place.place_code pk=task.pk %}">{{ task.title }}</a>
+
+    {% if not action.target %}
+      {% if task.work %}
+        on the work <a href="{% url 'work' frbr_uri=task.work.frbr_uri %}">{{ task.work.title }}</a>
+        {% if task.document %}
+          @ <a href="{% url 'document' doc_id=task.document.id %}">{{ task.document.expression_date }}</a>
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+
+  {% if action.target.target_actions.content_type.model == 'user' %}
+    {% if action.verb == 'requested changes to' %}
+      from
+    {% else %}
+      to
+    {% endif %}
+    {% user_profile action.target %}
+  {% endif %}
+
+  {% if action.target.target_actions.content_type.model == 'workflow' %}
+    {% with action.target as workflow %}
+      {% if action.verb == 'added' %}
+        to
+      {% elif action.verb == 'removed' %}
+        from
+      {% endif %}
+      {% if this_workflow %}
+        this workflow
+      {% else %}
+        the workflow <a href="{% url 'workflow_detail' place=workflow.place.place_code pk=workflow.pk %}">{{ workflow.title }}</a>
+      {% endif %}
+    {% endwith %}
+  {% endif %}
+
+  {% if action.verb == 'submitted' %}
+    for review
+  {% endif %}
+
+  {% if not ignore_place %}
+    in <a href="{% url 'place' place=task.place.place_code %}">{{ task.place }}</a>
+  {% endif %}
+{% endwith %}

--- a/indigo_app/templates/indigo_app/actions/_action_work.html
+++ b/indigo_app/templates/indigo_app/actions/_action_work.html
@@ -1,0 +1,7 @@
+{% with action.action_object as work %}
+  the work <a href="{% url 'work' frbr_uri=work.frbr_uri %}">{{ work.title }}</a>
+
+  {% if not ignore_place %}
+    in <a href="{% url 'place' place=work.place.place_code %}">{{ work.place }}</a>
+  {% endif %}
+{% endwith %}

--- a/indigo_app/templates/indigo_app/actions/_action_workflow.html
+++ b/indigo_app/templates/indigo_app/actions/_action_workflow.html
@@ -1,0 +1,11 @@
+{% with action.action_object as workflow %}
+  {% if this_workflow %}
+    this workflow
+  {% else %}
+    the workflow <a href="{% url 'workflow_detail' place=workflow.place.place_code pk=workflow.pk %}">{{ workflow.title }}</a>
+  {% endif %}
+
+  {% if not ignore_place %}
+    in <a href="{% url 'place' place=workflow.place.place_code %}">{{ workflow.place }}</a>
+  {% endif %}
+{% endwith %}

--- a/indigo_app/templates/indigo_app/actions/_activity_list.html
+++ b/indigo_app/templates/indigo_app/actions/_activity_list.html
@@ -1,17 +1,16 @@
-
 {% if actions %}
   <ul class="activity-list">
     {% if reverse_order %}
       {% for action in actions reversed %}
-      <li class="activity-item">
-        {% include 'indigo_app/actions/_action.html' with action=action %}
-      </li>
-    {% endfor %}
+        <li class="activity-item">
+          {% include 'indigo_app/actions/_action.html' with action=action %}
+        </li>
+      {% endfor %}
     {% else %}
       {% for action in actions %}
-      <li class="activity-item">
-        {% include 'indigo_app/actions/_action.html' with action=action %}
-      </li>
+        <li class="activity-item">
+          {% include 'indigo_app/actions/_action.html' with action=action %}
+        </li>
       {% endfor %}
     {% endif %}
   </ul>


### PR DESCRIPTION
#### What does this PR do?
Render points earned activity properly

#### Description of Task to be completed?
This PR adds the following:
* [x] cater for points earning activity

#### How should this be manually tested?
- Install the extension by cloning it next to your indigo setup
- Install using `pip install -e ../indigo-points`
- Add `indigo_points` on the list of apps in `indigo/settings.py`
- run `python manage.py migrate` and start your indigo instance
- Create a task & assign it
- Submit for review & approve it
- Changes will be reflected in the database, activity will be visible on activity and user profile.

#### Screenshots
Points activity appearing on user profile:
![image](https://user-images.githubusercontent.com/8082197/60331617-b8bfbf00-999d-11e9-94fe-86bd66223741.png)

Points activity as they appear on a task's activity feed:
![image](https://user-images.githubusercontent.com/8082197/60331672-dbea6e80-999d-11e9-9f91-c5cbd4151f75.png)

#### What are the relevant issues?
https://github.com/laws-africa/indigo-points/issues/1
