### PR TITLE
Base classes for regex-based markup (terms, refs)

### DIFF
--- a/indigo/analysis/markup.py
+++ b/indigo/analysis/markup.py
@@ -1,0 +1,98 @@
+from lxml import etree
+
+from indigo.xmlutils import wrap_text
+
+
+class TextPatternMarker:
+    """ Logic for marking up portions of text in a document using regular expressions.
+    """
+
+    pattern_re = None
+    """ Compiled re pattern to be applied to the text return by nodes matching candidate_xpath.
+    Must be defined by subclasses.
+    """
+
+    candidate_xpath = None
+    """ Xpath for candidate text nodes that should be tested for matches. Must be defined by subclasses.
+    """
+
+    ancestors = ['coverpage', 'preface', 'preamble', 'body', 'mainBody', 'conclusions']
+    """ Tags that the candidate_xpath should be run against.
+    """
+
+    marker_tag = 'b'
+    """ Tag that will be used to markup matches.
+    """
+
+    def setup(self, root):
+        self.ns = root.nsmap[None]
+        self.nsmap = {'a': self.ns}
+        self.marker_tag = "{%s}%s" % (self.ns, self.marker_tag)
+        self.ancestor_xpath = etree.XPath('|'.join(f'.//a:{a}' for a in self.ancestors), namespaces=self.nsmap)
+        self.candidate_xpath = etree.XPath(self.candidate_xpath, namespaces=self.nsmap)
+
+    def markup_patterns(self, root):
+        for ancestor in self.ancestor_nodes(root):
+            for candidate in self.candidate_nodes(ancestor):
+                node = candidate.getparent()
+
+                if not candidate.is_tail:
+                    # text directly inside a node
+                    for match in self.find_matches(node.text):
+                        new_node = self.handle_match(node, match, in_tail=False)
+                        if new_node is not None:
+                            # the node has now changed, making the offsets in any subsequent
+                            # matches incorrect. so stop looking and start again, checking
+                            # the tail of the newly inserted node
+                            node = new_node
+                            break
+
+                while node is not None and node.tail:
+                    for match in self.find_matches(node.tail):
+                        new_node = self.handle_match(node, match, in_tail=True)
+                        if new_node is not None:
+                            # the node has now changed, making the offsets in any subsequent
+                            # matches incorrect. so stop looking and start again, checking
+                            # the tail of the newly inserted node
+                            node = new_node
+                            break
+                    else:
+                        # we didn't break out of the loop, so there are no valid matches, give up
+                        node = None
+
+    def find_matches(self, text):
+        """ Return an iterable of matches in this chunk of text.
+        """
+        return self.pattern_re.finditer(text)
+
+    def is_valid(self, node, match):
+        return True
+
+    def handle_match(self, node, match, in_tail):
+        """ Process a match. If this modifies the text (or tail, if in_tail is True), then
+        return the new node that should have its tail checked for further matches.
+        Otherwise, return None.
+        """
+        if self.is_valid(node, match):
+            ref, start_pos, end_pos = self.markup_match(node, match)
+            return wrap_text(node, in_tail, lambda t: ref, start_pos, end_pos)
+
+    def markup_match(self, node, match):
+        """ Create a markup element for a match.
+
+        Returns an (element, start_pos, end_pos) tuple.
+
+        The element is the new element to insert into the tree, and the start_pos and end_pos specify
+        the offsets of the chunk of text that will be replaced by the new element.
+        """
+        marker = etree.Element(self.marker_tag)
+        marker.text = match.group(0)
+        return marker, match.start(0), match.end(0)
+
+    def ancestor_nodes(self, root):
+        for x in self.ancestor_xpath(root):
+            yield x
+
+    def candidate_nodes(self, root):
+        for x in self.candidate_xpath(root):
+            yield x

--- a/indigo/analysis/markup.py
+++ b/indigo/analysis/markup.py
@@ -92,12 +92,10 @@ class TextPatternMarker:
         return marker, match.start(0), match.end(0)
 
     def ancestor_nodes(self, root):
-        for x in self.ancestor_xpath(root):
-            yield x
+        return self.ancestor_xpath(root)
 
     def candidate_nodes(self, root):
-        for x in self.candidate_xpath(root):
-            yield x
+        return self.candidate_xpath(root)
 
 
 class MultipleTextPatternMarker(TextPatternMarker):

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -3,7 +3,7 @@ import re
 
 from indigo.analysis.markup import TextPatternMarker, MultipleTextPatternMarker
 from indigo.plugins import LocaleBasedMatcher, plugins
-from indigo.xmlutils import closest, wrap_text
+from indigo.xmlutils import closest
 
 
 class BaseRefsFinder(LocaleBasedMatcher, TextPatternMarker):

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -1,25 +1,15 @@
 from lxml import etree
 import re
 
+from indigo.analysis.markup import TextPatternMarker
 from indigo.plugins import LocaleBasedMatcher, plugins
 from indigo.xmlutils import closest, wrap_text
 
 
-class BaseRefsFinder(LocaleBasedMatcher):
+class BaseRefsFinder(LocaleBasedMatcher, TextPatternMarker):
     """ Finds references to Acts in documents.
     """
-
-    act_re = None
-    """ This must be defined by a subclass. It should be a compiled regular
-    expression, with named captures for `ref`, `num` and `year`.
-    """
-    candidate_xpath = None
-    """ Xpath for candidate text nodes that should be tested for references.
-    Must be defined by subclasses.
-    """
-
-    # the ancestor elements that can contain references
-    ancestors = ['coverpage', 'preface', 'preamble', 'body', 'mainBody', 'conclusions']
+    marker_tag = 'ref'
 
     def find_references_in_document(self, document):
         """ Find references in +document+, which is an Indigo Document object.
@@ -29,75 +19,21 @@ class BaseRefsFinder(LocaleBasedMatcher):
         root = etree.fromstring(document.content)
         self.frbr_uri = document.doc.frbr_uri
         self.setup(root)
-        self.find_references(root)
+        self.markup_patterns(root)
         document.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
 
-    def setup(self, root):
-        self.ns = root.nsmap[None]
-        self.nsmap = {'a': self.ns}
-        self.ref_tag = "{%s}ref" % self.ns
-
-        self.ancestor_xpath = etree.XPath('|'.join('.//a:%s' % a for a in self.ancestors), namespaces=self.nsmap)
-        self.candidate_xpath = etree.XPath(self.candidate_xpath, namespaces=self.nsmap)
+    def markup_match(self, node, match):
+        """ Markup the match with a ref tag. The first group in the match is substituted with the ref.
+        """
+        ref = etree.Element(self.marker_tag)
+        ref.text = match.group('ref')
+        ref.set('href', self.make_href(match))
+        return ref, match.start('ref'), match.end('ref')
 
     def make_href(self, match):
         """ Turn this match into a full FRBR URI href
         """
         return '/%s/act/%s/%s' % (self.frbr_uri.country, match.group('year'), match.group('num'))
-
-    def find_references(self, root):
-        for root in self.ancestor_nodes(root):
-            for candidate in self.candidate_nodes(root):
-                node = candidate.getparent()
-
-                if not candidate.is_tail:
-                    # text directly inside a node
-                    match = self.act_re.search(node.text)
-                    if match:
-                        # mark the reference and continue to check the new tail
-                        node = self.mark_reference(node, match, in_tail=False)
-
-                while node is not None and node.tail:
-                    match = self.act_re.search(node.tail)
-                    if not match:
-                        break
-
-                    # mark the reference and continue to check the new tail
-                    node = self.mark_reference(node, match, in_tail=True)
-
-    def mark_reference(self, node, match, in_tail):
-        ref, start_pos, end_pos = self.make_ref(match)
-
-        if in_tail:
-            node.addnext(ref)
-            node.tail = match.string[:start_pos]
-            ref.tail = match.string[end_pos:]
-        else:
-            node.text = match.string[:start_pos]
-            node.insert(0, ref)
-            ref.tail = match.string[end_pos:]
-
-        return ref
-
-    def make_ref(self, match):
-        """ Make a reference out of this match, returning a (ref, start, end) tuple
-        which is the new ref node, and the start and end position of what text
-        in the parent element it should be replacing.
-
-        By default, the first group in the `act_re` is substituted with the ref.
-        """
-        ref = etree.Element(self.ref_tag)
-        ref.text = match.group('ref')
-        ref.set('href', self.make_href(match))
-        return (ref, match.start('ref'), match.end('ref'))
-
-    def ancestor_nodes(self, root):
-        for x in self.ancestor_xpath(root):
-            yield x
-
-    def candidate_nodes(self, root):
-        for x in self.candidate_xpath(root):
-            yield x
 
 
 @plugins.register('refs')
@@ -113,7 +49,7 @@ class RefsFinderENG(BaseRefsFinder):
     # country, language, locality
     locale = (None, 'eng', None)
 
-    act_re = re.compile(
+    pattern_re = re.compile(
         r'''\bAct,?\s+
             (\d{4}\s+)?
             \(?

--- a/indigo_za/refs.py
+++ b/indigo_za/refs.py
@@ -22,7 +22,7 @@ class RefsFinderENGza(BaseRefsFinder):
     locale = ('za', 'eng', None)
 
     # if Act part changes, you may also want to update indigo/analysis/refs/global.py
-    act_re = re.compile(
+    pattern_re = re.compile(
         r'''\b
             (
              Act,?\s+(\d{4}\s+)?                    # Act   or   Act, 1998
@@ -50,7 +50,7 @@ class RefsFinderENGza(BaseRefsFinder):
         else:
             return '/%s/act/%s/%s' % (self.frbr_uri.country, year, number)
 
-    def make_ref(self, match):
+    def markup_match(self, node, match):
         if self.constitution in match.group(0):
             group = 0
         elif match.group(2):
@@ -58,10 +58,10 @@ class RefsFinderENGza(BaseRefsFinder):
         else:
             group = 1
 
-        ref = etree.Element(self.ref_tag)
+        ref = etree.Element(self.marker_tag)
         ref.text = match.group(group)
         ref.set('href', self.make_href(match))
-        return (ref, match.start(group), match.end(group))
+        return ref, match.start(group), match.end(group)
 
 
 @plugins.register('refs')
@@ -77,7 +77,7 @@ class RefsFinderAFRza(RefsFinderENGza):
     # country, language, locality
     locale = ('za', 'afr', None)
 
-    act_re = re.compile(
+    pattern_re = re.compile(
         r'''\b
             (?P<ref>
              Wet,?\s+([nN]o\.?\s*)?
@@ -92,13 +92,13 @@ class RefsFinderAFRza(RefsFinderENGza):
 
     constitution = 'Grondwet'
 
-    def make_ref(self, match):
+    def markup_match(self, node, match):
         if self.constitution in match.group(0):
             group = 0
         else:
             group = 'ref'
 
-        ref = etree.Element(self.ref_tag)
+        ref = etree.Element(self.marker_tag)
         ref.text = match.group(group)
         ref.set('href', self.make_href(match))
-        return (ref, match.start(group), match.end(group))
+        return ref, match.start(group), match.end(group)


### PR DESCRIPTION
Moves logic into base classes to make concrete implementations simpler.