### PR TITLE
FIX bug on external links

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -463,7 +463,7 @@
       html.querySelectorAll('a[href]').forEach(function(a) {
         if (!a.getAttribute('href').startsWith('#')) {
           a.setAttribute("target", "_blank");
-          $(a).tooltip({title: a.getAttribute('data-href')});
+          $(a).tooltip({title: a.getAttribute('data-href') || a.getAttribute('href')});
         }
       });
     },


### PR DESCRIPTION
Fixes a bug where a JS error is thrown when trying to ensure that an external link in the coverpage opens in a new tab.