### PR TITLE
Task Comments in Linked Annotations

### DIFF
--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -4,9 +4,11 @@ from actstream import action
 
 from django.views.decorators.cache import cache_control
 from django.db.models import F
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.search import SearchQuery
 from django.http import Http404
 from django.urls import reverse
+from django_comments.models import Comment
 
 from rest_framework.exceptions import ValidationError, MethodNotAllowed
 from rest_framework.views import APIView
@@ -25,7 +27,7 @@ from lxml.etree import LxmlError
 
 from indigo.analysis.differ import AttributeDiffer
 from indigo.plugins import plugins
-from ..models import Document, Annotation, DocumentActivity
+from ..models import Document, Annotation, DocumentActivity, Task
 from ..serializers import DocumentSerializer, RenderSerializer, ParseSerializer, DocumentAPISerializer, VersionSerializer, AnnotationSerializer, DocumentActivitySerializer, TaskSerializer
 from ..renderers import AkomaNtosoRenderer, PDFResponseRenderer, EPUBResponseRenderer, HTMLResponseRenderer, ZIPResponseRenderer, HTMLRenderer
 from ..authz import DocumentPermissions, AnnotationPermissions
@@ -150,7 +152,36 @@ class AnnotationViewSet(DocumentResourceView, viewsets.ModelViewSet):
     permission_classes = DEFAULT_PERMS + (DjangoModelPermissionsOrAnonReadOnly, AnnotationPermissions)
 
     def filter_queryset(self, queryset):
-        return queryset.filter(document=self.document).all()
+        queryset = list(queryset.filter(document=self.document).all())
+
+        fake_annotations = []
+
+        for annotation in queryset:
+            if annotation.task and annotation.in_reply_to is None:
+                task_content_type = ContentType.objects.get_for_model(Task)
+                # the task linked to the annotation
+                task = annotation.task
+                # get the tasks comments
+                task_comments = Comment.objects\
+                        .filter(content_type=task_content_type, object_pk=task.id)
+
+                for comment in task_comments:
+                    new_annotation = Annotation(
+                        # id=comment.id,
+                        document=self.document,
+                        text=comment.comment,
+                        created_by_user=comment.user,
+                        in_reply_to=annotation,
+                        closed=False,
+                        created_at=comment.submit_date,
+                        updated_at=comment.submit_date,
+                        anchor_id=annotation.anchor_id    
+                    )
+
+                    fake_annotations.append(new_annotation)
+        
+        queryset.extend(fake_annotations)
+        return queryset
 
     @detail_route(methods=['GET', 'POST'])
     def task(self, request, *args, **kwargs):

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -153,11 +153,11 @@ class AnnotationViewSet(DocumentResourceView, viewsets.ModelViewSet):
 
     def filter_queryset(self, queryset):
         queryset = list(queryset.filter(document=self.document).all())
+        task_content_type = ContentType.objects.get_for_model(Task)
 
         fake_annotations = []
         for annotation in queryset:
             if annotation.task and annotation.in_reply_to is None:
-                task_content_type = ContentType.objects.get_for_model(Task)
                 # the task linked to the annotation
                 task = annotation.task
                 # get the tasks comments

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -155,7 +155,6 @@ class AnnotationViewSet(DocumentResourceView, viewsets.ModelViewSet):
         queryset = list(queryset.filter(document=self.document).all())
 
         fake_annotations = []
-
         for annotation in queryset:
             if annotation.task and annotation.in_reply_to is None:
                 task_content_type = ContentType.objects.get_for_model(Task)
@@ -177,8 +176,8 @@ class AnnotationViewSet(DocumentResourceView, viewsets.ModelViewSet):
                     )
 
                     fake_annotations.append(fake_annotation)
-        
-        queryset.extend(fake_annotations)
+
+        queryset += fake_annotations
         return queryset
 
     @detail_route(methods=['GET', 'POST'])

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -166,19 +166,17 @@ class AnnotationViewSet(DocumentResourceView, viewsets.ModelViewSet):
                         .filter(content_type=task_content_type, object_pk=task.id)
 
                 for comment in task_comments:
-                    new_annotation = Annotation(
-                        # id=comment.id,
+                    fake_annotation = Annotation(
                         document=self.document,
                         text=comment.comment,
                         created_by_user=comment.user,
                         in_reply_to=annotation,
-                        closed=False,
                         created_at=comment.submit_date,
                         updated_at=comment.submit_date,
                         anchor_id=annotation.anchor_id    
                     )
 
-                    fake_annotations.append(new_annotation)
+                    fake_annotations.append(fake_annotation)
         
         queryset.extend(fake_annotations)
         return queryset

--- a/indigo_app/static/javascript/indigo/views/annotations.js
+++ b/indigo_app/static/javascript/indigo/views/annotations.js
@@ -8,7 +8,7 @@
    */
   Indigo.AnnotationView = Backbone.View.extend({
     className: function() {
-      return 'annotation ' + (!this.model.get('in_reply_to') ? 'root' : 'reply_id');
+      return 'annotation ' + (!this.model.get('in_reply_to') ? 'root' : 'reply');
     },
     events: {
       'click .delete-anntn': 'delete',

--- a/indigo_app/static/javascript/indigo/views/annotations.js
+++ b/indigo_app/static/javascript/indigo/views/annotations.js
@@ -34,10 +34,12 @@
 
     render: function() {
       this.$el.empty();
+
       /**
-       * Comments appended to the annotation thread appeared as new empty annotations
-       * since they lack IDs, additional check is to confirm that indeed the new
-       * annotation has no text. Appended task comments have a text field.
+       * Comments from tasks appended to the annotation thread appeared as new 
+       * empty annotations since they lack IDs. 
+       * Additional check is to confirm that indeed the new fake annotation has 
+       * no document. Appended task comments have a document attribute.
        * 
        * Other fields: text, created_by_user, in_reply_to, anchor_id
        */

--- a/indigo_app/static/javascript/indigo/views/annotations.js
+++ b/indigo_app/static/javascript/indigo/views/annotations.js
@@ -8,7 +8,7 @@
    */
   Indigo.AnnotationView = Backbone.View.extend({
     className: function() {
-      return 'annotation ' + (!this.model.get('in_reply_to') ? 'root' : 'reply');
+      return 'annotation ' + (!this.model.get('in_reply_to') ? 'root' : 'reply_id');
     },
     events: {
       'click .delete-anntn': 'delete',
@@ -34,8 +34,14 @@
 
     render: function() {
       this.$el.empty();
-
-      if (this.isNew) {
+      /**
+       * Comments appended to the annotation thread appeared as new empty annotations
+       * since they lack IDs, additional check is to confirm that indeed the new
+       * annotation has no text. Appended task comments have a text field.
+       * 
+       * Other fields: text, created_by_user, in_reply_to, anchor_id
+       */
+      if (this.isNew && this.document === null) {
         // controls for adding a new annotation
         var template = $("#new-annotation-template")
           .clone()

--- a/indigo_app/templates/document/_annotations.html
+++ b/indigo_app/templates/document/_annotations.html
@@ -17,8 +17,10 @@
       {{/unless}}
 
       {{#if permissions.can_change }}
-        <a href="#" class="dropdown-item edit-anntn">Edit</a>
-        <a href="#" class="dropdown-item delete-anntn">Delete</a>
+        {{#if id}}
+          <a href="#" class="dropdown-item edit-anntn">Edit</a>
+          <a href="#" class="dropdown-item delete-anntn">Delete</a>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/indigo_app/templates/document/_annotations.html
+++ b/indigo_app/templates/document/_annotations.html
@@ -2,27 +2,30 @@
 {% verbatim %}
 {{#unless permissions.readonly }}
   <div class="float-right">
-    <a href="#" class="dropdown-toggle btn btn-sm" data-toggle="dropdown"></a>
-    <div class="dropdown-menu">
-      {{#unless in_reply_to}}
-        {{#unless task}}
-          {{#if permissions.can_create_task}}
-            <a href="#" class="dropdown-item create-anntn-task">Create task</a>
+
+    {{#if id}}
+      <a href="#" class="dropdown-toggle btn btn-sm" data-toggle="dropdown"></a>
+    
+      <div class="dropdown-menu">
+        {{#unless in_reply_to}}
+          {{#unless task}}
+            {{#if permissions.can_create_task}}
+              <a href="#" class="dropdown-item create-anntn-task">Create task</a>
+            {{/if}}
+          {{/unless}}
+          {{#if permissions.can_change }}
+            <a href="#" class="dropdown-item close-anntn">Resolve</a>
+            <div class="dropdown-divider"></div>
           {{/if}}
         {{/unless}}
-        {{#if permissions.can_change }}
-          <a href="#" class="dropdown-item close-anntn">Resolve</a>
-          <div class="dropdown-divider"></div>
-        {{/if}}
-      {{/unless}}
 
-      {{#if permissions.can_change }}
-        {{#if id}}
+        {{#if permissions.can_change }}
           <a href="#" class="dropdown-item edit-anntn">Edit</a>
           <a href="#" class="dropdown-item delete-anntn">Delete</a>
         {{/if}}
-      {{/if}}
-    </div>
+      </div>
+    {{/if}}
+
   </div>
 {{/unless}}
 

--- a/indigo_app/templates/document/_annotations.html
+++ b/indigo_app/templates/document/_annotations.html
@@ -1,11 +1,8 @@
 <script id="annotation-template" type="text/x-handlebars-template">
-{% verbatim %}
-{{#unless permissions.readonly }}
-  <div class="float-right">
-
-    {{#if id}}
+  {% verbatim %}
+  {{#unless permissions.readonly }}
+    <div class="float-right">
       <a href="#" class="dropdown-toggle btn btn-sm" data-toggle="dropdown"></a>
-    
       <div class="dropdown-menu">
         {{#unless in_reply_to}}
           {{#unless task}}
@@ -18,34 +15,34 @@
             <div class="dropdown-divider"></div>
           {{/if}}
         {{/unless}}
-
+  
         {{#if permissions.can_change }}
-          <a href="#" class="dropdown-item edit-anntn">Edit</a>
-          <a href="#" class="dropdown-item delete-anntn">Delete</a>
+          {{#if id}}
+            <a href="#" class="dropdown-item edit-anntn">Edit</a>
+            <a href="#" class="dropdown-item delete-anntn">Delete</a>
+          {{/if}}
         {{/if}}
       </div>
-    {{/if}}
-
+    </div>
+  {{/unless}}
+  
+  <div class="author">{{ created_by_user.display_name }}</div>
+  <div class="time-ago" data-timestamp="{{ created_at }}">{{ created_at_text }}</div>
+  <div class="content">{{{ html }}}</div>
+  <div class="button-container"></div>
+  {{#if task}}
+    <div class="task mt-2">
+      <i class="fas fa-fw task-icon-{{ task.state }}" title="{{ task.state }}"></i>
+      <a href="{{ task.view_url }}">Task #{{ task.id }}</a>
+    </div>
+  {{/if}}
+  {% endverbatim %}
+  </script>
+  
+  <div id="new-annotation-floater" style="display: none"><i class="fas fa-comment"></i></div>
+  
+  <div id="new-annotation-template" style="display: none">
+    <textarea class="form-control" placeholder="Comment..."></textarea>
+    <button class="btn btn-primary btn-sm save" disabled>Comment</button>
+    <button class="btn btn-outline-secondary btn-sm float-right cancel">Cancel</button>
   </div>
-{{/unless}}
-
-<div class="author">{{ created_by_user.display_name }}</div>
-<div class="time-ago" data-timestamp="{{ created_at }}">{{ created_at_text }}</div>
-<div class="content">{{{ html }}}</div>
-<div class="button-container"></div>
-{{#if task}}
-  <div class="task mt-2">
-    <i class="fas fa-fw task-icon-{{ task.state }}" title="{{ task.state }}"></i>
-    <a href="{{ task.view_url }}">Task #{{ task.id }}</a>
-  </div>
-{{/if}}
-{% endverbatim %}
-</script>
-
-<div id="new-annotation-floater" style="display: none"><i class="fas fa-comment"></i></div>
-
-<div id="new-annotation-template" style="display: none">
-  <textarea class="form-control" placeholder="Comment..."></textarea>
-  <button class="btn btn-primary btn-sm save" disabled>Comment</button>
-  <button class="btn btn-outline-secondary btn-sm float-right cancel">Cancel</button>
-</div>

--- a/indigo_app/templates/document/_annotations.html
+++ b/indigo_app/templates/document/_annotations.html
@@ -1,48 +1,48 @@
 <script id="annotation-template" type="text/x-handlebars-template">
-  {% verbatim %}
-  {{#unless permissions.readonly }}
-    <div class="float-right">
-      <a href="#" class="dropdown-toggle btn btn-sm" data-toggle="dropdown"></a>
-      <div class="dropdown-menu">
-        {{#unless in_reply_to}}
-          {{#unless task}}
-            {{#if permissions.can_create_task}}
-              <a href="#" class="dropdown-item create-anntn-task">Create task</a>
-            {{/if}}
-          {{/unless}}
-          {{#if permissions.can_change }}
-            <a href="#" class="dropdown-item close-anntn">Resolve</a>
-            <div class="dropdown-divider"></div>
+{% verbatim %}
+{{#unless permissions.readonly }}
+  <div class="float-right">
+    <a href="#" class="dropdown-toggle btn btn-sm" data-toggle="dropdown"></a>
+    <div class="dropdown-menu">
+      {{#unless in_reply_to}}
+        {{#unless task}}
+          {{#if permissions.can_create_task}}
+            <a href="#" class="dropdown-item create-anntn-task">Create task</a>
           {{/if}}
         {{/unless}}
-  
         {{#if permissions.can_change }}
-          {{#if id}}
-            <a href="#" class="dropdown-item edit-anntn">Edit</a>
-            <a href="#" class="dropdown-item delete-anntn">Delete</a>
-          {{/if}}
+          <a href="#" class="dropdown-item close-anntn">Resolve</a>
+          <div class="dropdown-divider"></div>
         {{/if}}
-      </div>
+      {{/unless}}
+
+      {{#if permissions.can_change }}
+        {{#if id}}
+          <a href="#" class="dropdown-item edit-anntn">Edit</a>
+          <a href="#" class="dropdown-item delete-anntn">Delete</a>
+        {{/if}}
+      {{/if}}
     </div>
-  {{/unless}}
-  
-  <div class="author">{{ created_by_user.display_name }}</div>
-  <div class="time-ago" data-timestamp="{{ created_at }}">{{ created_at_text }}</div>
-  <div class="content">{{{ html }}}</div>
-  <div class="button-container"></div>
-  {{#if task}}
-    <div class="task mt-2">
-      <i class="fas fa-fw task-icon-{{ task.state }}" title="{{ task.state }}"></i>
-      <a href="{{ task.view_url }}">Task #{{ task.id }}</a>
-    </div>
-  {{/if}}
-  {% endverbatim %}
-  </script>
-  
-  <div id="new-annotation-floater" style="display: none"><i class="fas fa-comment"></i></div>
-  
-  <div id="new-annotation-template" style="display: none">
-    <textarea class="form-control" placeholder="Comment..."></textarea>
-    <button class="btn btn-primary btn-sm save" disabled>Comment</button>
-    <button class="btn btn-outline-secondary btn-sm float-right cancel">Cancel</button>
   </div>
+{{/unless}}
+
+<div class="author">{{ created_by_user.display_name }}</div>
+<div class="time-ago" data-timestamp="{{ created_at }}">{{ created_at_text }}</div>
+<div class="content">{{{ html }}}</div>
+<div class="button-container"></div>
+{{#if task}}
+  <div class="task mt-2">
+    <i class="fas fa-fw task-icon-{{ task.state }}" title="{{ task.state }}"></i>
+    <a href="{{ task.view_url }}">Task #{{ task.id }}</a>
+  </div>
+{{/if}}
+{% endverbatim %}
+</script>
+
+<div id="new-annotation-floater" style="display: none"><i class="fas fa-comment"></i></div>
+
+<div id="new-annotation-template" style="display: none">
+  <textarea class="form-control" placeholder="Comment..."></textarea>
+  <button class="btn btn-primary btn-sm save" disabled>Comment</button>
+  <button class="btn btn-outline-secondary btn-sm float-right cancel">Cancel</button>
+</div>


### PR DESCRIPTION
#### What does this PR do?
As a user viewing a document, I want to see task comments in linked annotations

#### Description of Task to be completed?
Annotations can be linked to tasks and annotations can have replies. Linked tasks have comments and this PR pulls the comments from linked tasks into the annotation thread.

#### How should this be manually tested?
- Create a document and create an annotation
- Create a task and link it to the annotation
- Post comments on the task and view them as replies to the annotation

#### Screenshots
Task comments are the ones without dropdowns:
![image](https://user-images.githubusercontent.com/8082197/62518185-9e48f300-b831-11e9-904c-606899c43b31.png)

#### What are the relevant issues?
closes #628 