### PR TITLE
Place name on coverpage

### DIFF
--- a/indigo_api/templates/indigo_api/akn/coverpage_act.html
+++ b/indigo_api/templates/indigo_api/akn/coverpage_act.html
@@ -4,6 +4,10 @@
 <div class="coverpage">
   {% block coat_of_arms %}{% endblock %}
 
+  {% block place_name %}
+    <p class="place-name">{{ document.work.country.name }}{% if document.work.locality %} – {{ document.work.locality.name }}{% endif %}</p>
+  {% endblock %}
+
   {% if document.work.parent_work %}
     {% block parent_title %}
       <h1>{{ document.work.parent_work.title }}</h1>

--- a/indigo_api/templates/indigo_api/akn/coverpage_act.html
+++ b/indigo_api/templates/indigo_api/akn/coverpage_act.html
@@ -5,7 +5,10 @@
   {% block coat_of_arms %}{% endblock %}
 
   {% block place_name %}
-    <p class="place-name">{{ document.work.country.name }}{% if document.work.locality %} – {{ document.work.locality.name }}{% endif %}</p>
+    <p class="place-name">
+      {% if document.work.locality %}{{ document.work.locality.name }}<br>{% endif %}
+      {{ document.work.country.name }}
+    </p>
   {% endblock %}
 
   {% if document.work.parent_work %}

--- a/indigo_app/static/lib/indigo-web/scss/_coverpage.scss
+++ b/indigo_app/static/lib/indigo-web/scss/_coverpage.scss
@@ -18,7 +18,7 @@
 
     .place-name {
       font-size: ceil($akn-font-size * 1.25); // ~ 18px
-      line-height: 1.2;
+      line-height: 1.4;
       margin-bottom: $akn-para-spacing;
       font-weight: bold;
     }

--- a/indigo_app/static/lib/indigo-web/scss/_coverpage.scss
+++ b/indigo_app/static/lib/indigo-web/scss/_coverpage.scss
@@ -18,7 +18,7 @@
 
     .place-name {
       font-size: ceil($akn-font-size * 1.25); // ~ 18px
-      line-height: 1.4;
+      line-height: 1.2;
       margin-bottom: $akn-para-spacing;
       font-weight: bold;
     }

--- a/indigo_app/static/lib/indigo-web/scss/_coverpage.scss
+++ b/indigo_app/static/lib/indigo-web/scss/_coverpage.scss
@@ -17,7 +17,7 @@
     }
 
     .place-name {
-      font-size: ceil($akn-font-size * 1.7); // ~ 24px
+      font-size: ceil($akn-font-size * 1.25); // ~ 18px
       line-height: 1.2;
       margin-bottom: $akn-para-spacing;
       font-weight: bold;

--- a/indigo_app/static/lib/indigo-web/scss/_coverpage.scss
+++ b/indigo_app/static/lib/indigo-web/scss/_coverpage.scss
@@ -16,6 +16,13 @@
       }
     }
 
+    .place-name {
+      font-size: ceil($akn-font-size * 1.7); // ~ 24px
+      line-height: 1.2;
+      margin-bottom: $akn-para-spacing;
+      font-weight: bold;
+    }
+
     .assent-date,
     .commencement-date {
       margin-bottom: $akn-para-spacing;


### PR DESCRIPTION
closes #857 

- Above Work title on coverpage
- Doesn't affect ToC or running heads in pdf

Document view on platform:
![image](https://user-images.githubusercontent.com/32566441/72923337-8883a780-3d57-11ea-8991-756aa9fedd42.png)

Pdf first page:
![image](https://user-images.githubusercontent.com/32566441/72923391-a3561c00-3d57-11ea-8cc1-947bea0250bc.png)

Pdf later page:
![image](https://user-images.githubusercontent.com/32566441/72923420-b1a43800-3d57-11ea-9421-c50cff734e8c.png)

With locality:
![image](https://user-images.githubusercontent.com/32566441/72923568-02b42c00-3d58-11ea-8329-d171c37025ca.png)

Pdf first page:
![image](https://user-images.githubusercontent.com/32566441/72923593-0f388480-3d58-11ea-8591-4882b1ef6635.png)

Pdf later page:
![image](https://user-images.githubusercontent.com/32566441/72923622-1f506400-3d58-11ea-8c0d-559db8dff04e.png)
