### PR TITLE
Fake celery so that pinax-badges is happy.

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -1,0 +1,11 @@
+# NOTE: this is a fake celery.py file to pretend to pinax-badges that
+# celery is installed.
+#
+# This is required because django-background-tasks eagerly auto-discovers
+# <app>.tasks modules for all apps in INSTALLED_APPS. That includes pinax-badges,
+# which tries to 'import celery' in pinax_badges.tasks.py.
+#
+# Indigo is currently incompatible with celery.
+
+class Task(object):
+    pass


### PR DESCRIPTION
This is horrible. We should instead have a way to prevent
pinax-badges from failing if celery tasks are not installed.
See https://github.com/pinax/pinax-badges/issues/31