### PR TITLE
Move stubs filter out of advanced, change wording for "all works"

### DIFF
--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -241,7 +241,7 @@ class TaskFilterForm(forms.Form):
 class WorkFilterForm(forms.Form):
     q = forms.CharField()
     stub = forms.ChoiceField(choices=[('', 'Exclude stubs'), ('only', 'Only stubs'), ('all', 'Everything')])
-    status = forms.MultipleChoiceField(choices=[('published', 'published'), ('draft', 'draft')])
+    status = forms.MultipleChoiceField(choices=[('published', 'published'), ('draft', 'draft')], initial=['published', 'draft'])
     sortby = forms.ChoiceField(choices=[('-updated_at', '-updated_at'), ('updated_at', 'updated_at'), ('title', 'title'), ('-title', '-title'), ('frbr_uri', 'frbr_uri')])
     # assent date filter
     assent = forms.ChoiceField(choices=[('', 'Any'), ('no', 'Not assented to'), ('yes', 'Assented to'), ('range', 'Assented to between...')])
@@ -272,19 +272,25 @@ class WorkFilterForm(forms.Form):
             .order_by('vocabulary__title', 'level_1', 'level_2'))
 
     advanced_filters = ['assent', 'publication', 'repeal', 'amendment', 'commencement',
-                        'primary_subsidiary', 'taxonomies', 'stub', 'completeness']
+                        'primary_subsidiary', 'taxonomies', 'completeness', 'status']
 
     def __init__(self, country, *args, **kwargs):
         self.country = country
         super(WorkFilterForm, self).__init__(*args, **kwargs)
-        self.fields['subtype'] = forms.ChoiceField(choices=[('', 'All works'), ('acts_only', 'Acts only')] + [(s.abbreviation, s.name) for s in Subtype.objects.all()])
+        self.fields['subtype'] = forms.ChoiceField(choices=[('', 'All types'), ('acts_only', 'Act')] + [(s.abbreviation, s.name) for s in Subtype.objects.all()])
 
     def data_as_url(self):
         return urllib.parse.urlencode(self.cleaned_data, 'utf-8')
 
     def show_advanced_filters(self):
         # Should we show the advanced options box by default?
-        return any(bool(self.cleaned_data.get(a)) for a in self.advanced_filters)
+        # true if there is a value set, and it's not the initial value
+        def is_set(a):
+            return (self.cleaned_data.get(a) and
+                    (not self.fields.get(a).initial or
+                     self.fields.get(a).initial != self.cleaned_data.get(a)))
+
+        return any(is_set(a) for a in self.advanced_filters)
 
     def filter_queryset(self, queryset):
         if self.cleaned_data.get('q'):

--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -277,7 +277,7 @@ class WorkFilterForm(forms.Form):
     def __init__(self, country, *args, **kwargs):
         self.country = country
         super(WorkFilterForm, self).__init__(*args, **kwargs)
-        self.fields['subtype'] = forms.ChoiceField(choices=[('', 'All types'), ('acts_only', 'Act')] + [(s.abbreviation, s.name) for s in Subtype.objects.all()])
+        self.fields['subtype'] = forms.ChoiceField(choices=[('', 'All types'), ('acts_only', 'Acts only')] + [(s.abbreviation, s.name) for s in Subtype.objects.all()])
 
     def data_as_url(self):
         return urllib.parse.urlencode(self.cleaned_data, 'utf-8')

--- a/indigo_app/templates/indigo_api/_work_filter_form.html
+++ b/indigo_app/templates/indigo_api/_work_filter_form.html
@@ -14,13 +14,14 @@
           {{ option }}
         {% endfor %}
       </select>
-    </div>    
+    </div>
 
-    <!-- Status filter -->
+    <!-- Stubs filter -->
     <div class="mr-2">
-      <select class="selectpicker notooltip" multiple name="status" data-width="fit" data-style="btn-outline-secondary">
-        <option value="published" {% if 'published' in form.status.value %} selected {% endif %} data-content="<i class='fas fa-circle fa-fw published'></i> Published">Published</option>
-        <option value="draft" {% if 'draft' in form.status.value %} selected {% endif %} data-content="<i class='fas fa-circle fa-fw draft'></i> Draft">Draft</option>
+      <select class="form-control" name="stub">
+        {% for opt in form.stub %}
+          <option value="{{ opt.data.value }}" {% if opt.data.selected %}selected{% endif %}>{{ opt.data.label }}</option>
+        {% endfor %}
       </select>
     </div>
 
@@ -50,21 +51,20 @@
         </select>
       </div>
 
-      <!-- Stubs filter -->
-      <div class="col-md-3">
-        <select class="form-control" name="stub">
-          {% for opt in form.stub %}
-            <option value="{{ opt.data.value }}" {% if opt.data.selected %}selected{% endif %}>{{ opt.data.label }}</option>
-          {% endfor %}
-        </select>
-      </div>
-
       <!-- Complete works filter -->
       <div class="col-md-3">
         <select name="completeness" class="form-control">
           {% for opt in form.completeness %}
             <option value="{{ opt.data.value}}" {% if opt.data.selected %}selected{% endif %}>{{ opt.data.label }}</option>
           {% endfor %}
+        </select>
+      </div>
+
+      <!-- Status filter -->
+      <div class="col-md-3">
+        <select class="selectpicker notooltip" multiple name="status" data-width="100%" data-style="btn-outline-secondary">
+          <option value="published" {% if 'published' in form.status.value %} selected {% endif %} data-content="<i class='fas fa-circle fa-fw published'></i> Published">Published</option>
+          <option value="draft" {% if 'draft' in form.status.value %} selected {% endif %} data-content="<i class='fas fa-circle fa-fw draft'></i> Draft">Draft</option>
         </select>
       </div>
     </div>

--- a/indigo_app/views/places.py
+++ b/indigo_app/views/places.py
@@ -233,7 +233,7 @@ class PlaceWorksView(PlaceViewBase, AbstractAuthedIndigoView, ListView):
             params.setdefault('sortby', '-updated_at')
 
         if not params.get('status'):
-            params.setlist('status', ['published', 'draft'])
+            params.setlist('status', WorkFilterForm.declared_fields['status'].initial)
 
         if not params.get('stub'):
             params.setdefault('stub', 'excl')


### PR DESCRIPTION
* This makes it clearer that we're hiding stubs by default.
* Move "published / draft" down into advanced
* "All works" -> "All types"
* "Acts only" -> "Act"

<img width="1143" alt="South Africa – Works – Laws Africa 2020-01-21 11-57-56" src="https://user-images.githubusercontent.com/4178542/72794852-56822080-3c45-11ea-9f4e-4faa24ecb373.png">

<img width="1123" alt="South Africa – Works – Laws Africa 2020-01-21 11-58-11" src="https://user-images.githubusercontent.com/4178542/72794863-5b46d480-3c45-11ea-8061-8496e9b4cc5a.png">
