### PR TITLE
Strip internal whitespace when importing.

### DIFF
--- a/indigo_za/importer.py
+++ b/indigo_za/importer.py
@@ -146,9 +146,12 @@ class ImporterZA(Importer):
         return '\n'.join(output)
 
     def strip_whitespace(self, text):
-        """ Remove leading whitespace at the start of non-blank lines.
+        """ Strip and normalise whitespace.
         """
         # replacing non-breaking spaces with normal spaces
         text = text.replace('\xA0', ' ')
+        # Remove leading whitespace at the start of non-blank lines.
         text = re.sub(r'^[ \t]+([^ \t])', '\\1', text, 0, re.MULTILINE)
+        # Remove excessive whitespace inside text
+        text = re.sub(r'(\S)[ \t]{2,}', '\\1 ', text, 0, re.MULTILINE)
         return text

--- a/indigo_za/importer.py
+++ b/indigo_za/importer.py
@@ -153,5 +153,5 @@ class ImporterZA(Importer):
         # Remove leading whitespace at the start of non-blank lines.
         text = re.sub(r'^[ \t]+([^ \t])', '\\1', text, 0, re.MULTILINE)
         # Remove excessive whitespace inside text
-        text = re.sub(r'(\S)[ \t]{2,}', '\\1 ', text, 0, re.MULTILINE)
+        text = re.sub(r'(\S)[ \t]{2,}', '\\1 ', text)
         return text

--- a/indigo_za/tests/test_importer_za.py
+++ b/indigo_za/tests/test_importer_za.py
@@ -138,9 +138,11 @@ permit; and
 
         (a) foo   bar
           (b) baz boom
+          (c)   baz   boom
         """), """
 test
 
-(a) foo   bar
+(a) foo bar
 (b) baz boom
+(c) baz boom
         """)


### PR DESCRIPTION
This solves an issue with the Nigerian imports that have a lot of whitespace mid-paragraph in the HTML.