### PR TITLE
Use commencement date as publication date for points in time. Fixes #680

### DIFF
--- a/indigo_api/models.py
+++ b/indigo_api/models.py
@@ -408,7 +408,7 @@ class Work(models.Model):
         that represents the initial point-in-time. This will include multiple
         objects at the same date, if there were multiple amendments at the same date.
         """
-        initial = Amendment(amended_work=self, date=self.publication_date)
+        initial = Amendment(amended_work=self, date=self.publication_date or self.commencement_date)
         initial.initial = True
         amendments = list(self.amendments.all())
 

--- a/indigo_api/tests/test_work.py
+++ b/indigo_api/tests/test_work.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 
@@ -20,6 +22,17 @@ class WorkTestCase(TestCase):
 
         document = Document.objects.get(pk=20)
         self.assertEqual(document.frbr_uri, '/za/act/2999/1')
+
+    def test_commencement_as_pit_date(self):
+        """ When the publication date is unknown, fall back
+        to the commencement date as a possible point in time.
+        """
+        self.work.publication_date = None
+        self.work.commencement_date = datetime.date.today()
+        events = self.work.amendments_with_initial()
+        initial = events[-1]
+        self.assertTrue(initial.initial)
+        self.assertEqual(initial.date, self.work.commencement_date)
 
     def test_validates_uri(self):
         country = Country.objects.first()

--- a/indigo_app/templates/indigo_api/_work_points_in_time.html
+++ b/indigo_app/templates/indigo_api/_work_points_in_time.html
@@ -28,15 +28,22 @@
 
         {% if event.initial %}
           <h6>
-            Initial publication
-            {% if not event.publication_date %}(using commencement date){% endif %}
-            {% if event.commencement_date %}
-              <span class="text-muted"> – Commenced on publication
-                {% if work.commencing_work %}
-                  by <a href="{% url 'work' frbr_uri=work.commencing_work.frbr_uri %}" data-popup-url="{% url 'work_popup' frbr_uri=work.commencing_work.frbr_uri %}">{{ work.commencing_work.title }}</a>
-                {% endif %}
-              </span>
+          {% if event.commencement_date %}
+            {% if event.publication_date %}
+              Initial publication
+              {% if not work.commencing_work %}
+                <span class="text-muted">– commenced on publication</span>
+              {% endif %}
+            {% else %}
+              Commencement
             {% endif %}
+            {% if work.commencing_work %}
+              – commenced{% if event.publication_date %} on publication{% endif %} by
+              <a href="{% url 'work' frbr_uri=work.commencing_work.frbr_uri %}" data-popup-url="{% url 'work_popup' frbr_uri=work.commencing_work.frbr_uri %}">{{ work.commencing_work.title }}</a>
+            {% endif %}
+          {% elif event.publication_date %}
+            Initial publication
+          {% endif %}
           </h6>
 
         {% elif event.commencement_date %}

--- a/indigo_app/templates/indigo_api/_work_points_in_time.html
+++ b/indigo_app/templates/indigo_api/_work_points_in_time.html
@@ -29,6 +29,7 @@
         {% if event.initial %}
           <h6>
             Initial publication
+            {% if not event.publication_date %}(using commencement date){% endif %}
             {% if event.commencement_date %}
               <span class="text-muted"> – Commenced on publication
                 {% if work.commencing_work %}

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -68,6 +68,7 @@ class WorkViewBase(PlaceViewBase, AbstractAuthedIndigoView, SingleObjectMixin):
         other_dates = [
             ('assent_date', self.work.assent_date),
             ('commencement_date', self.work.commencement_date),
+            ('publication_date', self.work.publication_date),
             ('repealed_date', self.work.repealed_date)
         ]
         # add to existing events (e.g. if publication and commencement dates are the same)


### PR DESCRIPTION
This makes it possible to have expressions for a work when we don't know the publication date.

<img width="721" alt="CPT Muni planning – Laws Africa 2019-07-16 14-01-58" src="https://user-images.githubusercontent.com/4178542/61292753-51de3a80-a7d2-11e9-9cfa-cc1107af6c3a.png">
