### PR TITLE
Correct perms for activity and versions

### DIFF
--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -212,6 +212,7 @@ class AnnotationViewSet(DocumentResourceView, viewsets.ModelViewSet):
 
 class RevisionViewSet(DocumentResourceView, viewsets.ReadOnlyModelViewSet):
     serializer_class = VersionSerializer
+    # The permissions applied in this case are for reversion.Version
     permission_classes = DEFAULT_PERMS + (DjangoModelPermissionsOrAnonReadOnly,)
 
     @detail_route(methods=['POST'])

--- a/indigo_social/default_badges.py
+++ b/indigo_social/default_badges.py
@@ -19,7 +19,8 @@ class ContributorBadge(PermissionBadge):
     group_name = name + ' Badge'
     description = 'Can view work details'
     permissions = ('indigo_api.add_annotation', 'indigo_api.change_annotation', 'indigo_api.delete_annotation',
-                   'indigo_api.add_task')
+                   'indigo_api.add_task',
+                   'indigo_api.add_documentactivity', 'indigo_api.change_documentactivity', 'indigo_api.delete_documentactivity')
 
 
 class DrafterBadge(PermissionBadge):
@@ -31,7 +32,7 @@ class DrafterBadge(PermissionBadge):
                    'indigo_api.add_document', 'indigo_api.change_document',
                    'indigo_api.add_amendment', 'indigo_api.change_amendment', 'indigo_api.delete_amendment',
                    # required when restoring a document version
-                   'reversion.change_version',
+                   'reversion.add_version', 'reversion.change_version',
                    'indigo_api.change_task', 'indigo_api.submit_task', 'indigo_api.reopen_task',
                    'indigo_api.add_workflow', 'indigo_api.change_workflow')
 


### PR DESCRIPTION
This ensures that:

* activity notifications ("this document is locked by X...") show up correctly
* users can restore old versions correctly