### PR TITLE
Email notification for new reply to an annotation

### DIFF
--- a/indigo_app/notifications.py
+++ b/indigo_app/notifications.py
@@ -83,7 +83,7 @@ class Notifier(object):
         email is sent to annotation creator and all users who replied, excluding
         the currently replying user.
         """
-        related_annotations = Annotation.objects.filter(in_reply_to_id=parent_annotation.id)
+        related_annotations = Annotation.objects.filter(in_reply_to=parent_annotation)
         document = parent_annotation.document
 
         recipient_list = [i.created_by_user for i in related_annotations]

--- a/indigo_app/signals.py
+++ b/indigo_app/signals.py
@@ -5,8 +5,8 @@ from actstream.models import Action
 from django_comments.models import Comment
 from django_comments.signals import comment_was_posted
 
-from indigo_api.models import Task
-from indigo_app.notifications import notify_task_action, notify_comment_posted
+from indigo_api.models import Task, Annotation
+from indigo_app.notifications import notify_task_action, notify_comment_posted, notify_annotation_reply_posted
 
 
 @receiver(signals.post_save, sender=Action)
@@ -24,3 +24,9 @@ def post_comment_save_notification(sender, **kwargs):
     """
     if kwargs['comment']:
         notify_comment_posted(kwargs['comment'].pk)
+
+
+@receiver(signals.post_save, sender=Annotation)
+def post_annotation_reply(sender, **kwargs):
+    if kwargs['instance'].in_reply_to:
+        notify_annotation_reply_posted(kwargs['instance'].pk)

--- a/indigo_app/templates/templated_email/annotation_new_reply.email
+++ b/indigo_app/templates/templated_email/annotation_new_reply.email
@@ -3,7 +3,7 @@
 {% block html %}
   {% include 'templated_email/_header.html' %}
 
-  <p> {{ annotation.created_by_user.username }} replied to a thread on
+  <p> {{ annotation.created_by_user.username }} replied to a comment on
     <a href="{{ SITE_URL }}{% url 'document' doc_id=document.pk %}"> Document #{{ document.pk }} – {{ document.title }} </a>:
 
     <hr>

--- a/indigo_app/templates/templated_email/annotation_new_reply.email
+++ b/indigo_app/templates/templated_email/annotation_new_reply.email
@@ -4,7 +4,7 @@
   {% include 'templated_email/_header.html' %}
 
   <p> {{ annotation.created_by_user.username }} replied to a comment on
-    <a href="{{ SITE_URL }}{% url 'document' doc_id=document.pk %}"> Document #{{ document.pk }} – {{ document.title }} </a>:
+    <a href="{{ SITE_URL }}{% url 'document' doc_id=document.pk %}?anntn={{ annotation.in_reply_to.pk }}">Document #{{ document.pk }} – {{ document.title }}</a>:
 
     <hr>
     {{ annotation.text|urlize|linebreaksbr }}

--- a/indigo_app/templates/templated_email/annotation_new_reply.email
+++ b/indigo_app/templates/templated_email/annotation_new_reply.email
@@ -1,0 +1,16 @@
+{% block subject %}Document #{{ document.pk }} – {{ document.title|safe }}{% endblock %}
+
+{% block html %}
+  {% include 'templated_email/_header.html' %}
+
+  <p> {{ annotation.created_by_user.username }} replied to a thread on
+    <a href="{{ SITE_URL }}{% url 'document' doc_id=document.pk %}"> Document #{{ document.pk }} – {{ document.title }} </a>:
+
+    <hr>
+    {{ annotation.text|urlize|linebreaksbr }}
+    <hr>
+  </p>
+
+  {% include 'templated_email/_footer.html' %}
+{% endblock %}
+


### PR DESCRIPTION
#### What does this PR do?
Notify users by email when a new reply to an annotation is posted.

#### Description of Task to be completed?
When a user replies to an annotation in a document, an email is sent to the user who posted the first annotation, and all other users who have also replied to the parent annotation. The user posting the reply is excluded from the email list.


#### How should this be manually tested?
- Set up Indigo
- Create a few users and documents
- Add an annotation on the document and reply to it with the other user accounts

#### What are the relevant issues?
closes #568  
