### PR TITLE
Warn when impersonating

### DIFF
--- a/indigo_api/models.py
+++ b/indigo_api/models.py
@@ -7,7 +7,6 @@ from itertools import chain, groupby
 
 from actstream import action
 from django.conf import settings
-from django.contrib.auth.models import Permission
 from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.db.models import signals, Q, Prefetch
@@ -1251,7 +1250,8 @@ class Task(models.Model):
         for task in tasks:
             submission_message = 'Are you sure you want to submit this task for review?'
             if task.assigned_to and not task.assigned_to == view.request.user:
-                submission_message = 'Are you sure you want to submit this task for review on behalf of {} {}?'.format(task.assigned_to.first_name, task.assigned_to.last_name)
+                submission_message = 'Are you sure you want to submit this task for review on behalf of {}?'\
+                    .format(user_display(task.assigned_to))
             task.submission_message = submission_message
 
         return tasks

--- a/indigo_api/models.py
+++ b/indigo_api/models.py
@@ -1246,6 +1246,16 @@ class Task(models.Model):
 
         return tasks
 
+    @classmethod
+    def decorate_submission_message(cls, tasks, view):
+        for task in tasks:
+            submission_message = 'Are you sure you want to submit this task for review?'
+            if task.assigned_to and not task.assigned_to == view.request.user:
+                submission_message = 'Are you sure you want to submit this task for review on behalf of {} {}?'.format(task.assigned_to.first_name, task.assigned_to.last_name)
+            task.submission_message = submission_message
+
+        return tasks
+
     # submit for review
     def may_submit(self, view):
         user = view.request.user

--- a/indigo_app/templates/indigo_api/_task_card_single.html
+++ b/indigo_app/templates/indigo_api/_task_card_single.html
@@ -15,7 +15,7 @@
               <button type="submit"
                       class="dropdown-item"
                       formaction="{% url 'submit_task' place=place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}"
-                      data-confirm="Are you sure you want to submit this task for review?">
+                      data-confirm="{{ task.submission_message }}">
                 Submit for review
               </button>
             {% endif %}

--- a/indigo_app/templates/indigo_api/task_detail.html
+++ b/indigo_app/templates/indigo_api/task_detail.html
@@ -137,7 +137,7 @@
             {% csrf_token %}
 
             {% if task.state == 'open' and task.submit_task_permission %}
-              <button class="btn btn-primary float-right" type="submit" data-confirm="Are you sure you want to submit this task for review?" formaction="{% url 'submit_task' place=place.place_code pk=task.pk %}">Submit for review</button>
+              <button class="btn btn-primary float-right" type="submit" data-confirm="{{ task.submission_message }}" formaction="{% url 'submit_task' place=place.place_code pk=task.pk %}">Submit for review</button>
             {% endif %}
 
             {% if task.state == 'cancelled' or task.state == 'done' %}

--- a/indigo_app/views/tasks.py
+++ b/indigo_app/views/tasks.py
@@ -80,6 +80,9 @@ class TaskListView(TaskViewBase, ListView):
         context['frbr_uri'] = self.request.GET.get('frbr_uri')
         context['task_groups'] = Task.task_columns(self.form.cleaned_data['state'], context['tasks'])
 
+        # warn when submitting task on behalf of another user
+        Task.decorate_submission_message(context['tasks'], self)
+
         Task.decorate_potential_assignees(context['tasks'], self.country)
         Task.decorate_permissions(context['tasks'], self)
 
@@ -105,6 +108,9 @@ class TaskDetailView(TaskViewBase, DetailView):
             key=lambda x: x.submit_date if hasattr(x, 'comment') else x.timestamp)
 
         context['possible_workflows'] = Workflow.objects.unclosed().filter(country=task.country, locality=task.locality).all()
+
+        # warn when submitting task on behalf of another user
+        Task.decorate_submission_message([task], self)
 
         Task.decorate_potential_assignees([task], self.country)
         Task.decorate_permissions([task], self)

--- a/indigo_app/views/workflows.py
+++ b/indigo_app/views/workflows.py
@@ -91,6 +91,9 @@ class WorkflowDetailView(WorkflowViewBase, DetailView):
             .defer('document__document_xml', 'document__search_text', 'document__search_vector')\
             .all()
 
+        # warn when submitting task on behalf of another user
+        Task.decorate_submission_message(tasks, self)
+
         Task.decorate_potential_assignees(tasks, self.country)
         Task.decorate_permissions(tasks, self)
 

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -510,7 +510,11 @@ class WorkTasksView(WorkViewBase, DetailView):
             context['tasks']
         )
 
+        # warn when submitting task on behalf of another user
+        Task.decorate_submission_message(context['tasks'], self)
+
         Task.decorate_potential_assignees(context['tasks'], self.country)
+        Task.decorate_permissions(context['tasks'], self)
 
         return context
 


### PR DESCRIPTION
closes #705 

### What does this PR do?
If the person submitting a task is not the assignee, include 'on behalf of \<assignee\>' as part of the confirmation message.

### How to test?
- Set up indigo, create two users and a task in a place.
- Assign the task to the user that isn't currently signed in.
- Hit 'Submit for review' and check that the confirmation message includes the wording given above.

![image](https://user-images.githubusercontent.com/32566441/62306130-88c67880-b481-11e9-81c8-ce1d583732b5.png)

