### PR TITLE
FIX: badge can_award_manually attribute

### DIFF
--- a/indigo_social/badges.py
+++ b/indigo_social/badges.py
@@ -22,6 +22,7 @@ class BaseBadge(Badge):
     multiple = False
     levels = [1]
     events = []
+    can_award_manually = True
 
     def __init__(self):
         # hoop jumping to ensure that BadgeAward objects pick up the correct name

--- a/indigo_social/forms.py
+++ b/indigo_social/forms.py
@@ -60,7 +60,7 @@ class UserProfileForm(forms.ModelForm):
 
 
 def badge_choices():
-    return sorted([(b.slug, u'%s – %s' % (b.name, b.description)) for b in badges.registry.itervalues()])
+    return sorted([(b.slug, u'%s – %s' % (b.name, b.description)) for b in badges.registry.itervalues() if b.can_award_manually])
 
 
 class AwardBadgeForm(forms.Form):


### PR DESCRIPTION
#### What does this PR do?
Filter off badges that cannot be awarded manually

#### Description of Task to be completed?
LevelBadges cannot be awarded manually and therefore should not be listed on the user profile `Award Badge` section.

#### What are the relevant issues?
[#2 on Indigo Points](https://github.com/laws-africa/indigo-points/issues/2
