### PR TITLE
Ensure that empty p tags take up space in HTML. 

### DIFF
--- a/indigo_api/static/xsl/act.xsl
+++ b/indigo_api/static/xsl/act.xsl
@@ -242,6 +242,15 @@
     </section>
   </xsl:template>
 
+  <!-- empty p tags must take up space in HTML, so add an nbsp;
+       empty means no child elements and only whitespace content -->
+  <xsl:template match="a:p[not(*) and not(normalize-space())]">
+    <span class="akn-{local-name()}">
+      <xsl:apply-templates select="@*" />
+      <xsl:text>&#160;</xsl:text>
+    </span>
+  </xsl:template>
+
   <!-- for all nodes, generate a SPAN element with a class matching
        the AN name of the node and copy over the attributes -->
   <xsl:template match="*" name="generic-elem">

--- a/indigo_content_api/tests/v1/test_content_api.py
+++ b/indigo_content_api/tests/v1/test_content_api.py
@@ -240,7 +240,7 @@ class ContentAPIV1TestMixin(object):
         assert_equal(response.accepted_media_type, 'text/html')
         assert_equal(response.content.decode('utf-8'), '''<section class="akn-section" id="section-1" data-id="section-1"><h3>1. </h3>
 <span class="akn-content">
-          <span class="akn-p">tester😀</span><span class="akn-p"></span><span class="akn-p"><img data-src="media/test-image.png" src="media/test-image.png"></span>
+          <span class="akn-p">tester😀</span><span class="akn-p"> </span><span class="akn-p"><img data-src="media/test-image.png" src="media/test-image.png"></span>
         </span></section>
 ''')
 


### PR DESCRIPTION
Partially fixes #612, for subsections (a relatively common case)

For block lists, our AKN should have an empty `<p/>` tag, but doesn't. We don't have any content in NA which matches this case.

![Linter tester @ 2019-10-23 2019-11-18 15-51-14](https://user-images.githubusercontent.com/4178542/69057949-55e9c580-0a1b-11ea-81c2-feb71cb5d2ad.png)
