### PR TITLE
Filter Works by `Act` type

### DIFF
--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -242,7 +242,6 @@ class WorkFilterForm(forms.Form):
     q = forms.CharField()
     stub = forms.ChoiceField(choices=[('', 'Exclude stubs'), ('only', 'Only stubs'), ('all', 'Everything')])
     status = forms.MultipleChoiceField(choices=[('published', 'published'), ('draft', 'draft')])
-    subtype = forms.ChoiceField(choices=[('', 'All works'), ('act', 'Acts only')] + [(s.abbreviation, s.name) for s in Subtype.objects.all()])
     sortby = forms.ChoiceField(choices=[('-updated_at', '-updated_at'), ('updated_at', 'updated_at'), ('title', 'title'), ('-title', '-title'), ('frbr_uri', 'frbr_uri')])
     # assent date filter
     assent = forms.ChoiceField(choices=[('', 'Any'), ('no', 'Not assented to'), ('yes', 'Assented to'), ('range', 'Assented to between...')])
@@ -277,6 +276,7 @@ class WorkFilterForm(forms.Form):
     def __init__(self, country, *args, **kwargs):
         self.country = country
         super(WorkFilterForm, self).__init__(*args, **kwargs)
+        self.fields['subtype'] = forms.ChoiceField(choices=[('', 'All works'), ('act', 'Acts only')] + [(s.abbreviation, s.name) for s in Subtype.objects.all()])
 
     def data_as_url(self):
         return urllib.parse.urlencode(self.cleaned_data, 'utf-8')

--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -306,7 +306,7 @@ class WorkFilterForm(forms.Form):
         # filter by subtype indicated on frbr_uri
         if self.cleaned_data.get('subtype'):
             if self.cleaned_data['subtype'] == 'act':
-                queryset = queryset.filter(frbr_uri__regex=r'.\/act\/\d+\/\w+')
+                queryset = queryset.filter(frbr_uri__regex=r'.\/act\/\d{4}\/\w+')
             else:
                 queryset = queryset.filter(frbr_uri__contains='/act/%s/' % self.cleaned_data['subtype'])
 

--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -276,7 +276,7 @@ class WorkFilterForm(forms.Form):
     def __init__(self, country, *args, **kwargs):
         self.country = country
         super(WorkFilterForm, self).__init__(*args, **kwargs)
-        self.fields['subtype'] = forms.ChoiceField(choices=[('', 'All works'), ('act', 'Acts only')] + [(s.abbreviation, s.name) for s in Subtype.objects.all()])
+        self.fields['subtype'] = forms.ChoiceField(choices=[('', 'All works'), ('acts_only', 'Acts only')] + [(s.abbreviation, s.name) for s in Subtype.objects.all()])
 
     def data_as_url(self):
         return urllib.parse.urlencode(self.cleaned_data, 'utf-8')
@@ -305,7 +305,7 @@ class WorkFilterForm(forms.Form):
         
         # filter by subtype indicated on frbr_uri
         if self.cleaned_data.get('subtype'):
-            if self.cleaned_data['subtype'] == 'act':
+            if self.cleaned_data['subtype'] == 'acts_only':
                 queryset = queryset.filter(frbr_uri__regex=r'.\/act\/\d{4}\/\w+')
             else:
                 queryset = queryset.filter(frbr_uri__contains='/act/%s/' % self.cleaned_data['subtype'])

--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -4,7 +4,7 @@ import urllib.parse
 
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
-from django.db.models import Q, F
+from django.db.models import Q
 from django.core.validators import URLValidator
 from django.conf import settings
 from captcha.fields import ReCaptchaField


### PR DESCRIPTION
#### What does this PR do?

Enable users to filter works by `Acts` only - works with no subtype

#### Description of Task to be completed?

On the overview page, there are links to filtered works by the categories listed. Currently, there is no filter by `Acts` type. This PR adds this functionality

#### How should this be manually tested?

Open a place, head over to the works tab and toggle the `All works` (subtypes) filter.

#### What are the relevant issues?

closes #888

#### Screenshots (if appropriate)

Acts only filter option activated:
![image](https://user-images.githubusercontent.com/8082197/71674730-1984e580-2d8d-11ea-840d-98e367cc9951.png)
