### PR TITLE
Include commenced flag in content api

### DIFF
--- a/indigo_api/fixtures/work.json
+++ b/indigo_api/fixtures/work.json
@@ -36,6 +36,7 @@
       "updated_at": "2015-02-17T10:57:47.779Z",
       "created_by_user": 1,
       "updated_by_user": 1,
+      "commenced": true,
       "commencement_date": "2010-06-01",
       "assent_date": "2010-04-01",
       "frbr_uri": "/za/act/2010/1",

--- a/indigo_content_api/tests/v1/test_content_api.py
+++ b/indigo_content_api/tests/v1/test_content_api.py
@@ -332,6 +332,13 @@ class ContentAPIV1TestMixin(object):
             'repealing_title': 'Water Act',
         })
 
+    def test_commenced(self):
+        response = self.client.get(self.api_path + '/za/act/2010/1.json')
+        assert_equal(response.status_code, 200)
+        assert_equal(response.accepted_media_type, 'application/json')
+        assert_equal(response.data['commenced'], True)
+        assert_equal(response.data['commencement_date'], '2010-06-01')
+
     def test_published_alternate_links(self):
         response = self.client.get(self.api_path + '/za/act/2001/8/eng.json')
         assert_equal(response.status_code, 200)

--- a/indigo_content_api/v1/serializers.py
+++ b/indigo_content_api/v1/serializers.py
@@ -64,6 +64,7 @@ class PublishedDocumentSerializer(DocumentSerializer):
     publication_document = serializers.SerializerMethodField()
     taxonomies = serializers.SerializerMethodField()
     as_at_date = serializers.DateField(source='work.as_at_date')
+    commenced = serializers.BooleanField(source='work.commenced')
 
     class Meta:
         model = Document
@@ -75,7 +76,7 @@ class PublishedDocumentSerializer(DocumentSerializer):
             'country', 'locality', 'nature', 'subtype', 'year', 'number', 'frbr_uri', 'expression_frbr_uri',
 
             'publication_date', 'publication_name', 'publication_number', 'publication_document',
-            'expression_date', 'commencement_date', 'assent_date',
+            'expression_date', 'commenced', 'commencement_date', 'assent_date',
             'language', 'repeal', 'amendments', 'points_in_time',
             'numbered_title', 'taxonomies', 'as_at_date',
 


### PR DESCRIPTION
We, erroneously, don't include the commencing work. It would
be best to do so in a new 'commencement' property that includes
the date and commencing work. Moving the commencement_dat field
is backwards incompatible and will therefore require a new API
version (v3).