### PR TITLE
Load Annotation Replies as Comments to the Associated Task

### DIFF
--- a/indigo_app/views/tasks.py
+++ b/indigo_app/views/tasks.py
@@ -111,12 +111,12 @@ class TaskDetailView(TaskViewBase, DetailView):
         if task_annotation:
             fake_comments = []
             # get the replies to the annotation
-            annotation_replies = Annotation.objects.filter(in_reply_to=task_annotation)
+            annotation_replies = Annotation.objects.filter(in_reply_to=task_annotation)\
+                    .select_related('created_by_user')
             for annotation in annotation_replies:
                 fake_comment = Comment(
                     user=annotation.created_by_user,
                     comment=annotation.text,
-                    object_pk=task_annotation.task,
                     submit_date=annotation.created_at
                 )
                 fake_comments.append(fake_comment)


### PR DESCRIPTION
#### What does this PR do?
As a user viewing a task, I want to see annotation replies as comments in the task timeline

#### Description of Task to be completed?
Annotations can be linked to Tasks and annotations can have replies. This PR pulls a linked annotation's replies into the Task's timelines as if they were comments on the task.

#### How should this be manually tested?
- Create a document and create an annotation
- Create a task and link it to the annotation
- Post replies to the annotation and view them as comments to the task

#### Screenshots
Annotation reply showing up as a comment:
![image](https://user-images.githubusercontent.com/8082197/63152074-a06e3700-c013-11e9-9bb7-b798a5e94e3a.png)


#### What are the relevant issues?
closes #627 