### PR TITLE
Overview page links

### DIFF
--- a/indigo_app/templates/indigo_api/_work_filter_form.html
+++ b/indigo_app/templates/indigo_api/_work_filter_form.html
@@ -67,23 +67,28 @@
           {% endfor %}
         </select>
       </div>
-
-      <!-- Work Taxonomy filter -->
-      <div class="col-md-6">
-        {% regroup form.fields.taxonomies.queryset by vocabulary as topic_groups %}
-        {% if topic_groups %}
-          <select name="taxonomies" class="selectpicker notooltip" title="Taxonomies..." data-width="auto" data-live-search="true" multiple data-selected-text-format="count > 1" data-style="btn-outline-secondary">
-            {% for topic in topic_groups %}
-              <optgroup label="{{ topic.grouper }}">
-                {% for taxonomy in topic.list %}
-                  <option {% if taxonomy.pk|stringformat:"i" in form.taxonomies.value %} selected {% endif %} value="{{ taxonomy.pk }}">{{ taxonomy }}</option>
-                {% endfor %}
-              </optgroup>
-            {% endfor %}
-          </select>
-        {% endif %}
-      </div>
     </div>
+
+    <!-- Work Taxonomy filter -->
+    {% regroup form.fields.taxonomies.queryset by vocabulary as topic_groups %}
+    {% if topic_groups %}
+      <div class="form-group mt-2">
+        <label>Taxonomies</label>
+        <div class="form-row">
+          <div class="col-md-6">
+            <select name="taxonomies" class="selectpicker notooltip" title="Taxonomies..." data-width="100%" data-live-search="true" multiple data-selected-text-format="count > 1" data-style="btn-outline-secondary">
+              {% for topic in topic_groups %}
+                <optgroup label="{{ topic.grouper }}">
+                  {% for taxonomy in topic.list %}
+                    <option {% if taxonomy.pk|stringformat:"i" in form.taxonomies.value %} selected {% endif %} value="{{ taxonomy.pk }}">{{ taxonomy }}</option>
+                  {% endfor %}
+                </optgroup>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+      </div>
+    {% endif %}
 
     <div class="row mt-2">
       <!-- Assent Date filter -->

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -15,17 +15,17 @@
         </div>
         <div class="card-body">
           {% for item in subtypes %}
-            {% if item.1 %}          
+            {% if item.2 %}          
               <div class="row mb-2">
                 <div class="col-4">
                   <span>{{ item.0 }}</span>
                 </div>
                 <div class="col-6">
                   <div class="progress" style="border-radius: 3px; height: 20px;">
-                    <div class="progress-bar bg-success" role="progressbar" style="width: {{ item.2 }}%" aria-valuenow="{{ item.2 }}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar bg-success" role="progressbar" style="width: {{ item.3 }}%" aria-valuenow="{{ item.3 }}" aria-valuemin="0" aria-valuemax="100"></div>
                   </div> 
                 </div>
-                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?subtype={{ forloop.counter }}">{{ item.1}}</a></div> 
+                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?subtype={{ item.1 }}">{{ item.2 }}</a></div> 
               </div>                             
             {% endif %}
           {% endfor %}

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -25,7 +25,7 @@
                     <div class="progress-bar bg-success" role="progressbar" style="width: {{ perc }}%"></div>
                   </div> 
                 </div>
-                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?subtype={{ subtype.abbreviation|default:'acts_only' }}">{{ count }}</a></div>
+                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?stub=all&subtype={{ subtype.abbreviation|default:'acts_only' }}">{{ count }}</a></div>
               </div>                             
             {% endif %}
           {% endfor %}

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -11,21 +11,21 @@
       <div class="card mt-4">
         <div class="card-header">
           <a class="float-right" href="{% url 'place_works' place=place.place_code %}">Works →</a>
-          <h5 class="mb-0">Types of works</h5>
+          <h5 class="mb-0">Works ({{ total_works }})</h5>
         </div>
         <div class="card-body">
-          {% for item in subtypes %}
-            {% if item.2 %}          
+          {% for subtype, count, perc in subtypes %}
+            {% if count %}
               <div class="row mb-2">
                 <div class="col-4">
-                  <span>{{ item.0 }}</span>
+                  <span>{{ subtype.name|default:'Act' }}</span>
                 </div>
                 <div class="col-6">
                   <div class="progress" style="border-radius: 3px; height: 20px;">
-                    <div class="progress-bar bg-success" role="progressbar" style="width: {{ item.3 }}%" aria-valuenow="{{ item.3 }}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar bg-success" role="progressbar" style="width: {{ perc }}%"></div>
                   </div> 
                 </div>
-                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?subtype={{ item.1 }}">{{ item.2 }}</a></div> 
+                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?subtype={{ subtype.pk }}">{{ count }}</a></div>
               </div>                             
             {% endif %}
           {% endfor %}

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -49,7 +49,7 @@
 
           <div class="row">
             <div class="col-4">
-              <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=primary">Primary ({{ primary_works_count }})</a>
+              <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=primary&stub=all">Primary ({{ primary_works_count }})</a>
             </div>
             <div class="col-5">
               <div class="progress" style="border-radius: 3px; height: 20px;">

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -104,11 +104,7 @@
               <div class="row mb-2">
                 <div class="col-4">
                   <i class="fas fa-sm fa-fw task-icon-{{ item.state }}"></i> 
-                  {% if item.state == 'open' %}
-                    <a class="text-dark" href="{% url 'tasks' place=place.place_code %}"">{{ item.state_string }}</a>
-                  {% else %}
                     <a class="text-dark" href="{% url 'tasks' place=place.place_code %}?state={{ item.state }}&format=columns">{{ item.state_string }}</a>
-                  {% endif %}
                 </div>
                 <div class="col-6">
                   <div class="progress" style="border-radius: 3px; height: 20px;">

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -17,7 +17,9 @@
           {% for item in subtypes %}
             {% if item.1 %}          
               <div class="row mb-2">
-                <div class="col-4">{{ item.0 }}</div>
+                <div class="col-4">
+                  <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?subtype={{ forloop.counter }}">{{ item.0 }}</a>
+                </div>
                 <div class="col-6">
                   <div class="progress" style="border-radius: 3px; height: 20px;">
                     <div class="progress-bar bg-success" role="progressbar" style="width: {{ item.2 }}%" aria-valuenow="{{ item.2 }}" aria-valuemin="0" aria-valuemax="100"></div>
@@ -31,25 +33,33 @@
           <hr>
 
           <div class="row mb-2">
-            <div class="col-4"> Principal works ({{ non_stubs_count }}) </div>
+            <div class="col-4">
+              <a class="text-dark" href="{% url 'place_works' place=place.place_code %}">Principal works ({{ non_stubs_count }})</a>
+            </div>
             <div class="col-5">
               <div class="progress" style="border-radius: 3px; height: 20px;">
                 <div class="progress-bar bg-success" role="progressbar" style="width: {{ non_stubs_percentage }}%" aria-valuenow="{{ non_stubs_percentage }}" aria-valuemin="0" aria-valuemax="100"></div>
                 <div class="progress-bar" role="progressbar" style="width: {{ stubs_percentage }}%" aria-valuenow="{{ stubs_percentage }}" aria-valuemin="0" aria-valuemax="100"></div>
               </div> 
             </div>
-            <div class="col-3"> Stubs ({{ stubs_count }}) </div>
+            <div class="col-3">
+              <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?stub=only">Stubs ({{ stubs_count }})</a>
+            </div>
           </div>
 
           <div class="row">
-            <div class="col-4"> Primary ({{ primary_works_count }}) </div>
+            <div class="col-4">
+              <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=primary">Primary ({{ primary_works_count }})</a>
+            </div>
             <div class="col-5">
               <div class="progress" style="border-radius: 3px; height: 20px;">
                 <div class="progress-bar bg-success" role="progressbar" style="width: {{ primary_works_percentage }}%" aria-valuenow="{{ primary_works_percentage }}" aria-valuemin="0" aria-valuemax="100"></div>
                 <div class="progress-bar" role="progressbar" style="width: {{ subsidiary_works_percentage }}%" aria-valuenow="{{ subsidiary_works_percentage }}" aria-valuemin="0" aria-valuemax="100"></div>
               </div> 
             </div>
-            <div class="col-3"> Subsidiary ({{ subsidiary_works_count }}) </div>
+            <div class="col-3">
+                <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=subsidiary">Subsidiary ({{ subsidiary_works_count }})</a>
+            </div>
           </div>
         </div>
       </div>
@@ -93,7 +103,12 @@
             {% if item.count %}
               <div class="row mb-2">
                 <div class="col-4">
-                  <i class="fas fa-sm fa-fw task-icon-{{ item.state }}"></i> {{ item.state_string }}
+                  <i class="fas fa-sm fa-fw task-icon-{{ item.state }}"></i> 
+                  {% if item.state == 'open' %}
+                    <a class="text-dark" href="{% url 'tasks' place=place.place_code %}"">{{ item.state_string }}</a>
+                  {% else %}
+                    <a class="text-dark" href="{% url 'tasks' place=place.place_code %}?state={{ item.state }}&format=columns">{{ item.state_string }}</a>
+                  {% endif %}
                 </div>
                 <div class="col-6">
                   <div class="progress" style="border-radius: 3px; height: 20px;">
@@ -113,7 +128,9 @@
             {% for item in open_tasks_by_label %}
               {% if item.count %}
                 <div class="row mb-2">
-                  <div class="col-4"><span class="badge badge-secondary">{{ item.title }}</span></div>
+                  <div class="col-4">
+                    <a class="badge badge-secondary" href="{% url 'tasks' place=place.place_code %}?state=open&state=assigned&state=pending_review&format=columns&labels={{ item.slug }}">{{ item.title }}</a>
+                  </div>
                   <div class="col-6">
                     <div class="progress" style="border-radius: 3px; height: 20px;">
                       <div class="progress-bar bg-success" role="progressbar" style="width: {{ item.percentage }}%"></div>

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -18,14 +18,14 @@
             {% if item.1 %}          
               <div class="row mb-2">
                 <div class="col-4">
-                  <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?subtype={{ forloop.counter }}">{{ item.0 }}</a>
+                  <span>{{ item.0 }}</span>
                 </div>
                 <div class="col-6">
                   <div class="progress" style="border-radius: 3px; height: 20px;">
                     <div class="progress-bar bg-success" role="progressbar" style="width: {{ item.2 }}%" aria-valuenow="{{ item.2 }}" aria-valuemin="0" aria-valuemax="100"></div>
                   </div> 
                 </div>
-                <div class="col-2">{{ item.1}}</div> 
+                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?subtype={{ forloop.counter }}">{{ item.1}}</a></div> 
               </div>                             
             {% endif %}
           {% endfor %}
@@ -34,7 +34,7 @@
 
           <div class="row mb-2">
             <div class="col-4">
-              <a class="text-dark" href="{% url 'place_works' place=place.place_code %}">Principal works ({{ non_stubs_count }})</a>
+              <span class="text-dark">Principal works (<a href="{% url 'place_works' place=place.place_code %}">{{ non_stubs_count }}</a>)</span>
             </div>
             <div class="col-5">
               <div class="progress" style="border-radius: 3px; height: 20px;">
@@ -43,13 +43,13 @@
               </div> 
             </div>
             <div class="col-3">
-              <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?stub=only">Stubs ({{ stubs_count }})</a>
+              <span class="text-dark">Stubs (<a href="{% url 'place_works' place=place.place_code %}?stub=only">{{ stubs_count }}</a>)</span>
             </div>
           </div>
 
           <div class="row">
             <div class="col-4">
-              <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=primary&stub=all">Primary ({{ primary_works_count }})</a>
+              <span class="text-dark">Primary (<a href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=primary&stub=all">{{ primary_works_count }}</a>)</span>
             </div>
             <div class="col-5">
               <div class="progress" style="border-radius: 3px; height: 20px;">
@@ -58,7 +58,7 @@
               </div> 
             </div>
             <div class="col-3">
-                <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=subsidiary&stub=all">Subsidiary ({{ subsidiary_works_count }})</a>
+                <span class="text-dark">Subsidiary (<a href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=subsidiary&stub=all">{{ subsidiary_works_count }}</a>)</span>
             </div>
           </div>
         </div>
@@ -104,7 +104,7 @@
               <div class="row mb-2">
                 <div class="col-4">
                   <i class="fas fa-sm fa-fw task-icon-{{ item.state }}"></i> 
-                    <a class="text-dark" href="{% url 'tasks' place=place.place_code %}?state={{ item.state }}&format=columns">{{ item.state_string }}</a>
+                    <span>{{ item.state_string }}</span>
                 </div>
                 <div class="col-6">
                   <div class="progress" style="border-radius: 3px; height: 20px;">
@@ -112,7 +112,7 @@
                   </div>
                 </div>
                 <div class="col-2">
-                  <span class="text-muted">{{ item.count }}</span>
+                  <a href="{% url 'tasks' place=place.place_code %}?state={{ item.state }}&format=columns">{{ item.count }}</a>
                 </div>
               </div>
             {% endif %}
@@ -125,7 +125,7 @@
               {% if item.count %}
                 <div class="row mb-2">
                   <div class="col-4">
-                    <a class="badge badge-secondary" href="{% url 'tasks' place=place.place_code %}?state=open&state=assigned&state=pending_review&format=columns&labels={{ item.slug }}">{{ item.title }}</a>
+                    <span class="badge badge-secondary">{{ item.title }}</span>
                   </div>
                   <div class="col-6">
                     <div class="progress" style="border-radius: 3px; height: 20px;">
@@ -133,7 +133,7 @@
                     </div>
                   </div>
                   <div class="col-2">
-                    <span class="text-muted">{{ item.count }}</span>
+                    <a href="{% url 'tasks' place=place.place_code %}?state=open&state=assigned&state=pending_review&format=columns&labels={{ item.slug }}">{{ item.count }}</a>
                   </div>
                 </div>
               {% endif %}

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -58,7 +58,7 @@
               </div> 
             </div>
             <div class="col-3">
-                <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=subsidiary">Subsidiary ({{ subsidiary_works_count }})</a>
+                <a class="text-dark" href="{% url 'place_works' place=place.place_code %}?primary_subsidiary=subsidiary&stub=all">Subsidiary ({{ subsidiary_works_count }})</a>
             </div>
           </div>
         </div>

--- a/indigo_app/templates/place/detail.html
+++ b/indigo_app/templates/place/detail.html
@@ -25,7 +25,7 @@
                     <div class="progress-bar bg-success" role="progressbar" style="width: {{ perc }}%"></div>
                   </div> 
                 </div>
-                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?subtype={{ subtype.pk }}">{{ count }}</a></div>
+                <div class="col-2"><a href="{% url 'place_works' place=place.place_code %}?subtype={{ subtype.abbreviation|default:'acts_only' }}">{{ count }}</a></div>
               </div>                             
             {% endif %}
           {% endfor %}

--- a/indigo_app/views/places.py
+++ b/indigo_app/views/places.py
@@ -168,13 +168,16 @@ class PlaceDetailView(PlaceViewBase, AbstractAuthedIndigoView, TemplateView):
                 return 'Act'
             st = Subtype.for_abbreviation(abbr)
             return st.name if st else abbr
-        pairs = list(Counter([subtype_name(w.subtype) for w in works]).items())
-        pairs = [list(p) for p in pairs]
-        pairs.sort(key=lambda p: p[1], reverse=True)
 
-        total = sum([x[1] for x in pairs])
+        pairs = list(Counter([w.subtype or 'act' for w in works]).items())
+        pairs = [list(p) for p in pairs]
+        paris = [p.insert(0, subtype_name(p[0])) for p in pairs]
+
+        pairs.sort(key=lambda p: p[2], reverse=True)
+
+        total = sum([x[2] for x in pairs])
         for p in pairs:
-            p.append(int((p[1] / (total or 1)) * 100))        
+            p.append(int((p[2] / (total or 1)) * 100))
 
         return pairs
 

--- a/indigo_app/views/places.py
+++ b/indigo_app/views/places.py
@@ -213,6 +213,7 @@ class PlaceDetailView(PlaceViewBase, AbstractAuthedIndigoView, TemplateView):
             labels_chart.append({
                 'count': l.n_tasks,
                 'title': l.title,
+                'slug': l.slug,
                 'percentage': int((l.n_tasks / (total_open_tasks or 1)) * 100)
             })
 

--- a/indigo_app/views/places.py
+++ b/indigo_app/views/places.py
@@ -164,10 +164,10 @@ class PlaceDetailView(PlaceViewBase, AbstractAuthedIndigoView, TemplateView):
 
     def get_works_by_subtype(self, works):
         def subtype_name(abbr):
-            if not abbr:
+            if abbr == 'act':
                 return 'Act'
             st = Subtype.for_abbreviation(abbr)
-            return st.name if st else abbr
+            return st.name
 
         pairs = list(Counter([w.subtype or 'act' for w in works]).items())
         pairs = [list(p) for p in pairs]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'django-ckeditor>=5.8',
         'dj-database-url>=0.3.0',
         'django-activity-stream>=0.7.0',
-        'django-allauth>=0.36.0',
+        'django-allauth>=0.36.0,<0.41.0',
         'django-background-tasks>=1.2.0',
         'django-compressor>=2.2',
         'django-cors-headers>=3.1.0',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'django-ckeditor>=5.8',
         'dj-database-url>=0.3.0',
         'django-activity-stream>=0.7.0',
-        'django-allauth>=0.36.0,<0.41.0',
         'django-allauth>=0.36.0,<0.41.0',  # 0.41.0 moved to django 2
         'django-background-tasks>=1.2.0',
         'django-compressor>=2.2',


### PR DESCRIPTION
#### What does this PR do?

Add clickable on links on the overview page to quickly find tasks and works.

#### Description of Task to be completed?

This PR makes some elements clickable, which jumps to the appropriate listing page, with the correct filtering.

The following elements are clickable:

- [x] Task labels -> task listing with label filter applied
- [x] Open tasks -> normal task listing page
- [x] Assigned & pending -> task listing with the corresponding filter applied
works
- [x] Types of works, e.g. By-law -> work listing page with the filter applied
- [x] Principal works  ->  work listing page with the `exclude stubs` filter applied
- [x] Stubs  -> work listing page with the `only stubs` filter applied
- [x] Primary  -> work listing page with the `primary & subsidiary works` filter applied
- [x] Subsidiary  -> work listing page with the `primary & subsidiary works` filter applied

#### How should this be manually tested?

Open the place overview page and click on any of the above-listed items as indicated in the screenshot below. You'll be redirected to the page with the filter applied.

#### What are the relevant issues?

closes #882 

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/8082197/70710111-89083780-1cef-11ea-8dc7-a8c5a829a8cf.png)
