### PR TITLE
Section refs finder tweaks

### DIFF
--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -201,7 +201,7 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
           )
           (\s*\([A-Z0-9]+\))*      # bracketed subsections of first number
           (\s*                     # optional list of sections
-            (,|and|or)\s+          # list separators
+            (,|(,\s*)?and|(,\s*)?or)\s*          # list separators
             (\d+[A-Z0-9]*(\s*\([A-Z0-9]+\))*)
           )*
         )

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -183,9 +183,7 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
         sections 22(1) and 25(3)(b);
         sections 18, 61 and 62(1).
         in terms of section 2 or 7
-        sections 12(6)(d) and (e)
-        Subject to sections 1(4), 3(6), 4, 8, 24, 34(2) and 44, no person
-        sections 4(1), (2) and (3), 6(3) and 10(1) and (2) is guilty
+        A person who contravenes sections 4(1) and (2), 6(3), 10(1) and (2), 11(1), 12(1), 19(1), 19(3), 20(1), 20(2), 21(1), 22(1), 24(1), 25(3), (4) , (5) and (6) , 26(1), (2), (3) and (5), 28(1), (2) and (3) is guilty of an offence.
 
         TODO: match subsections
         TODO: match paragraphs

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -203,17 +203,17 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
         (
           (?P<ref>
             (?<!-)sections?\s+
-            (?P<num>\d+[A-Z0-9]*)  # first section number, including subsections
+            (?P<num>\d+[A-Z0-9]*)    # first section number, including subsections
           )
           (
-            (\s*(,|(,\s*)?and|(,\s*)?or)\s*)*          # list separators
+            (\s*(,|and|or))*         # list separators
             (\s*\([A-Z0-9]+\))+      # bracketed subsections of first number
           )*
-          (\s*                     # optional list of sections
-            (,|(,\s*)?and|(,\s*)?or)\s*          # list separators
+          (\s*                       # optional list of sections
+            (\s*(,|and|or))*         # list separators
             (
-              \d+[A-Z0-9]*(
-                (\s*(,|(,\s*)?and|(,\s*)?or)\s*)*          # list separators
+              \s*\d+[A-Z0-9]*(
+                (\s*(,|and|or))*     # list separators
                 (\s*\([A-Z0-9]+\))+
               )*
             )
@@ -226,6 +226,8 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
     # individual numbers in the list grouping above
     # we use <ref> and <num> named captures so that the is_valid and make_ref
     # methods can handle matches from both ref_re and this re.
+    # negative lookaround for parentheses around each number in the run guards against subsections being picked up as section numbers, e.g.
+    # sections 4(1) and (2), 25(3), (4), (5) and (6), etc
     item_re = re.compile(r'(?P<ref>(?P<num>(?<!\()\d+[A-Z0-9]*(?!\))))(\s*\([A-Z0-9]+\))*', re.IGNORECASE)
 
     candidate_xpath = ".//text()[contains(translate(., 'S', 's'), 'section') and not(ancestor::a:ref)]"

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -199,7 +199,10 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
             (?<!-)sections?\s+
             (?P<num>\d+[A-Z0-9]*)  # first section number, including subsections
           )
-          (\s*\([A-Z0-9]+\))*      # bracketed subsections of first number
+          (
+            (\s*(,|(,\s*)?and|(,\s*)?or)\s*)*          # list separators
+            (\s*\([A-Z0-9]+\))+      # bracketed subsections of first number
+          )*
           (\s*                     # optional list of sections
             (,|(,\s*)?and|(,\s*)?or)\s*          # list separators
             (\d+[A-Z0-9]*(\s*\([A-Z0-9]+\))*)
@@ -212,7 +215,7 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
     # individual numbers in the list grouping above
     # we use <ref> and <num> named captures so that the is_valid and make_ref
     # methods can handle matches from both ref_re and this re.
-    item_re = re.compile(r'(?P<ref>(?P<num>\d+[A-Z0-9]*))(\s*\([A-Z0-9]+\))*', re.IGNORECASE)
+    item_re = re.compile(r'(?P<ref>(?P<num>(?<!\()\d+[A-Z0-9]*(?!\))))(\s*\([A-Z0-9]+\))*', re.IGNORECASE)
 
     candidate_xpath = ".//text()[contains(translate(., 'S', 's'), 'section') and not(ancestor::a:ref)]"
     match_cache = {}

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -208,7 +208,12 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
           )*
           (\s*                     # optional list of sections
             (,|(,\s*)?and|(,\s*)?or)\s*          # list separators
-            (\d+[A-Z0-9]*(\s*\([A-Z0-9]+\))*)
+            (
+              \d+[A-Z0-9]*(
+                (\s*(,|(,\s*)?and|(,\s*)?or)\s*)*          # list separators
+                (\s*\([A-Z0-9]+\))+
+              )*
+            )
           )*
         )
         (\s+of\s+(this)?|\s+thereof)?

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -196,7 +196,7 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
         r'''\b
         (
           (?P<ref>
-            sections?\s+
+            (?<!-)sections?\s+
             (?P<num>\d+[A-Z0-9]*)  # first section number, including subsections
           )
           (\s*\([A-Z0-9]+\))*      # bracketed subsections of first number

--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -176,6 +176,8 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
         # lists
         sections 22 and 32
         and sections 19, 22 and 23, unless it appears to him
+        and sections 19, 22, and 23 (oxford comma)
+        and sections 19,22 and 23 (incorrect spacing)
         Sections 24, 26, 28, 36, 42(2), 46, 48, 49(2), 52, 53, 54 and 56 shall mutatis mutandis
         sections 23, 24, 25, 26 and 28;
         sections 22(1) and 25(3)(b);
@@ -183,6 +185,7 @@ class SectionRefsFinderENG(BaseInternalRefsFinder):
         in terms of section 2 or 7
         sections 12(6)(d) and (e)
         Subject to sections 1(4), 3(6), 4, 8, 24, 34(2) and 44, no person
+        sections 4(1), (2) and (3), 6(3) and 10(1) and (2) is guilty
 
         TODO: match subsections
         TODO: match paragraphs

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -45,7 +45,6 @@ class SectionRefsFinderTestCase(TestCase):
         <num>7.</num>
         <heading>Active ref heading</heading>
         <content>
-          <p>As given in sub-section 1, blah.</p>
           <p>A person who contravenes sections 4(1) and (2), 6(3), 10(1) and (2), 11(1), 12(1), 19(1), 19(3), 20(1), 20(2), 21(1), 22(1), 24(1), 25(3), (4) , (5) and (6) , 26(1), (2), (3) and (5), 28(1), (2) and (3) is guilty of an offence.</p>
         </content>
       </section>
@@ -172,7 +171,6 @@ class SectionRefsFinderTestCase(TestCase):
         <num>7.</num>
         <heading>Active ref heading</heading>
         <content>
-          <p>As given in sub-section 1, blah.</p>
           <p>A person who contravenes sections <ref href="#section-4">4</ref>(1) and (2), <ref href="#section-6">6</ref>(3), <ref href="#section-10">10</ref>(1) and (2), <ref href="#section-11">11</ref>(1), <ref href="#section-12">12</ref>(1), <ref href="#section-19">19</ref>(1), <ref href="#section-19">19</ref>(3), <ref href="#section-20">20</ref>(1), <ref href="#section-20">20</ref>(2), <ref href="#section-21">21</ref>(1), <ref href="#section-22">22</ref>(1), <ref href="#section-24">24</ref>(1), <ref href="#section-25">25</ref>(3), (4) , (5) and (6) , <ref href="#section-26">26</ref>(1), (2), (3) and (5), <ref href="#section-28">28</ref>(1), (2) and (3) is guilty of an offence.</p>
         </content>
       </section>
@@ -564,6 +562,7 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As <i>given</i> in (we're now in a tail) sections 26, 27 and 28 of the Nursing Act, blah.</p>
           <p>As given in section 26 of Cap. C38, blah.</p>
           <p>As given in section 26 of the Criminal Code, blah.</p>
+          <p>As given in sub-section 1, blah.</p>
         </content>
       </section>
       <section id="section-26">

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -16,264 +16,6 @@ class SectionRefsFinderTestCase(TestCase):
         self.eng = Language.for_code('eng')
         self.maxDiff = None
 
-    def test_section_latest(self):
-        document = Document(
-            document_xml=document_fixture(
-                xml="""
-      <section id="section-1">
-        <num>1.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-4">
-        <num>4.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-6">
-        <num>6.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-7">
-        <num>7.</num>
-        <heading>Active ref heading</heading>
-        <content>
-          <p>A person who contravenes sections 4(1) and (2), 6(3), 10(1) and (2), 11(1), 12(1), 19(1), 19(3), 20(1), 20(2), 21(1), 22(1), 24(1), 25(3), (4) , (5) and (6) , 26(1), (2), (3) and (5), 28(1), (2) and (3) is guilty of an offence.</p>
-        </content>
-      </section>
-      <section id="section-10">
-        <num>10.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-11">
-        <num>11.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-12">
-        <num>12.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-19">
-        <num>19.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-20">
-        <num>20.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-21">
-        <num>21.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-22">
-        <num>22.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-24">
-        <num>24.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-25">
-        <num>25.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-26">
-        <num>26.</num>
-        <heading>Important heading</heading>
-        <content>
-          <p>An important provision.</p>
-        </content>
-      </section>
-      <section id="section-26B">
-        <num>26B.</num>
-        <heading>Another important heading</heading>
-        <content>
-          <p>Another important provision.</p>
-        </content>
-      </section>
-      <section id="section-30">
-        <num>30.</num>
-        <heading>More important</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-31">
-        <num>31.</num>
-        <heading>More important</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-        """
-            ),
-            language=self.eng)
-
-        expected = Document(
-            document_xml=document_fixture(
-                xml="""
-      <section id="section-1">
-        <num>1.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-4">
-        <num>4.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-6">
-        <num>6.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-7">
-        <num>7.</num>
-        <heading>Active ref heading</heading>
-        <content>
-          <p>A person who contravenes sections <ref href="#section-4">4</ref>(1) and (2), <ref href="#section-6">6</ref>(3), <ref href="#section-10">10</ref>(1) and (2), <ref href="#section-11">11</ref>(1), <ref href="#section-12">12</ref>(1), <ref href="#section-19">19</ref>(1), <ref href="#section-19">19</ref>(3), <ref href="#section-20">20</ref>(1), <ref href="#section-20">20</ref>(2), <ref href="#section-21">21</ref>(1), <ref href="#section-22">22</ref>(1), <ref href="#section-24">24</ref>(1), <ref href="#section-25">25</ref>(3), (4) , (5) and (6) , <ref href="#section-26">26</ref>(1), (2), (3) and (5), <ref href="#section-28">28</ref>(1), (2) and (3) is guilty of an offence.</p>
-        </content>
-      </section>
-      <section id="section-10">
-        <num>10.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-11">
-        <num>11.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-12">
-        <num>12.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-19">
-        <num>19.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-20">
-        <num>20.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-21">
-        <num>21.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-22">
-        <num>22.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-24">
-        <num>24.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-25">
-        <num>25.</num>
-        <heading>Unimportant</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-26">
-        <num>26.</num>
-        <heading>Important heading</heading>
-        <content>
-          <p>An important provision.</p>
-        </content>
-      </section>
-      <section id="section-26B">
-        <num>26B.</num>
-        <heading>Another important heading</heading>
-        <content>
-          <p>Another important provision.</p>
-        </content>
-      </section>
-      <section id="section-30">
-        <num>30.</num>
-        <heading>More important</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-      <section id="section-31">
-        <num>31.</num>
-        <heading>More important</heading>
-        <content>
-          <p>Hi!</p>
-        </content>
-      </section>
-        """
-            ),
-            language=self.eng)
-
-        self.section_refs_finder.find_references_in_document(document)
-        root = etree.fromstring(expected.content)
-        expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
-        self.assertEqual(expected.content, document.content)
-
     def test_section_basic(self):
         document = Document(
             document_xml=document_fixture(
@@ -663,6 +405,27 @@ class SectionRefsFinderTestCase(TestCase):
           <p>An unimportant provision.</p>
         </content>
       </section>
+      <section id="section-4">
+        <num>4.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-5">
+        <num>5.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-6">
+        <num>6.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
       <section id="section-7">
         <num>7.</num>
         <heading>Active ref heading</heading>
@@ -677,6 +440,15 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in section 26(2) and (3), blah.</p>
           <p>As given in sections 26 (2) and (3), blah.</p>
           <p>As given in sections 26(2) and (3), blah.</p>
+          <p>A person who contravenes sections 4(1), (2) and (3), 6(3) and 10(1) and (2) is guilty of an offence.</p>
+          <p>Subject to sections 1(4) and (5) and 4(6), no person is guilty of an offence.</p>
+        </content>
+      </section>
+      <section id="section-10">
+        <num>10.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
         </content>
       </section>
       <section id="section-26">
@@ -728,6 +500,27 @@ class SectionRefsFinderTestCase(TestCase):
           <p>An unimportant provision.</p>
         </content>
       </section>
+      <section id="section-4">
+        <num>4.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-5">
+        <num>5.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-6">
+        <num>6.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
       <section id="section-7">
         <num>7.</num>
         <heading>Active ref heading</heading>
@@ -742,6 +535,15 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26">section 26</ref>(2) and (3), blah.</p>
           <p>As given in <ref href="#section-26">sections 26</ref> (2) and (3), blah.</p>
           <p>As given in <ref href="#section-26">sections 26</ref>(2) and (3), blah.</p>
+          <p>A person who contravenes sections <ref href="#section-4">4</ref>(1), (2) and (3), <ref href="#section-6">6</ref>(3) and <ref href="#section-10">10</ref>(1) and (2) is guilty of an offence.</p>
+          <p>Subject to sections <ref href="#section-1">1</ref>(4) and (5) and <ref href="#section-4">4</ref>(6), no person is guilty of an offence.</p>
+        </content>
+      </section>
+      <section id="section-10">
+        <num>10.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
         </content>
       </section>
       <section id="section-26">

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -45,8 +45,6 @@ class SectionRefsFinderTestCase(TestCase):
         <num>7.</num>
         <heading>Active ref heading</heading>
         <content>
-          <p>under sections 10,11, or 19 of this Act, blah.</p>
-          <p>As given in sections 10, 11, and 19 of this Act, blah.</p>
           <p>As given in sub-section 1, blah.</p>
           <p>A person who contravenes sections 4(1) and (2), 6(3), 10(1) and (2), 11(1), 12(1), 19(1), 19(3), 20(1), 20(2), 21(1), 22(1), 24(1), 25(3), (4) , (5) and (6) , 26(1), (2), (3) and (5), 28(1), (2) and (3) is guilty of an offence.</p>
         </content>
@@ -174,8 +172,6 @@ class SectionRefsFinderTestCase(TestCase):
         <num>7.</num>
         <heading>Active ref heading</heading>
         <content>
-          <p>under sections <ref href="#section-10">10</ref>,<ref href="#section-11">11</ref>, or <ref href="#section-19">19</ref> of this Act, blah.</p>
-          <p>As given in sections <ref href="#section-10">10</ref>, <ref href="#section-11">11</ref>, and <ref href="#section-19">19</ref> of this Act, blah.</p>
           <p>As given in sub-section 1, blah.</p>
           <p>A person who contravenes sections <ref href="#section-4">4</ref>(1) and (2), <ref href="#section-6">6</ref>(3), <ref href="#section-10">10</ref>(1) and (2), <ref href="#section-11">11</ref>(1), <ref href="#section-12">12</ref>(1), <ref href="#section-19">19</ref>(1), <ref href="#section-19">19</ref>(3), <ref href="#section-20">20</ref>(1), <ref href="#section-20">20</ref>(2), <ref href="#section-21">21</ref>(1), <ref href="#section-22">22</ref>(1), <ref href="#section-24">24</ref>(1), <ref href="#section-25">25</ref>(3), (4) , (5) and (6) , <ref href="#section-26">26</ref>(1), (2), (3) and (5), <ref href="#section-28">28</ref>(1), (2) and (3) is guilty of an offence.</p>
         </content>
@@ -445,6 +441,8 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in sections 26(b), 30(1) or 31, blah.</p>
           <p>As given in section 26 (b), 30 (1) or 31, blah.</p>
           <p>As <i>given</i> in (we're now in a tail) section 26, 30 and 31.</p>
+          <p>under sections 26,30 or 31 of this Act, blah.</p>
+          <p>As given in sections 26, 30, and 31 of this Act, blah.</p>
         </content>
       </section>
       <section id="section-26">
@@ -495,6 +493,8 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in sections <ref href="#section-26">26</ref>(b), <ref href="#section-30">30</ref>(1) or <ref href="#section-31">31</ref>, blah.</p>
           <p>As given in section <ref href="#section-26">26</ref> (b), <ref href="#section-30">30</ref> (1) or <ref href="#section-31">31</ref>, blah.</p>
           <p>As <i>given</i> in (we're now in a tail) section <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref> and <ref href="#section-31">31</ref>.</p>
+          <p>under sections <ref href="#section-26">26</ref>,<ref href="#section-30">30</ref> or <ref href="#section-31">31</ref> of this Act, blah.</p>
+          <p>As given in sections <ref href="#section-26">26</ref>, <ref href="#section-30">30</ref>, and <ref href="#section-31">31</ref> of this Act, blah.</p>
         </content>
       </section>
       <section id="section-26">

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -562,6 +562,8 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As <i>given</i> in (we're now in a tail) section 26 of Act 5 of 2012, blah.</p>
           <p>As <i>given</i> in (we're now in a tail) section 26 of the Nursing Act, blah.</p>
           <p>As <i>given</i> in (we're now in a tail) sections 26, 27 and 28 of the Nursing Act, blah.</p>
+          <p>As given in section 26 of Cap. C38, blah.</p>
+          <p>As given in section 26 of the Criminal Code, blah.</p>
         </content>
       </section>
       <section id="section-26">

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -16,6 +16,270 @@ class SectionRefsFinderTestCase(TestCase):
         self.eng = Language.for_code('eng')
         self.maxDiff = None
 
+    def test_section_latest(self):
+        document = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-1">
+        <num>1.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-4">
+        <num>4.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-6">
+        <num>6.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>under sections 10,11, or 19 of this Act, blah.</p>
+          <p>As given in sections 10, 11, and 19 of this Act, blah.</p>
+          <p>As given in sub-section 1, blah.</p>
+          <p>A person who contravenes sections 4(1) and (2), 6(3), 10(1) and (2), 11(1), 12(1), 19(1), 19(3), 20(1), 20(2), 21(1), 22(1), 24(1), 25(3), (4) , (5) and (6) , 26(1), (2), (3) and (5), 28(1), (2) and (3) is guilty of an offence.</p>
+        </content>
+      </section>
+      <section id="section-10">
+        <num>10.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-11">
+        <num>11.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-12">
+        <num>12.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-19">
+        <num>19.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-20">
+        <num>20.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-21">
+        <num>21.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-22">
+        <num>22.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-24">
+        <num>24.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-25">
+        <num>25.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-26B">
+        <num>26B.</num>
+        <heading>Another important heading</heading>
+        <content>
+          <p>Another important provision.</p>
+        </content>
+      </section>
+      <section id="section-30">
+        <num>30.</num>
+        <heading>More important</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-31">
+        <num>31.</num>
+        <heading>More important</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        expected = Document(
+            document_xml=document_fixture(
+                xml="""
+      <section id="section-1">
+        <num>1.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-4">
+        <num>4.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-6">
+        <num>6.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-7">
+        <num>7.</num>
+        <heading>Active ref heading</heading>
+        <content>
+          <p>under sections <ref href="#section-10">10</ref>,<ref href="#section-11">11</ref>, or <ref href="#section-19">19</ref> of this Act, blah.</p>
+          <p>As given in sections <ref href="#section-10">10</ref>, <ref href="#section-11">11</ref>, and <ref href="#section-19">19</ref> of this Act, blah.</p>
+          <p>As given in sub-section 1, blah.</p>
+          <p>A person who contravenes sections <ref href="#section-4">4</ref>(1) and (2), <ref href="#section-6">6</ref>(3), <ref href="#section-10">10</ref>(1) and (2), <ref href="#section-11">11</ref>(1), <ref href="#section-12">12</ref>(1), <ref href="#section-19">19</ref>(1), <ref href="#section-19">19</ref>(3), <ref href="#section-20">20</ref>(1), <ref href="#section-20">20</ref>(2), <ref href="#section-21">21</ref>(1), <ref href="#section-22">22</ref>(1), <ref href="#section-24">24</ref>(1), <ref href="#section-25">25</ref>(3), (4) , (5) and (6) , <ref href="#section-26">26</ref>(1), (2), (3) and (5), <ref href="#section-28">28</ref>(1), (2) and (3) is guilty of an offence.</p>
+        </content>
+      </section>
+      <section id="section-10">
+        <num>10.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-11">
+        <num>11.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-12">
+        <num>12.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-19">
+        <num>19.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-20">
+        <num>20.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-21">
+        <num>21.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-22">
+        <num>22.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-24">
+        <num>24.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-25">
+        <num>25.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-26">
+        <num>26.</num>
+        <heading>Important heading</heading>
+        <content>
+          <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-26B">
+        <num>26B.</num>
+        <heading>Another important heading</heading>
+        <content>
+          <p>Another important provision.</p>
+        </content>
+      </section>
+      <section id="section-30">
+        <num>30.</num>
+        <heading>More important</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-31">
+        <num>31.</num>
+        <heading>More important</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+        """
+            ),
+            language=self.eng)
+
+        self.section_refs_finder.find_references_in_document(document)
+        root = etree.fromstring(expected.content)
+        expected.content = etree.tostring(root, encoding='utf-8').decode('utf-8')
+        self.assertEqual(expected.content, document.content)
+
     def test_section_basic(self):
         document = Document(
             document_xml=document_fixture(

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -442,10 +442,67 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in sections 26(2) and (3), blah.</p>
           <p>A person who contravenes sections 4(1), (2) and (3), 6(3) and 10(1) and (2) is guilty of an offence.</p>
           <p>Subject to sections 1(4) and (5) and 4(6), no person is guilty of an offence.</p>
+          <p>A person who contravenes sections 4(1) and (2), 6(3), 10(1) and (2), 11(1), 12(1), 19(1), 19(3), 20(1), 20(2), 21(1), 22(1), 24(1), 25(3), (4) , (5) and (6) , 26(1), (2), (3) and (5), 28(1), (2) and (3) is guilty of an offence.</p>
         </content>
       </section>
       <section id="section-10">
         <num>10.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-11">
+        <num>11.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-12">
+        <num>12.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-19">
+        <num>19.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-20">
+        <num>20.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-21">
+        <num>21.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-22">
+        <num>22.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-24">
+        <num>24.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-25">
+        <num>25.</num>
         <heading>Unimportant</heading>
         <content>
           <p>Hi!</p>
@@ -456,6 +513,13 @@ class SectionRefsFinderTestCase(TestCase):
         <heading>Important heading</heading>
         <content>
           <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-28">
+        <num>28.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
         </content>
       </section>
       <section id="section-30">
@@ -537,10 +601,67 @@ class SectionRefsFinderTestCase(TestCase):
           <p>As given in <ref href="#section-26">sections 26</ref>(2) and (3), blah.</p>
           <p>A person who contravenes sections <ref href="#section-4">4</ref>(1), (2) and (3), <ref href="#section-6">6</ref>(3) and <ref href="#section-10">10</ref>(1) and (2) is guilty of an offence.</p>
           <p>Subject to sections <ref href="#section-1">1</ref>(4) and (5) and <ref href="#section-4">4</ref>(6), no person is guilty of an offence.</p>
+          <p>A person who contravenes sections <ref href="#section-4">4</ref>(1) and (2), <ref href="#section-6">6</ref>(3), <ref href="#section-10">10</ref>(1) and (2), <ref href="#section-11">11</ref>(1), <ref href="#section-12">12</ref>(1), <ref href="#section-19">19</ref>(1), <ref href="#section-19">19</ref>(3), <ref href="#section-20">20</ref>(1), <ref href="#section-20">20</ref>(2), <ref href="#section-21">21</ref>(1), <ref href="#section-22">22</ref>(1), <ref href="#section-24">24</ref>(1), <ref href="#section-25">25</ref>(3), (4) , (5) and (6) , <ref href="#section-26">26</ref>(1), (2), (3) and (5), <ref href="#section-28">28</ref>(1), (2) and (3) is guilty of an offence.</p>
         </content>
       </section>
       <section id="section-10">
         <num>10.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-11">
+        <num>11.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-12">
+        <num>12.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-19">
+        <num>19.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-20">
+        <num>20.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-21">
+        <num>21.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-22">
+        <num>22.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-24">
+        <num>24.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
+        </content>
+      </section>
+      <section id="section-25">
+        <num>25.</num>
         <heading>Unimportant</heading>
         <content>
           <p>Hi!</p>
@@ -551,6 +672,13 @@ class SectionRefsFinderTestCase(TestCase):
         <heading>Important heading</heading>
         <content>
           <p>An important provision.</p>
+        </content>
+      </section>
+      <section id="section-28">
+        <num>28.</num>
+        <heading>Unimportant</heading>
+        <content>
+          <p>Hi!</p>
         </content>
       </section>
       <section id="section-30">

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'django-ckeditor>=5.8',
         'dj-database-url>=0.3.0',
         'django-activity-stream>=0.7.0',
-        'django-allauth==0.40.0',  # 0.41.0 moved to django 2
+        'django-allauth>=0.36.0,<0.41.0',  # 0.41.0 moved to django 2
         'django-background-tasks>=1.2.0',
         'django-compressor>=2.2',
         'django-cors-headers>=3.1.0',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'django-ckeditor>=5.8',
         'dj-database-url>=0.3.0',
         'django-activity-stream>=0.7.0',
-        'django-allauth>=0.36.0',
+        'django-allauth>=0.36.0<0.41.0',  # 0.41.0 moved to django 2
         'django-background-tasks>=1.2.0',
         'django-compressor>=2.2',
         'django-cors-headers>=3.1.0',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'django-ckeditor>=5.8',
         'dj-database-url>=0.3.0',
         'django-activity-stream>=0.7.0',
-        'django-allauth>=0.36.0<0.41.0',  # 0.41.0 moved to django 2
+        'django-allauth==0.40.0',  # 0.41.0 moved to django 2
         'django-background-tasks>=1.2.0',
         'django-compressor>=2.2',
         'django-cors-headers>=3.1.0',


### PR DESCRIPTION
deals with the following real-life examples encountered since deploying:

(1) A person who contravenes sections [4](#section-4)(1) and (2), 6(3), 10(1) and (2), 11(1), 12(1), 19(1), 19(3), 20(1), 20(2), 21(1), 22(1), 24(1), 25(3), (4) , (5) and (6) , 26(1), (2), (3) and (5), 28(1), (2) and (3) is guilty of an offence.
(https://edit.laws.africa/documents/3376/)

in sub-[section 1](#section-1) will

sections [64](#section-64), [65](#section-65), and 67 of this Act

under [sections 35](#section-35),36, or 37 of this Act

