### PR TITLE
Prevent duplicate editors saving the same doc. 

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_activity.js
+++ b/indigo_app/static/javascript/indigo/views/document_activity.js
@@ -56,16 +56,34 @@
         data: {nonce: this.nonce},
         global: false,
       }).then(function(resp) {
+        // mark is_self
+        resp.results.forEach(function(r) {
+          r.is_self = (r.nonce == self.nonce);
+        });
+
         self.collection.set(resp.results);
         self.collection.sort();
+
+        // we're locked if we're not the first item in the collection
+        // once locked, page must be refreshed before editing can happen
+        self.locked = self.locked || !self.collection.at(0).get('is_self');
+        self.render();
       });
     },
 
     render: function() {
-      var self = this;
-      var items = this.collection.toJSON();
+      var self = this,
+          items = this.collection.toJSON();
+
+      if (this.locked) {
+        document.querySelector('.document-workspace-buttons .save-btn-group').innerHTML =
+          items[0].is_self ?
+            ('You must <a href="#" onclick="window.location.reload();">refresh</a><br>before making changes.') :
+            ('Editing has been locked<br>by ' + items[0].user.display_name + '.');
+      }
+
       // exclude us
-      items = _.filter(items, function(a) { return a.nonce != self.nonce; });
+      items = _.filter(items, function(a) { return !a.is_self; });
       items.forEach(function(a) {
         a.user.colour = a.nonce.charCodeAt(0) % 8;
       });

--- a/indigo_app/templates/document/_toolbar.html
+++ b/indigo_app/templates/document/_toolbar.html
@@ -100,7 +100,7 @@
 <div id="document-activity-view" class="ml-auto"></div>
 
 <div class="document-workspace-buttons">
-  <div class="btn-group logged-in">
+  <div class="btn-group logged-in save-btn-group">
     <button class="btn btn-success save" disabled><span class="if-published">Save &amp; publish</span><span class="if-draft">Save draft</span></button>
     <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-toggle="dropdown"></button>
     <div class="dropdown-menu">


### PR DESCRIPTION
Fixes #643.

Whoever opens the document first gets the lock. Anyone else MUST then refresh the page in order to pick up (potential) changes before they can make changes.

<img width="282" alt="Example @ 2009-11-20 2019-06-30 18-12-15" src="https://user-images.githubusercontent.com/4178542/60399289-a6db4900-9b62-11e9-8d55-83e2869f5385.png">

<img width="269" alt="Example @ 2009-11-20 2019-06-30 18-12-56" src="https://user-images.githubusercontent.com/4178542/60399293-b5c1fb80-9b62-11e9-9bea-61ef590f8cc7.png">
