### PR TITLE
FIX raise http404, not return

### DIFF
--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -594,7 +594,7 @@ class WorkPublicationDocumentView(WorkViewBase, View):
             if self.work.publication_document.trusted_url:
                 return redirect(self.work.publication_document.trusted_url)
             return view_attachment(self.work.publication_document)
-        return Http404()
+        raise Http404()
 
 
 class BatchAddWorkView(PlaceViewBase, AbstractAuthedIndigoView, FormView):


### PR DESCRIPTION
Fixes error for https://edit.laws.africa/works/za-cpt/act/by-law/2019/municipal-planning-amendment/media/publication/za-cpt-act-2019-municipal-planning-amendment-publication-document.pdf