### PR TITLE
Support bold and italics in tables

### DIFF
--- a/indigo_app/static/javascript/indigo/views/table_editor.js
+++ b/indigo_app/static/javascript/indigo/views/table_editor.js
@@ -39,6 +39,18 @@
       // make TH and TD editable
       CKEDITOR.dtd.$editable.th = 1;
       CKEDITOR.dtd.$editable.td = 1;
+      this.ckeditorConfig = {
+        enterMode: CKEDITOR.ENTER_BR,
+        shiftEnterMode: CKEDITOR.ENTER_BR,
+        toolbar: [],
+        // this must align with the elements and attributes supported by
+        // indigo_app/static/xsl/html_to_akn.xsl
+        allowedContent: 'a[!data-href,!href]; img[!src,!data-src]; span(akn-remark); span(akn-p);' +
+                        'b; i; p;' +
+                        'table[id, data-id]; thead; tbody; tr;' +
+                        'th(akn--text-center,akn--text-right){width}[colspan,rowspan];' +
+                        'td(akn--text-center,akn--text-right){width}[colspan,rowspan];',
+      };
 
       // setup transforms
       var htmlTransform = new XSLTProcessor();
@@ -138,18 +150,8 @@
           self.manageTableWidth(self.table);
         });
 
-        this.ckeditor = CKEDITOR.inline(editable, {
-          enterMode: CKEDITOR.ENTER_BR,
-          shiftEnterMode: CKEDITOR.ENTER_BR,
-          toolbar: [],
-          allowedContent: 'a[!data-href,!href]; img[!src,!data-src]; span(akn-remark); span(akn-p); p; ' +
-                          'table[id, data-id]; thead; tbody; tr;' +
-                          'th(akn--text-center,akn--text-right){width}[colspan,rowspan]; ' +
-                          'td(akn--text-center,akn--text-right){width}[colspan,rowspan];',
-          on: {
-            selectionChange: _.bind(this.selectionChanged, this),
-          },
-        });
+        this.ckeditor = CKEDITOR.inline(editable, this.ckeditorConfig);
+        this.ckeditor.on('selectionChange', _.bind(this.selectionChanged, this));
 
         this.editing = true;
         this.trigger('start');

--- a/indigo_app/static/xsl/html_to_akn.xsl
+++ b/indigo_app/static/xsl/html_to_akn.xsl
@@ -54,6 +54,12 @@
     <eol/>
   </xsl:template>
 
+  <xsl:template match="html:b | html:i">
+    <xsl:element name="{name(.)}">
+      <xsl:apply-templates />
+    </xsl:element>
+  </xsl:template>
+
   <xsl:template match="html:a">
     <ref>
       <xsl:attribute name="href"><xsl:value-of select="@data-href" /></xsl:attribute>


### PR DESCRIPTION
Turns out we weren't support them at all previously.

![Tables tester @ 1980-01-01 2019-12-03 19-02-35](https://user-images.githubusercontent.com/4178542/70072343-790d9b00-15ff-11ea-9502-d3c69370b8df.png)
