### PR TITLE
Support runs of section references

### DIFF
--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -282,7 +282,7 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
     # individual numbers in the list grouping above
     # we use <ref> and <num> named captures so that the is_valid and make_ref
     # methods can handle matches from both ref_re and this re.
-    item_re = re.compile(r'(?P<ref>(?P<num>\d+[A-Z0-9]*))[A-Z0-9()]*', re.IGNORECASE)
+    item_re = re.compile(r'(?P<ref>(?P<num>\d+[A-Z0-9]*))(\([A-Z0-9]+\))*', re.IGNORECASE)
 
     candidate_xpath = ".//text()[contains(translate(., 'S', 's'), 'section') and not(ancestor::a:ref)]"
     match_cache = {}

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -280,6 +280,8 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
         re.X | re.IGNORECASE)
 
     # individual numbers in the list grouping above
+    # we use <ref> and <num> named captures so that the is_valid and make_ref
+    # methods can handle matches from both ref_re and this re.
     item_re = re.compile(r'(?P<ref>(?P<num>\d+[A-Z0-9]*))[A-Z0-9()]*', re.IGNORECASE)
 
     candidate_xpath = ".//text()[contains(translate(., 'S', 's'), 'section') and not(ancestor::a:ref)]"

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -31,6 +31,10 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26(1)(b)(iii)(dd)(A), which we'll discard for now, blah.</p>
           <p>As given in section 26B, blah.</p>
           <p>As given in section 26 and section 31, blah.</p>
+          <p>As given in sections 26 and 31, blah.</p>
+          <p>As given in sections 26 or 31, blah.</p>
+          <p>As given in sections 26, 30 and 31.</p>
+          <p>As given in sections 26(b), 30(1) or 31.</p>
           <p>As given in section 26 of this Act, blah.</p>
           <p>In section 200 it says one thing and in section 26 it says another.</p>
           <p>In section 26 of Act 5 of 2012 it says one thing and in section 26 of this Act it says another.</p>
@@ -84,6 +88,10 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26B">section 26B</ref>, blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref> and <ref href="#section-31">section 31</ref>, blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref> of this Act, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref> and <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref> or <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>(b), <ref href="#section-30">30</ref>(1) or <ref href="#section-31">31</ref>.</p>
           <p>In section 200 it says one thing and in <ref href="#section-26">section 26</ref> it says another.</p>
           <p>In section 26 of Act 5 of 2012 it says one thing and in <ref href="#section-26">section 26</ref> of this Act it says another.</p>
           <p>Two baddies: In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
@@ -124,7 +132,7 @@ class SectionRefsFinderTestCase(TestCase):
         self.section_refs_finder.find_references_in_document(document)
         root = etree.fromstring(expected.content)
         expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(document.content, expected.content)
+        self.assertEqual(expected.content, document.content)
 
     def test_section_basic_in_tail(self):
         document = Document(
@@ -138,6 +146,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As <i>given</i> in (we're now in a tail) section 26 of this Act, blah.</p>
           <p>As <i>given</i> in (we're now in a tail) section 200, blah, but section 26 says something else.</p>
           <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah, but section 26 of this Act says something else.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26, 30 and 31.</p>
         </content>
       </section>
       <section id="section-26">
@@ -162,6 +171,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As <i>given</i> in (we're now in a tail) <ref href="#section-26">section 26</ref> of this Act, blah.</p>
           <p>As <i>given</i> in (we're now in a tail) section 200, blah, but <ref href="#section-26">section 26</ref> says something else.</p>
           <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah, but <ref href="#section-26">section 26</ref> of this Act says something else.</p>
+          <p>As <i>given</i> in (we're now in a tail) section <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>.</p>
         </content>
       </section>
       <section id="section-26">
@@ -178,7 +188,7 @@ class SectionRefsFinderTestCase(TestCase):
         self.section_refs_finder.find_references_in_document(document)
         root = etree.fromstring(expected.content)
         expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(document.content, expected.content)
+        self.assertEqual(expected.content, document.content)
 
     def test_section_notfound(self):
         document = Document(
@@ -189,6 +199,8 @@ class SectionRefsFinderTestCase(TestCase):
         <heading>Active ref heading</heading>
         <content>
           <p>As given in section 26, which isn't in this document, blah.</p>
+          <p>As given in sections 26 and 35, one of which isn't in this document, blah.</p>
+          <p>As given in sections 35 and 26, one of which isn't in this document, blah.</p>
         </content>
       </section>
       <section id="section-35">
@@ -202,11 +214,33 @@ class SectionRefsFinderTestCase(TestCase):
             ),
             language=self.eng)
 
-        expected_content = document.content
+        expected = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in section 26, which isn't in this document, blah.</p>
+          <p>As given in sections 26 and <ref href="#section-35">35</ref>, one of which isn't in this document, blah.</p>
+          <p>As given in sections <ref href="#section-35">35</ref> and 26, one of which isn't in this document, blah.</p>
+        </content>
+      </section>
+      <section id="section-35">
+        <num>35.</num>
+        <heading>Not the section we want</heading>
+        <content>
+          <p>Not the provision you're looking for.</p>
+        </content>
+      </section>
+          """
+            ),
+            language=self.eng)
+
         self.section_refs_finder.find_references_in_document(document)
-        root = etree.fromstring(expected_content)
+        root = etree.fromstring(expected.content)
         expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(document.content, expected_content)
+        self.assertEqual(expected_content, document.content)
 
     def test_section_external(self):
         document = Document(
@@ -223,6 +257,8 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26 (b) (iii) of the Nursing Act, blah.</p>
           <p>As given in section 26(b)(iii)(bb) of the Nursing Act, blah.</p>
           <p>As given in section 26(b)(iii)(aa)(A) of the Nursing Act, blah.</p>
+          <p>As given in section 26, 27 or 28(b) of the Nursing Act, blah.</p>
+          <p>As given in section 26 or 27 of the Nursing Act, blah.</p>
           <p>As given in the unusual reference of section 26(b)(iii)(1) of the Nursing Act, blah.</p>
         </content>
       </section>
@@ -241,7 +277,7 @@ class SectionRefsFinderTestCase(TestCase):
         self.section_refs_finder.find_references_in_document(document)
         root = etree.fromstring(expected_content)
         expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(document.content, expected_content)
+        self.assertEqual(expected_content, document.content)
 
     def test_section_external_in_tail(self):
         document = Document(
@@ -253,6 +289,7 @@ class SectionRefsFinderTestCase(TestCase):
         <content>
           <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah.</p>
           <p>As <i>given</i> in (we're now in a tail) section 26 of the Nursing Act, blah.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26, 27 and 28 of the Nursing Act, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -270,4 +307,4 @@ class SectionRefsFinderTestCase(TestCase):
         self.section_refs_finder.find_references_in_document(document)
         root = etree.fromstring(expected_content)
         expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(document.content, expected_content)
+        self.assertEqual(expected_content, document.content)

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -28,7 +28,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26(b), blah.</p>
           <p>As given in section 26(1)(b)(iii), blah.</p>
           <p>As given in section 26(1)(b)(iii)(bb), blah.</p>
-          <p>As given in section 26(1)(b)(iii)(dd)(A), which we'll discard for now, blah.</p>
+          <p>As given in section 26(1)(b)(iii)(dd)(A), blah.</p>
           <p>As given in section 26B, blah.</p>
           <p>As given in section 26 and section 31, blah.</p>
           <p>As given in sections 26 and 31, blah.</p>
@@ -84,14 +84,14 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26">section 26</ref>(b), blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref>(1)(b)(iii), blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref>(1)(b)(iii)(bb), blah.</p>
-          <p>As given in section 26(1)(b)(iii)(dd)(A), which we'll discard for now, blah.</p>
+          <p>As given in <ref href="#section-26">section 26</ref>(1)(b)(iii)(dd)(A), blah.</p>
           <p>As given in <ref href="#section-26B">section 26B</ref>, blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref> and <ref href="#section-31">section 31</ref>, blah.</p>
-          <p>As given in <ref href="#section-26">section 26</ref> of this Act, blah.</p>
           <p>As given in sections <ref href="#section-26">26</ref> and <ref href="#section-31">31</ref>, blah.</p>
           <p>As given in sections <ref href="#section-26">26</ref> or <ref href="#section-31">31</ref>, blah.</p>
           <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>.</p>
           <p>As given in sections <ref href="#section-26">26</ref>(b), <ref href="#section-30">30</ref>(1) or <ref href="#section-31">31</ref>.</p>
+          <p>As given in <ref href="#section-26">section 26</ref> of this Act, blah.</p>
           <p>In section 200 it says one thing and in <ref href="#section-26">section 26</ref> it says another.</p>
           <p>In section 26 of Act 5 of 2012 it says one thing and in <ref href="#section-26">section 26</ref> of this Act it says another.</p>
           <p>Two baddies: In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
@@ -156,6 +156,20 @@ class SectionRefsFinderTestCase(TestCase):
           <p>An important provision.</p>
         </content>
       </section>
+      <section id="section-30">
+        <num>30.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-31">
+        <num>31.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
         """
             ),
             language=self.eng)
@@ -176,6 +190,20 @@ class SectionRefsFinderTestCase(TestCase):
       </section>
       <section id="section-26">
         <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-30">
+        <num>30.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-31">
+        <num>31.</num>
         <heading>Important heading</heading>
         <content>
           <p>An important provision.</p>
@@ -233,7 +261,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>Not the provision you're looking for.</p>
         </content>
       </section>
-          """
+        """
             ),
             language=self.eng)
 

--- a/indigo/xmlutils.py
+++ b/indigo/xmlutils.py
@@ -18,9 +18,34 @@ def wrap_tail(elem, wrapper):
     """ Wrap the tail text of elem in wrapper (a callable), and
     append the new element directly after elem.
     """
-    x = wrapper(elem.tail)
-    elem.tail = None
-    elem.addnext(x)
+    return wrap_text(elem, True, wrapper)
+
+
+def wrap_text(node, tail, wrapper, start_pos=None, end_pos=None):
+    """ Wrap the text (or tail if tail is True) of a node in wrapper (a callable).
+    Optionally, start_pos and end_pos specify the substring of the node's text (or tail)
+    to be wrapped. The wrapper callable will be called with the text being wrapped.
+    """
+    if tail:
+        text = node.tail or ''
+        start_pos = start_pos or 0
+        end_pos = len(text) if end_pos is None else end_pos
+        wrapped = wrapper(text[start_pos:end_pos])
+
+        node.addnext(wrapped)
+        node.tail = text[:start_pos]
+        wrapped.tail = text[end_pos:]
+    else:
+        text = node.text or ''
+        start_pos = start_pos or 0
+        end_pos = len(text) if end_pos is None else end_pos
+        wrapped = wrapper(text[start_pos:end_pos])
+
+        node.text = text[:start_pos]
+        node.insert(0, wrapped)
+        wrapped.tail = text[end_pos:]
+
+    return wrapped
 
 
 def unwrap_element(elem):


### PR DESCRIPTION
eg:

```
sections 22 and 32
and sections 19, 22 and 23, unless it appears to him
Sections 24, 26, 28, 36, 42(2), 46, 48, 49(2), 52, 53, 54 and 56 shall mutatis mutandis
sections 23, 24, 25, 26 and 28;
sections 22(1) and 25(3)(b);
sections 18, 61 and 62(1).
in terms of section 2 or 7
sections 12(6)(d) and (e)
Subject to sections 1(4), 3(6), 4, 8, 24, 34(2) and 44, no person
```