### PR TITLE
FIX looking up task anchor in components

### DIFF
--- a/indigo/documents.py
+++ b/indigo/documents.py
@@ -35,14 +35,14 @@ class ResolvedAnchor(object):
 
         while anchor_id:
             escaped = anchor_id.replace("'", "\'")
-            elems = component.xpath("//*[@id='%s']" % escaped)
+            elems = component.xpath(".//*[@id='%s']" % escaped)
             if elems:
                 self.resolve_element(elems[0])
                 break
             elif anchor_id in ['preface', 'preamble']:
                 # HACK HACK HACK
                 # We sometimes use 'preamble' and 'preface' even though they aren't IDs
-                elems = component.xpath("//a:%s" % escaped, namespaces={'a': self.document.doc.namespace})
+                elems = component.xpath(".//a:%s" % escaped, namespaces={'a': self.document.doc.namespace})
                 if elems:
                     self.resolve_element(elems[0])
                     break


### PR DESCRIPTION
Ensure the xpath is relative to the component.

Fixes this task which shows the wrong item: https://edit.laws.africa/places/ng/tasks/4311/