### PR TITLE
only include task approvals in work recent changes view

### DIFF
--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -537,9 +537,8 @@ class WorkVersionsView(WorkViewBase, MultipleObjectMixin, DetailView):
 
     def get_task_actions(self):
         tasks = self.work.tasks.all()
-        actions_per_task = [t.action_object_actions.all() for t in tasks]
-        return [action for actions in actions_per_task for action in actions
-                if action.verb == 'approved']
+        actions_per_task = [t.action_object_actions.filter(verb='approved') for t in tasks]
+        return [action for actions in actions_per_task for action in actions]
 
 
 class WorkTasksView(WorkViewBase, DetailView):

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -538,7 +538,8 @@ class WorkVersionsView(WorkViewBase, MultipleObjectMixin, DetailView):
     def get_task_actions(self):
         tasks = self.work.tasks.all()
         actions_per_task = [t.action_object_actions.all() for t in tasks]
-        return [action for actions in actions_per_task for action in actions]
+        return [action for actions in actions_per_task for action in actions
+                if action.verb == 'approved']
 
 
 class WorkTasksView(WorkViewBase, DetailView):


### PR DESCRIPTION
otherwise the recent changes view gets too cluttered and uninformative
(there's always the tasks on work view, so we're not losing information)