### PR TITLE
simplify regex, add test

### DIFF
--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -148,7 +148,7 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
             (\d+[A-Z0-9]*(\s*\([A-Z0-9]+\))*)
           )*
         )
-        (\s+of\s+(this\s+Act|the\s+|Act\s+)?)?
+        (\s+of\s+(this)?|\s+thereof)?
         ''',
         re.X | re.IGNORECASE)
 
@@ -167,7 +167,7 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
     def is_valid(self, node, match):
         # check that it's not an external reference
         ref = match.group(0)
-        if ref.endswith('the ') or ref.endswith('Act '):
+        if ref.endswith('of ') or ref.endswith('thereof'):
             return False
         return True
 

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -165,6 +165,8 @@ class SectionRefsFinderTestCase(TestCase):
         <num>7.</num>
         <heading>Active ref heading</heading>
         <content>
+          <p>As given in section 26(1), blah.</p>
+          <p>As given in section 26 (1), blah.</p>
           <p>As given in section 26(1), (2) and (3), blah.</p>
           <p>As given in section 26 (1), (2) and (3), blah.</p>
           <p>As given in sections 26(1), (2) and (3), blah.</p>
@@ -179,6 +181,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
           <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>
           <p>As per Act 9 of 2005, as given in section 26 of that Act, blah.</p>
+          <p>As given in section 26(1)(b)(iii)(dd)(A) of Act 5 of 2002, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -234,6 +237,8 @@ class SectionRefsFinderTestCase(TestCase):
         <num>7.</num>
         <heading>Active ref heading</heading>
         <content>
+          <p>As given in <ref href="#section-26">section 26</ref>(1), blah.</p>
+          <p>As given in <ref href="#section-26">section 26</ref> (1), blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref>(1), (2) and (3), blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref> (1), (2) and (3), blah.</p>
           <p>As given in <ref href="#section-26">sections 26</ref>(1), (2) and (3), blah.</p>
@@ -248,6 +253,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
           <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>
           <p>As per Act 9 of 2005, as given in section 26 of that Act, blah.</p>
+          <p>As given in section 26(1)(b)(iii)(dd)(A) of Act 5 of 2002, blah.</p>
         </content>
       </section>
       <section id="section-26">

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -31,10 +31,6 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26(1)(b)(iii)(dd)(A), blah.</p>
           <p>As given in section 26B, blah.</p>
           <p>As given in section 26 and section 31, blah.</p>
-          <p>As given in sections 26 and 31, blah.</p>
-          <p>As given in sections 26 or 31, blah.</p>
-          <p>As given in sections 26, 30 and 31.</p>
-          <p>As given in sections 26(b), 30 (1) or 31.</p>
           <p>In section 200 it says one thing and in section 26 it says another.</p>
           <p>Two baddies: In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
         </content>
@@ -51,13 +47,6 @@ class SectionRefsFinderTestCase(TestCase):
         <heading>Another important heading</heading>
         <content>
           <p>Another important provision.</p>
-        </content>
-      </section>
-      <section id="section-30">
-        <num>30.</num>
-        <heading>Less important</heading>
-        <content>
-          <p>Meh.</p>
         </content>
       </section>
       <section id="section-31">
@@ -85,10 +74,6 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26">section 26</ref>(1)(b)(iii)(dd)(A), blah.</p>
           <p>As given in <ref href="#section-26B">section 26B</ref>, blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref> and <ref href="#section-31">section 31</ref>, blah.</p>
-          <p>As given in sections <ref href="#section-26">26</ref> and <ref href="#section-31">31</ref>, blah.</p>
-          <p>As given in sections <ref href="#section-26">26</ref> or <ref href="#section-31">31</ref>, blah.</p>
-          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>.</p>
-          <p>As given in sections <ref href="#section-26">26</ref>(b), <ref href="#section-30">30</ref> (1) or <ref href="#section-31">31</ref>.</p>
           <p>In section 200 it says one thing and in <ref href="#section-26">section 26</ref> it says another.</p>
           <p>Two baddies: In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
         </content>
@@ -105,13 +90,6 @@ class SectionRefsFinderTestCase(TestCase):
         <heading>Another important heading</heading>
         <content>
           <p>Another important provision.</p>
-        </content>
-      </section>
-      <section id="section-30">
-        <num>30.</num>
-        <heading>Less important</heading>
-        <content>
-          <p>Meh.</p>
         </content>
       </section>
       <section id="section-31">
@@ -186,6 +164,110 @@ class SectionRefsFinderTestCase(TestCase):
         expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
         self.assertEqual(expected.content, document.content)
 
+    def test_section_multiple(self):
+        document = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in sections 26 and 31, blah.</p>
+          <p>As given in sections 26, 26B, 30 and 31, blah.</p>
+          <p>As given in section 26 or 31, blah.</p>
+          <p>As given in sections 26 or 31, blah.</p>
+          <p>As given in sections 26, 30(1) and 31, blah.</p>
+          <p>As given in sections 26, 30 (1) and 31, blah.</p>
+          <p>As given in sections 26(b), 30(1) or 31, blah.</p>
+          <p>As given in section 26 (b), 30 (1) or 31, blah.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-26B">
+        <num>26B.</num>
+        <heading>Another important heading</heading>
+        <content>
+          <p>Another important provision.</p>
+        </content>
+      </section>
+      <section id="section-30">
+        <num>30.</num>
+        <heading>Less important</heading>
+        <content>
+          <p>Meh.</p>
+        </content>
+      </section>
+      <section id="section-31">
+        <num>31.</num>
+        <heading>More important</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        expected = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in sections <ref href="#section-26">26</ref> and <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-26B">26B</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in section <ref href="#section-26">26</ref> or <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref> or <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref>(1) and <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> (1) and <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>(b), <ref href="#section-30">30</ref>(1) or <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in section <ref href="#section-26">26</ref> (b), <ref href="#section-30"> (1) or <ref href="#section-31">31</ref>, blah.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-26B">
+        <num>26B.</num>
+        <heading>Another important heading</heading>
+        <content>
+          <p>Another important provision.</p>
+        </content>
+      </section>
+      <section id="section-30">
+        <num>30.</num>
+        <heading>Less important</heading>
+        <content>
+          <p>Meh.</p>
+        </content>
+      </section>
+      <section id="section-31">
+        <num>31.</num>
+        <heading>More important</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        self.section_refs_finder.find_references_in_document(document)
+        root = etree.fromstring(expected.content)
+        expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
+        self.assertEqual(expected.content, document.content)
+
     def test_section_edge(self):
         document = Document(
             document_xml=document_fixture(
@@ -225,8 +307,6 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26(2) and (3), blah.</p>
           <p>As given in sections 26 (2) and (3), blah.</p>
           <p>As given in sections 26(2) and (3), blah.</p>
-          <p>As given in sections 26, 30(1) and 31.</p>
-          <p>As given in sections 26, 30 (1) and 31.</p>
           <p>As given in section 26(1)(a) of Proclamation 9 of 1926, blah.</p>
           <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
           <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>
@@ -297,8 +377,6 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26">section 26</ref>(2) and (3), blah.</p>
           <p>As given in <ref href="#section-26">sections 26</ref> (2) and (3), blah.</p>
           <p>As given in <ref href="#section-26">sections 26</ref>(2) and (3), blah.</p>
-          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref>(1) and <ref href="#section-31">31</ref>.</p>
-          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> (1) and <ref href="#section-31">31</ref>.</p>
           <p>As given in section 26(1)(a) of Proclamation 9 of 1926, blah.</p>
           <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
           <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -31,7 +31,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26(1)(b)(iii)(dd)(A), blah.</p>
           <p>As given in section 26B, blah.</p>
           <p>As given in section 26 and section 31, blah.</p>
-          <p>In section 200 it says one thing and in section 26 it says another.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -73,7 +73,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26">section 26</ref>(1)(b)(iii)(dd)(A), blah.</p>
           <p>As given in <ref href="#section-26B">section 26B</ref>, blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref> and <ref href="#section-31">section 31</ref>, blah.</p>
-          <p>In section 200 it says one thing and in <ref href="#section-26">section 26</ref> it says another.</p>
+          <p>As <i>given</i> in (we're now in a tail) <ref href="#section-26">section 26</ref>, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -119,6 +119,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26 (1) of this Proclamation, blah.</p>
           <p>As given in section 26(1)(b)(iii)(dd)(A) of this Act, blah.</p>
           <p>In section 26 of Act 5 of 2012 it says one thing and in section 26 of this Act it says another.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26 of this Act, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -144,6 +145,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26">section 26</ref> (1) of this Proclamation, blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref>(1)(b)(iii)(dd)(A) of this Act, blah.</p>
           <p>In section 26 of Act 5 of 2012 it says one thing and in <ref href="#section-26">section 26</ref> of this Act it says another.</p>
+          <p>As <i>given</i> in (we're now in a tail) <ref href="#section-26">section 26</ref> of this Act, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -178,6 +180,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in sections 26, 30 (1) and 31, blah.</p>
           <p>As given in sections 26(b), 30(1) or 31, blah.</p>
           <p>As given in section 26 (b), 30 (1) or 31, blah.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26, 30 and 31.</p>
         </content>
       </section>
       <section id="section-26">
@@ -227,6 +230,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> (1) and <ref href="#section-31">31</ref>, blah.</p>
           <p>As given in sections <ref href="#section-26">26</ref>(b), <ref href="#section-30">30</ref>(1) or <ref href="#section-31">31</ref>, blah.</p>
           <p>As given in section <ref href="#section-26">26</ref> (b), <ref href="#section-30">30</ref> (1) or <ref href="#section-31">31</ref>, blah.</p>
+          <p>As <i>given</i> in (we're now in a tail) section <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>.</p>
         </content>
       </section>
       <section id="section-26">
@@ -310,6 +314,62 @@ class SectionRefsFinderTestCase(TestCase):
         expected_content = document.content
         self.section_refs_finder.find_references_in_document(document)
         root = etree.fromstring(expected_content)
+        expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
+        self.assertEqual(expected_content, document.content)
+
+    def test_section_valid_and_invalid(self):
+        document = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in sections 26 and 35, one of which isn't in this document, blah.</p>
+          <p>As given in sections 35 and 26, one of which isn't in this document, blah.</p>
+          <p>In section 200 it says one thing and in section 26 it says another.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 200, blah, but section 26 says something else.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah, but section 26 of this Act says something else.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>The section we want</heading>
+        <content>
+          <p>The provision you're looking for.</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        expected = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in sections <ref href="#section-26">26</ref> and 35, one of which isn't in this document, blah.</p>
+          <p>As given in sections 35 and <ref href="#section-26">26</ref>, one of which isn't in this document, blah.</p>
+          <p>In section 200 it says one thing and in <ref href="#section-26">section 26</ref> it says another.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 200, blah, but <ref href="#section-26">section 26</ref> says something else.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah, but <ref href="#section-26">section 26</ref> of this Act says something else.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>The section we want</heading>
+        <content>
+          <p>The provision you're looking for.</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        self.section_refs_finder.find_references_in_document(document)
+        root = etree.fromstring(expected.content)
         expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
         self.assertEqual(expected_content, document.content)
 
@@ -448,137 +508,3 @@ class SectionRefsFinderTestCase(TestCase):
         root = etree.fromstring(expected.content)
         expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
         self.assertEqual(expected.content, document.content)
-
-    def test_section_basic_in_tail(self):
-        document = Document(
-            document_xml=document_fixture(
-                xml="""
-      <section id="section-7">
-        <num>7.</num>
-        <heading>Active ref heading</heading>
-        <content>
-          <p>As <i>given</i> in (we're now in a tail) section 26, blah.</p>
-          <p>As <i>given</i> in (we're now in a tail) section 26 of this Act, blah.</p>
-          <p>As <i>given</i> in (we're now in a tail) section 200, blah, but section 26 says something else.</p>
-          <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah, but section 26 of this Act says something else.</p>
-          <p>As <i>given</i> in (we're now in a tail) section 26, 30 and 31.</p>
-        </content>
-      </section>
-      <section id="section-26">
-        <num>26.</num>
-        <heading>Important heading</heading>
-        <content>
-          <p>An important provision.</p>
-        </content>
-      </section>
-      <section id="section-30">
-        <num>30.</num>
-        <heading>Important heading</heading>
-        <content>
-          <p>An important provision.</p>
-        </content>
-      </section>
-      <section id="section-31">
-        <num>31.</num>
-        <heading>Important heading</heading>
-        <content>
-          <p>An important provision.</p>
-        </content>
-      </section>
-        """
-            ),
-            language=self.eng)
-
-        expected = Document(
-            document_xml=document_fixture(
-                xml="""
-      <section id="section-7">
-        <num>7.</num>
-        <heading>Active ref heading</heading>
-        <content>
-          <p>As <i>given</i> in (we're now in a tail) <ref href="#section-26">section 26</ref>, blah.</p>
-          <p>As <i>given</i> in (we're now in a tail) <ref href="#section-26">section 26</ref> of this Act, blah.</p>
-          <p>As <i>given</i> in (we're now in a tail) section 200, blah, but <ref href="#section-26">section 26</ref> says something else.</p>
-          <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah, but <ref href="#section-26">section 26</ref> of this Act says something else.</p>
-          <p>As <i>given</i> in (we're now in a tail) section <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>.</p>
-        </content>
-      </section>
-      <section id="section-26">
-        <num>26.</num>
-        <heading>Important heading</heading>
-        <content>
-          <p>An important provision.</p>
-        </content>
-      </section>
-      <section id="section-30">
-        <num>30.</num>
-        <heading>Important heading</heading>
-        <content>
-          <p>An important provision.</p>
-        </content>
-      </section>
-      <section id="section-31">
-        <num>31.</num>
-        <heading>Important heading</heading>
-        <content>
-          <p>An important provision.</p>
-        </content>
-      </section>
-        """
-            ),
-            language=self.eng)
-
-        self.section_refs_finder.find_references_in_document(document)
-        root = etree.fromstring(expected.content)
-        expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(expected.content, document.content)
-
-    def test_section_notfound(self):
-        document = Document(
-            document_xml=document_fixture(
-                xml="""
-      <section id="section-7">
-        <num>7.</num>
-        <heading>Active ref heading</heading>
-        <content>
-          <p>As given in sections 26 and 35, one of which isn't in this document, blah.</p>
-          <p>As given in sections 35 and 26, one of which isn't in this document, blah.</p>
-        </content>
-      </section>
-      <section id="section-35">
-        <num>35.</num>
-        <heading>Not the section we want</heading>
-        <content>
-          <p>Not the provision you're looking for.</p>
-        </content>
-      </section>
-        """
-            ),
-            language=self.eng)
-
-        expected = Document(
-            document_xml=document_fixture(
-                xml="""
-      <section id="section-7">
-        <num>7.</num>
-        <heading>Active ref heading</heading>
-        <content>
-          <p>As given in sections 26 and <ref href="#section-35">35</ref>, one of which isn't in this document, blah.</p>
-          <p>As given in sections <ref href="#section-35">35</ref> and 26, one of which isn't in this document, blah.</p>
-        </content>
-      </section>
-      <section id="section-35">
-        <num>35.</num>
-        <heading>Not the section we want</heading>
-        <content>
-          <p>Not the provision you're looking for.</p>
-        </content>
-      </section>
-        """
-            ),
-            language=self.eng)
-
-        self.section_refs_finder.find_references_in_document(document)
-        root = etree.fromstring(expected.content)
-        expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(expected_content, document.content)

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -136,6 +136,150 @@ class SectionRefsFinderTestCase(TestCase):
         expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
         self.assertEqual(expected.content, document.content)
 
+    def test_section_edge(self):
+        document = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-1">
+        <num>1.</num>
+        <heading>Unimportant heading</heading>
+        <content>
+          <p>An unimportant provision.</p>
+        </content>
+      </section>
+      <section id="section-2">
+        <num>2.</num>
+        <heading>Unimportant heading</heading>
+        <content>
+          <p>An unimportant provision.</p>
+        </content>
+      </section>
+      <section id="section-3">
+        <num>3.</num>
+        <heading>Unimportant heading</heading>
+        <content>
+          <p>An unimportant provision.</p>
+        </content>
+      </section>
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in section 26(1), (2) and (3), blah.</p>
+          <p>As given in section 26 (1), (2) and (3), blah.</p>
+          <p>As given in sections 26(1), (2) and (3), blah.</p>
+          <p>As given in sections 26 (1), (2) and (3), blah.</p>
+          <p>As given in section 26 (2) and (3), blah.</p>
+          <p>As given in section 26(2) and (3), blah.</p>
+          <p>As given in sections 26 (2) and (3), blah.</p>
+          <p>As given in sections 26(2) and (3), blah.</p>
+          <p>As given in sections 26, 30(1) and 31.</p>
+          <p>As given in sections 26, 30 (1) and 31.</p>
+          <p>As given in section 26(1)(a) of Proclamation 9 of 1926, blah.</p>
+          <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
+          <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>
+          <p>As per Act 9 of 2005, as given in section 26 of that Act, blah.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-30">
+        <num>30.</num>
+        <heading>Less important</heading>
+        <content>
+          <p>Meh.</p>
+        </content>
+      </section>
+      <section id="section-31">
+        <num>31.</num>
+        <heading>More important</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        expected = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-1">
+        <num>1.</num>
+        <heading>Unimportant heading</heading>
+        <content>
+          <p>An unimportant provision.</p>
+        </content>
+      </section>
+      <section id="section-2">
+        <num>2.</num>
+        <heading>Unimportant heading</heading>
+        <content>
+          <p>An unimportant provision.</p>
+        </content>
+      </section>
+      <section id="section-3">
+        <num>3.</num>
+        <heading>Unimportant heading</heading>
+        <content>
+          <p>An unimportant provision.</p>
+        </content>
+      </section>
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in <ref href="#section-26">section 26</ref>(1), (2) and (3), blah.</p>
+          <p>As given in <ref href="#section-26">section 26</ref> (1), (2) and (3), blah.</p>
+          <p>As given in <ref href="#section-26">sections 26</ref>(1), (2) and (3), blah.</p>
+          <p>As given in <ref href="#section-26">sections 26</ref> (1), (2) and (3), blah.</p>
+          <p>As given in <ref href="#section-26">section 26</ref> (2) and (3), blah.</p>
+          <p>As given in <ref href="#section-26">section 26</ref>(2) and (3), blah.</p>
+          <p>As given in <ref href="#section-26">sections 26</ref> (2) and (3), blah.</p>
+          <p>As given in <ref href="#section-26">sections 26</ref>(2) and (3), blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref>(1) and <ref href="#section-31">31</ref>.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> (1) and <ref href="#section-31">31</ref>.</p>
+          <p>As given in section 26(1)(a) of Proclamation 9 of 1926, blah.</p>
+          <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
+          <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>
+          <p>As per Act 9 of 2005, as given in section 26 of that Act, blah.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-30">
+        <num>30.</num>
+        <heading>Less important</heading>
+        <content>
+          <p>Meh.</p>
+        </content>
+      </section>
+      <section id="section-31">
+        <num>31.</num>
+        <heading>More important</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        self.section_refs_finder.find_references_in_document(document)
+        root = etree.fromstring(expected.content)
+        expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
+        self.assertEqual(expected.content, document.content)
+
     def test_section_basic_in_tail(self):
         document = Document(
             document_xml=document_fixture(

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -35,10 +35,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in sections 26 or 31, blah.</p>
           <p>As given in sections 26, 30 and 31.</p>
           <p>As given in sections 26(b), 30 (1) or 31.</p>
-          <p>As given in section 26 of this Act, blah.</p>
-          <p>As given in section 26 (1) of this Act, blah.</p>
           <p>In section 200 it says one thing and in section 26 it says another.</p>
-          <p>In section 26 of Act 5 of 2012 it says one thing and in section 26 of this Act it says another.</p>
           <p>Two baddies: In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
         </content>
       </section>
@@ -92,10 +89,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in sections <ref href="#section-26">26</ref> or <ref href="#section-31">31</ref>, blah.</p>
           <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>.</p>
           <p>As given in sections <ref href="#section-26">26</ref>(b), <ref href="#section-30">30</ref> (1) or <ref href="#section-31">31</ref>.</p>
-          <p>As given in <ref href="#section-26">section 26</ref> of this Act, blah.</p>
-          <p>As given in <ref href="#section-26">section 26</ref> (1) of this Act, blah.</p>
           <p>In section 200 it says one thing and in <ref href="#section-26">section 26</ref> it says another.</p>
-          <p>In section 26 of Act 5 of 2012 it says one thing and in <ref href="#section-26">section 26</ref> of this Act it says another.</p>
           <p>Two baddies: In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
         </content>
       </section>
@@ -125,6 +119,62 @@ class SectionRefsFinderTestCase(TestCase):
         <heading>More important</heading>
         <content>
           <p>Hi!</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        self.section_refs_finder.find_references_in_document(document)
+        root = etree.fromstring(expected.content)
+        expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
+        self.assertEqual(expected.content, document.content)
+
+    def test_section_of_this(self):
+        document = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in section 26 of this Act, blah.</p>
+          <p>As given in section 26 (1) of this Act, blah.</p>
+          <p>As given in section 26 (1) of this Proclamation, blah.</p>
+          <p>As given in section 26(1)(b)(iii)(dd)(A) of this Act, blah.</p>
+          <p>In section 26 of Act 5 of 2012 it says one thing and in section 26 of this Act it says another.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        expected = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in <ref href="#section-26">section 26</ref> of this Act, blah.</p>
+          <p>As given in <ref href="#section-26">section 26</ref> (1) of this Act, blah.</p>
+          <p>As given in <ref href="#section-26">section 26</ref> (1) of this Proclamation, blah.</p>
+          <p>As given in <ref href="#section-26">section 26</ref>(1)(b)(iii)(dd)(A) of this Act, blah.</p>
+          <p>In section 26 of Act 5 of 2012 it says one thing and in <ref href="#section-26">section 26</ref> of this Act it says another.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
         </content>
       </section>
         """

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -32,7 +32,6 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26B, blah.</p>
           <p>As given in section 26 and section 31, blah.</p>
           <p>In section 200 it says one thing and in section 26 it says another.</p>
-          <p>Two baddies: In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
         </content>
       </section>
       <section id="section-26">
@@ -75,7 +74,6 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26B">section 26B</ref>, blah.</p>
           <p>As given in <ref href="#section-26">section 26</ref> and <ref href="#section-31">section 31</ref>, blah.</p>
           <p>In section 200 it says one thing and in <ref href="#section-26">section 26</ref> it says another.</p>
-          <p>Two baddies: In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
         </content>
       </section>
       <section id="section-26">
@@ -268,6 +266,53 @@ class SectionRefsFinderTestCase(TestCase):
         expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
         self.assertEqual(expected.content, document.content)
 
+    def test_section_invalid(self):
+        document = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>As given in section 25, which isn't in this document, blah.</p>
+          <p>In section 200 it says one thing and in section 26 of Act 5 of 2012 it says another.</p>
+          <p>As given in section 26(1)(a) of Proclamation 9 of 1926, blah.</p>
+          <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
+          <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>
+          <p>As per Act 9 of 2005, as given in section 26 of that Act, blah.</p>
+          <p>As given in section 26(1)(b)(iii)(dd)(A) of Act 5 of 2002, blah.</p>
+          <p>As given in section 26 of Act 5 of 2012, blah.</p>
+          <p>As given in section 26 of the Nursing Act, blah.</p>
+          <p>As given in section 26(b) of the Nursing Act, blah.</p>
+          <p>As given in section 26(b)(iii) of the Nursing Act, blah.</p>
+          <p>As given in section 26 (b) (iii) of the Nursing Act, blah.</p>
+          <p>As given in section 26(b)(iii)(bb) of the Nursing Act, blah.</p>
+          <p>As given in section 26(b)(iii)(aa)(A) of the Nursing Act, blah.</p>
+          <p>As given in section 26, 27 or 28(b) of the Nursing Act, blah.</p>
+          <p>As given in section 26 or 27 of the Nursing Act, blah.</p>
+          <p>As given in section 26(b)(iii)(1) of the Nursing Act, blah.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah.</p>
+          <p>As <i>given</i> in (we're now in a tail) section 26 of the Nursing Act, blah.</p>
+          <p>As <i>given</i> in (we're now in a tail) sections 26, 27 and 28 of the Nursing Act, blah.</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        expected_content = document.content
+        self.section_refs_finder.find_references_in_document(document)
+        root = etree.fromstring(expected_content)
+        expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
+        self.assertEqual(expected_content, document.content)
+
     def test_section_edge(self):
         document = Document(
             document_xml=document_fixture(
@@ -307,11 +352,6 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26(2) and (3), blah.</p>
           <p>As given in sections 26 (2) and (3), blah.</p>
           <p>As given in sections 26(2) and (3), blah.</p>
-          <p>As given in section 26(1)(a) of Proclamation 9 of 1926, blah.</p>
-          <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
-          <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>
-          <p>As per Act 9 of 2005, as given in section 26 of that Act, blah.</p>
-          <p>As given in section 26(1)(b)(iii)(dd)(A) of Act 5 of 2002, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -377,11 +417,6 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26">section 26</ref>(2) and (3), blah.</p>
           <p>As given in <ref href="#section-26">sections 26</ref> (2) and (3), blah.</p>
           <p>As given in <ref href="#section-26">sections 26</ref>(2) and (3), blah.</p>
-          <p>As given in section 26(1)(a) of Proclamation 9 of 1926, blah.</p>
-          <p>As per Proclamation 9 of 1926, as given in section 26 thereof, blah.</p>
-          <p>As per Proclamation 9 of 1926, as given in section 26 of that Proclamation, blah.</p>
-          <p>As per Act 9 of 2005, as given in section 26 of that Act, blah.</p>
-          <p>As given in section 26(1)(b)(iii)(dd)(A) of Act 5 of 2002, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -506,7 +541,6 @@ class SectionRefsFinderTestCase(TestCase):
         <num>7.</num>
         <heading>Active ref heading</heading>
         <content>
-          <p>As given in section 26, which isn't in this document, blah.</p>
           <p>As given in sections 26 and 35, one of which isn't in this document, blah.</p>
           <p>As given in sections 35 and 26, one of which isn't in this document, blah.</p>
         </content>
@@ -529,7 +563,6 @@ class SectionRefsFinderTestCase(TestCase):
         <num>7.</num>
         <heading>Active ref heading</heading>
         <content>
-          <p>As given in section 26, which isn't in this document, blah.</p>
           <p>As given in sections 26 and <ref href="#section-35">35</ref>, one of which isn't in this document, blah.</p>
           <p>As given in sections <ref href="#section-35">35</ref> and 26, one of which isn't in this document, blah.</p>
         </content>
@@ -547,72 +580,5 @@ class SectionRefsFinderTestCase(TestCase):
 
         self.section_refs_finder.find_references_in_document(document)
         root = etree.fromstring(expected.content)
-        expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(expected_content, document.content)
-
-    def test_section_external(self):
-        document = Document(
-            document_xml=document_fixture(
-                xml="""
-      <section id="section-7">
-        <num>7.</num>
-        <heading>Active ref heading</heading>
-        <content>
-          <p>As given in section 26 of Act 5 of 2012, blah.</p>
-          <p>As given in section 26 of the Nursing Act, blah.</p>
-          <p>As given in section 26(b) of the Nursing Act, blah.</p>
-          <p>As given in section 26(b)(iii) of the Nursing Act, blah.</p>
-          <p>As given in section 26 (b) (iii) of the Nursing Act, blah.</p>
-          <p>As given in section 26(b)(iii)(bb) of the Nursing Act, blah.</p>
-          <p>As given in section 26(b)(iii)(aa)(A) of the Nursing Act, blah.</p>
-          <p>As given in section 26, 27 or 28(b) of the Nursing Act, blah.</p>
-          <p>As given in section 26 or 27 of the Nursing Act, blah.</p>
-          <p>As given in the unusual reference of section 26(b)(iii)(1) of the Nursing Act, blah.</p>
-        </content>
-      </section>
-      <section id="section-26">
-        <num>26.</num>
-        <heading>Passive ref heading</heading>
-        <content>
-          <p>An important provision, but not the one referred to above.</p>
-        </content>
-      </section>
-        """
-            ),
-            language=self.eng)
-
-        expected_content = document.content
-        self.section_refs_finder.find_references_in_document(document)
-        root = etree.fromstring(expected_content)
-        expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(expected_content, document.content)
-
-    def test_section_external_in_tail(self):
-        document = Document(
-            document_xml=document_fixture(
-                xml="""
-      <section id="section-7">
-        <num>7.</num>
-        <heading>Active ref heading</heading>
-        <content>
-          <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah.</p>
-          <p>As <i>given</i> in (we're now in a tail) section 26 of the Nursing Act, blah.</p>
-          <p>As <i>given</i> in (we're now in a tail) section 26, 27 and 28 of the Nursing Act, blah.</p>
-        </content>
-      </section>
-      <section id="section-26">
-        <num>26.</num>
-        <heading>Passive ref heading</heading>
-        <content>
-          <p>An important provision, but not the one referred to above.</p>
-        </content>
-      </section>
-        """
-            ),
-            language=self.eng)
-
-        expected_content = document.content
-        self.section_refs_finder.find_references_in_document(document)
-        root = etree.fromstring(expected_content)
         expected_content = etree.tostring(root, encoding='utf-8').decode('utf-8')
         self.assertEqual(expected_content, document.content)

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -226,7 +226,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref>(1) and <ref href="#section-31">31</ref>, blah.</p>
           <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> (1) and <ref href="#section-31">31</ref>, blah.</p>
           <p>As given in sections <ref href="#section-26">26</ref>(b), <ref href="#section-30">30</ref>(1) or <ref href="#section-31">31</ref>, blah.</p>
-          <p>As given in section <ref href="#section-26">26</ref> (b), <ref href="#section-30"> (1) or <ref href="#section-31">31</ref>, blah.</p>
+          <p>As given in section <ref href="#section-26">26</ref> (b), <ref href="#section-30">30</ref> (1) or <ref href="#section-31">31</ref>, blah.</p>
         </content>
       </section>
       <section id="section-26">


### PR DESCRIPTION
closes #837 

regex simplified so that only `of this` is recognised as internal – `of` anything else (`of the`, `of that`, `of Act / Proc / Ord`, etc) will be assumed to be external, as will `thereof`. if there's no `of` or `thereof` it will also be assumed to be internal.
