### PR TITLE
Feedback for errors during creation of works

### DIFF
--- a/indigo_app/templates/indigo_api/work_form.html
+++ b/indigo_app/templates/indigo_api/work_form.html
@@ -11,6 +11,18 @@
     <div class="alert alert-danger">You don't have permission to create or change a work.</div>
   {% endif %}
 
+  {% if form.errors %}
+    <div class="alert alert-danger" role="alert">
+      <p>There were some errors in the information you entered. Please correct the following:</p>
+      {{ form.non_field_errors }}
+      <ul>
+        {% for field in form %}
+          {% if field.errors %}<li>{{ field.label }}: {{ field.errors|striptags }}</li>{% endif %}
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+
   <form id="edit-work-form" method="POST" enctype="multipart/form-data">
     {% csrf_token %}
 

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -233,6 +233,17 @@ class AddWorkView(PlaceViewBase, AbstractAuthedIndigoView, WorkFormMixin, Create
             reversion.set_user(self.request.user)
             return super(AddWorkView, self).form_valid(form)
 
+    def form_invalid(self, form):
+        error_msgs = [error[0] for error in form.errors.values()]
+
+        messages.error(self.request, error_msgs[0])
+        return redirect(self.get_redirect_url())
+
+    def get_redirect_url(self):
+        if self.request.GET.get('next'):
+            return self.request.GET.get('next')
+        return reverse('new_work', kwargs={'place': self.kwargs['place']})
+
     def get_success_url(self):
         return reverse('work', kwargs={'frbr_uri': self.object.frbr_uri})
 

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -233,17 +233,6 @@ class AddWorkView(PlaceViewBase, AbstractAuthedIndigoView, WorkFormMixin, Create
             reversion.set_user(self.request.user)
             return super(AddWorkView, self).form_valid(form)
 
-    def form_invalid(self, form):
-        error_msgs = [error[0] for error in form.errors.values()]
-
-        messages.error(self.request, error_msgs[0])
-        return redirect(self.get_redirect_url())
-
-    def get_redirect_url(self):
-        if self.request.GET.get('next'):
-            return self.request.GET.get('next')
-        return reverse('new_work', kwargs={'place': self.kwargs['place']})
-
     def get_success_url(self):
         return reverse('work', kwargs={'frbr_uri': self.object.frbr_uri})
 


### PR DESCRIPTION
#### What does this PR do?

Give better feedback when something goes wrong when creating a work

#### Description of Task to be completed?

When a user creates a new work with any error such as an existing similar work(same year and number), there is no feedback as the page just refreshes.

This PR adds a notification (as seen in the screenshot down below) to tell the user what went wrong.

#### How should this be manually tested?

- Create a new work
- Recreate the work that already exists (same year and number) 

#### What are the relevant issues?

closes #759 

#### Screenshots

When recreating an existing work:
![image](https://user-images.githubusercontent.com/8082197/65768197-f4069100-e138-11e9-802b-a390c2cd8013.png)

