### PR TITLE
Attachment tweaks

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_source_att.js
+++ b/indigo_app/static/javascript/indigo/views/document_source_att.js
@@ -43,12 +43,12 @@
           return am.amending_work.publication_document && am.amending_work.publication_document.url;
         }).map(function(am) {
           return {
-            'title': am.date + ' - ' + am.amending_work.frbr_uri,
+            'title': am.date + ' – ' + am.amending_work.frbr_uri,
             'url': am.amending_work.publication_document.url,
             'group': 'Amendments',
           };
         });
-        this.amendments = _.sortBy(this.amendments, 'date');
+        this.amendments = _.sortBy(this.amendments, 'date').reverse();
       },
 
       rebuildChoices: function() {


### PR DESCRIPTION
When checking amendments we'll often be checking the most recent one.

Let's not assume that people will get it wrong, but we may want to eventually show only 'this date and previous' amendments. But it may be more useful to always have them all to hand, so let's only do that if it becomes necessary?