### PR TITLE
Improved options for advanced work filter date fields

### DIFF
--- a/indigo_app/static/javascript/indigo/views/work_filter_form.js
+++ b/indigo_app/static/javascript/indigo/views/work_filter_form.js
@@ -1,0 +1,22 @@
+(function(exports) {
+  "use strict";
+
+  if (!exports.Indigo) exports.Indigo = {};
+  Indigo = exports.Indigo;
+
+  /** This view handles the work filter form.
+   */
+  Indigo.WorkFilterFormView = Backbone.View.extend({
+    el: '#work-filter-form',
+    events: {
+      'change [data-toggle="daterange"]': 'dateRangeToggled',
+    },
+
+    dateRangeToggled: function(e) {
+      // When value of the toggler is 'range' reveal the date range elements
+      var input = e.currentTarget;
+
+      this.$('#' + input.name + '-daterange').toggleClass('d-none', input.value != 'range');
+    },
+  });
+})(window);

--- a/indigo_app/templates/indigo_api/_work_filter_form.html
+++ b/indigo_app/templates/indigo_api/_work_filter_form.html
@@ -79,15 +79,24 @@
     <div class="row mt-2">
       <!-- Assent Date filter -->
       <div class="col-md-6 mt-2">
-        <div class="input-group input-daterange">
-          <div class="custom-control custom-checkbox mt-2 mr-2">
-            <input type="checkbox" class="custom-control-input" id="assent_date_check" name="assent_date_check" {% if form.assent_date_check.value %} checked {% endif %} onchange="checkAssentDate()">
-            <label class="custom-control-label" for="assent_date_check">Assented to between</label>
+        <div class="form-group">
+          <label for="{{ form.assent.id_for_label }}">Assent</label>
+          <div class="form-row">
+            <div class="col">
+              <select name="{{ form.assent.html_name }}" class="form-control" id="{{ form.assent.id_for_label }}" data-toggle="daterange">
+                {% for opt in form.assent %}
+                  {{ opt }}
+                {% endfor %}
+              </select>
+            </div>
+            <div class="col">
+              <div class="input-group input-daterange {% if form.assent.value != 'range'%}d-none{% endif %}" id="assent-daterange">
+                <input type="text" class="form-control mr-1" data-provide="datepicker" placeholder="start date" pattern="\d{4}-\d\d-\d\d" id="assent_date_start" name="assent_date_start" value="{{ form.assent_date_start.value | default:'' }}">
+                <div class="input-group-addon"> and </div>
+                <input type="text" class="form-control ml-1 mr-1" data-provide="datepicker" placeholder="end date" pattern="\d{4}-\d\d-\d\d" id="assent_date_end" name="assent_date_end" value="{{ form.assent_date_end.value | default:'' }}">
+              </div>
+            </div>
           </div>
-
-          <input type="text" class="form-control mr-1" data-provide="datepicker" placeholder="start date" pattern="\d{4}-\d\d-\d\d" id="assent_date_start" name="assent_date_start" value="{{ form.assent_date_start.value | default:'' }}">
-          <div class="input-group-addon"> and </div>
-          <input type="text" class="form-control ml-1 mr-1" data-provide="datepicker" placeholder="end date" pattern="\d{4}-\d\d-\d\d" id="assent_date_end" name="assent_date_end" value="{{ form.assent_date_end.value | default:'' }}">
         </div>
       </div>
 

--- a/indigo_app/views/places.py
+++ b/indigo_app/views/places.py
@@ -103,6 +103,7 @@ class PlaceDetailView(PlaceViewBase, AbstractAuthedIndigoView, ListView):
     tab = 'works'
     context_object_name = 'works'
     paginate_by = 50
+    js_view = 'PlaceDetailView WorkFilterFormView'
 
     def get(self, request, *args, **kwargs):
         params = QueryDict(mutable=True)


### PR DESCRIPTION
Allow the user to filter assent by "any", "not assented to", "assented to" and "assented to between dates X and Y".

The same logic needs to be applied to the other date filters.