### PR TITLE
Repealed badge for repealed works

### DIFF
--- a/indigo_app/templates/indigo_api/_work_related_table.html
+++ b/indigo_app/templates/indigo_api/_work_related_table.html
@@ -14,7 +14,10 @@
     {% for item in items %}
       <tr>
         <td><strong>{{ item.rel|capfirst }}</strong></td>
-        <td><a href="{% url 'work' frbr_uri=item.work.frbr_uri %}" data-popup-url="{% url 'work_popup' frbr_uri=item.work.frbr_uri %}">{{ item.work.title }}</a></td>
+        <td>
+          <a href="{% url 'work' frbr_uri=item.work.frbr_uri %}" data-popup-url="{% url 'work_popup' frbr_uri=item.work.frbr_uri %}">{{ item.work.title }}</a> 
+          {% if item.work.repealed_date %} <span class="badge badge-info">repealed</span> {% endif %} 
+        </td>
         <td>{{ item.work.frbr_uri }}</td>
         <td>{{ item.work.year }}</td>
         <td>{{ item.work.number }}</td>

--- a/indigo_app/templates/indigo_api/work_layout.html
+++ b/indigo_app/templates/indigo_api/work_layout.html
@@ -68,7 +68,11 @@
   <a href="{% url 'create_task' place=place.place_code %}?frbr_uri={{ work.frbr_uri|urlencode }}" class="btn btn-success">Create task</a>
 </div>
 
-<h5 class="main-header-title"><span class="work-title">{% if work.pk %}{{ work.title }}{% else %}Create a new work{% endif %}</span> <span class="badge badge-info if-repealed">repealed</span> {% if work.stub %}<span class="badge badge-info">stub</span>{% endif %}</h5>
+<h5 class="main-header-title">
+  <span class="work-title">{% if work.pk %}{{ work.title }}{% else %}Create a new work{% endif %}</span> 
+  {% if work.stub %}<span class="badge badge-info">stub</span>{% endif %}
+  {% if work.repealed_date %} <span class="badge badge-info">repealed</span> {% endif %}
+</h5>
 {% endblock %}
 
 

--- a/indigo_app/templates/indigo_api/work_overview.html
+++ b/indigo_app/templates/indigo_api/work_overview.html
@@ -15,6 +15,8 @@
   <h3>
     {{ work.title }}
     {% if work.stub %}<span class="badge badge-info">stub</span>{% endif %}
+
+    {% if work.repealed_date %} <span class="badge badge-info">repealed</span> {% endif %}
   </h3>
   <h4 class="text-muted">{{ work.frbr_uri }}</h4>
 

--- a/indigo_app/templates/indigo_api/work_overview.html
+++ b/indigo_app/templates/indigo_api/work_overview.html
@@ -15,7 +15,6 @@
   <h3>
     {{ work.title }}
     {% if work.stub %}<span class="badge badge-info">stub</span>{% endif %}
-
     {% if work.repealed_date %} <span class="badge badge-info">repealed</span> {% endif %}
   </h3>
   <h4 class="text-muted">{{ work.frbr_uri }}</h4>

--- a/indigo_app/templates/indigo_api/work_popup.html
+++ b/indigo_app/templates/indigo_api/work_popup.html
@@ -6,6 +6,9 @@
     {% if work.stub %}
       <span class="badge badge-info">stub</span>
     {% endif %}
+    {% if work.repealed_date %}
+      <span class="badge badge-info">repealed</span>
+    {% endif %} 
     <br><span class="text-muted mt-1 wb-all">{{ work.frbr_uri }}</span>
   </h6>
 

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -65,6 +65,9 @@
                       {% if work.stub %}
                         <span class="badge badge-info">stub</span>
                       {% endif %}
+                      {% if work.repealed_date %} 
+                        <span class="badge badge-info">repealed</span>
+                      {% endif %}
                     </div>
                     <div class="text-muted">{{ work.frbr_uri }}</div>
                     {% if work.parent_work %}


### PR DESCRIPTION
#### What does this PR do?
Add a `repealed` badge to works that have been repealed.

#### Description of Task to be completed?
As a user, I'd like to see repeal and stub badges on all work-related pages. In the same way, a stub is indicated with a badge, a repeal badge should be shown when necessary.

- [x] on work overview page
- [x] on other work-related pages
- [x] on work listing page
- [x] on the document page

#### How should this be manually tested?
- Set up and run Indigo
- Create several works and works that repeal others
- Navigate to the works listing and click on individual works

#### What are the relevant issues?
closes #753 

#### Screenshots (if appropriate)
Work detail page:
![image](https://user-images.githubusercontent.com/8082197/65241259-c5126e80-daeb-11e9-9f3b-9ab47e988080.png)

Work list view:
![image](https://user-images.githubusercontent.com/8082197/65241274-cc397c80-daeb-11e9-914d-0aacb66ba8b0.png)