### PR TITLE
Fix activity perms

### DIFF
--- a/indigo_api/authz.py
+++ b/indigo_api/authz.py
@@ -73,3 +73,12 @@ class AttachmentPermissions(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return DocumentPermissions().has_object_permission(request, view, obj.document)
+
+
+class DocumentActivityPermission(BasePermission):
+    """ The user must be able to make changes to the document in order to "lock"
+    it with a DocumentActivity object.
+    """
+    def has_permission(self, request, view):
+        return (request.user.has_perm('indigo_api.change_document')
+                and request.user.editor.has_country_permission(view.document.work.country))

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -30,7 +30,7 @@ from indigo.plugins import plugins
 from ..models import Document, Annotation, DocumentActivity, Task
 from ..serializers import DocumentSerializer, RenderSerializer, ParseSerializer, DocumentAPISerializer, VersionSerializer, AnnotationSerializer, DocumentActivitySerializer, TaskSerializer
 from ..renderers import AkomaNtosoRenderer, PDFResponseRenderer, EPUBResponseRenderer, HTMLResponseRenderer, ZIPResponseRenderer, HTMLRenderer
-from ..authz import DocumentPermissions, AnnotationPermissions
+from ..authz import DocumentPermissions, AnnotationPermissions, DocumentActivityPermission
 from ..utils import Headline, SearchPagination, SearchRankCD
 from .misc import DEFAULT_PERMS
 
@@ -283,9 +283,12 @@ class DocumentActivityViewSet(DocumentResourceView,
                               mixins.CreateModelMixin,
                               viewsets.GenericViewSet):
     """ API endpoint to see who's working in a document.
+
+    Because this "locks" a document, only users who have permission to edit the document
+    can create an activity object.
     """
     serializer_class = DocumentActivitySerializer
-    permission_classes = DEFAULT_PERMS + (DjangoModelPermissionsOrAnonReadOnly,)
+    permission_classes = DEFAULT_PERMS + (DjangoModelPermissionsOrAnonReadOnly, DocumentActivityPermission)
 
     def get_queryset(self):
         return self.document.activities.prefetch_related('user').all()

--- a/indigo_app/templates/indigo_api/document/_toolbar.html
+++ b/indigo_app/templates/indigo_api/document/_toolbar.html
@@ -132,7 +132,7 @@
         <div>You don't have permission to make changes.</div>
       {% endif %}
     {% else %}
-      <div><a href="{% url 'account_login' %}?next={{ request.get_absolute_url|urlencode }}">Log in</a> to make changes.</div>
+      <div><a href="{% url 'account_login' %}?next={{ request.get_full_path|urlencode }}">Log in</a> to make changes.</div>
     {% endif %}
   {% endblock %}
 </div>

--- a/indigo_app/templates/indigo_api/document/_toolbar.html
+++ b/indigo_app/templates/indigo_api/document/_toolbar.html
@@ -118,15 +118,22 @@
 
 <div class="btn-toolbar document-workspace-buttons">
   {% block save-buttons %}
-  <div class="btn-group logged-in save-btn-group">
-    <button class="btn btn-success save" disabled><span class="if-published">Save &amp; publish</span><span class="if-draft">Save draft</span></button>
-    <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-toggle="dropdown"></button>
-    <div class="dropdown-menu dropdown-menu-right">
-      <a class="dropdown-item save-and-publish if-draft {% if not perms.indigo_api.publish_document %}disabled{% endif %}" href="#">Save &amp; publish</a>
-      <a class="dropdown-item save-and-unpublish if-published {% if not perms.indigo_api.publish_document %}disabled{% endif %}" href="#">Unpublish &amp; save</a>
-    </div>
-  </div>
-  <div class="not-logged-in"><a href="{% url 'account_login' %}?next={{ request.get_absolute_url|urlencode }}">Log in</a> to make changes.</div>
+    {% if request.user.is_authenticated %}
+      {% if user_can_edit %}
+        <div class="btn-group save-btn-group">
+          <button class="btn btn-success save" disabled><span class="if-published">Save &amp; publish</span><span class="if-draft">Save draft</span></button>
+          <button class="btn btn-success dropdown-toggle dropdown-toggle-split" data-toggle="dropdown"></button>
+          <div class="dropdown-menu dropdown-menu-right">
+            <a class="dropdown-item save-and-publish if-draft {% if not perms.indigo_api.publish_document %}disabled{% endif %}" href="#">Save &amp; publish</a>
+            <a class="dropdown-item save-and-unpublish if-published {% if not perms.indigo_api.publish_document %}disabled{% endif %}" href="#">Unpublish &amp; save</a>
+          </div>
+        </div>
+      {% else %}
+        <div>You don't have permission to make changes.</div>
+      {% endif %}
+    {% else %}
+      <div><a href="{% url 'account_login' %}?next={{ request.get_absolute_url|urlencode }}">Log in</a> to make changes.</div>
+    {% endif %}
   {% endblock %}
 </div>
 

--- a/indigo_app/views/documents.py
+++ b/indigo_app/views/documents.py
@@ -55,6 +55,10 @@ class DocumentDetailView(AbstractAuthedIndigoView, DetailView):
 
         context['form'] = DocumentForm(instance=doc)
         context['subtypes'] = Subtype.objects.order_by('name').all()
+        context['user_can_edit'] = (
+            self.request.user.is_authenticated
+            and self.request.user.has_perm('indigo_api.change_document')
+            and self.request.user.editor.has_country_permission(doc.work.country))
 
         context['download_formats'] = [{
             'url': reverse('document-detail', kwargs={'pk': doc.id, 'format': r.format}) + getattr(r, 'suffix', ''),

--- a/indigo_social/default_badges.py
+++ b/indigo_social/default_badges.py
@@ -19,8 +19,7 @@ class ContributorBadge(PermissionBadge):
     group_name = name + ' Badge'
     description = 'Can view work details'
     permissions = ('indigo_api.add_annotation', 'indigo_api.change_annotation', 'indigo_api.delete_annotation',
-                   'indigo_api.add_task',
-                   'indigo_api.add_documentactivity', 'indigo_api.change_documentactivity', 'indigo_api.delete_documentactivity')
+                   'indigo_api.add_task')
 
 
 class DrafterBadge(PermissionBadge):
@@ -30,6 +29,7 @@ class DrafterBadge(PermissionBadge):
     description = 'Can create new works and edit the details of existing works'
     permissions = ('indigo_api.add_work', 'indigo_api.change_work',
                    'indigo_api.add_document', 'indigo_api.change_document',
+                   'indigo_api.add_documentactivity', 'indigo_api.change_documentactivity', 'indigo_api.delete_documentactivity',
                    'indigo_api.add_amendment', 'indigo_api.change_amendment', 'indigo_api.delete_amendment',
                    # required when restoring a document version
                    'reversion.add_version', 'reversion.change_version',


### PR DESCRIPTION
* users who can't edit documents shouldn't be able to lock the edit view (we do this by limiting who can create the DocumentActivity object)
* contributors don't have perms to create DocumentActivity object
* improve template to be clearer about when a user can actually edit a document