### PR TITLE
Commencements editing

### DIFF
--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -66,6 +66,8 @@ class TOCBuilderBase(LocaleBasedMatcher):
     # eg. schedule1
     component_id_re = re.compile('([^0-9]+)([0-9]+)')
 
+    non_commenceable_types = set(['coverpage', 'preface', 'preamble', 'conclusions', 'doc'])
+
     def table_of_contents_for_document(self, document):
         """ Build the table of contents for a document.
         """
@@ -209,6 +211,26 @@ class TOCBuilderBase(LocaleBasedMatcher):
                 title += ' ' + item.num
 
         return title
+
+    def commenceable_items(self, toc):
+        """ Return a list of those items in +toc+ that are considered commenceable.
+
+        By default, these are all the child items in the main component, except
+        the preface, preamble and conclusion.
+        """
+        def process(item):
+            if item.component == 'main':
+                if item.children:
+                    for kid in item.children:
+                        process(kid)
+                elif item.type not in self.non_commenceable_types:
+                    items.append(item)
+
+        items = []
+        for entry in toc:
+            process(entry)
+
+        return items
 
 
 class TOCElement(object):

--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -361,8 +361,8 @@ if DEBUG:
 # Messages
 from django.contrib.messages import constants as messages
 MESSAGE_TAGS = {
-    messages.INFO: 'alert alert-primary',
-    messages.SUCCESS: 'alert alert-success',
+    messages.INFO: 'alert alert-primary auto-dismiss',
+    messages.SUCCESS: 'alert alert-success auto-dismiss',
     messages.WARNING: 'alert alert-warning',
     messages.ERROR: 'alert alert-danger',
 }

--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -463,15 +463,18 @@ class Commencement(models.Model):
 
     def rationalise(self):
         work = self.commenced_work
-        # if the work was uncommenced and has now fully commenced, delete the uncommencement
-        # if it was uncommenced and has now partly commenced, edit it to be partial too
-        uncommencement = work.uncommenced_provisions
-        if uncommencement and uncommencement.all_provisions:
-            if self.all_provisions:
-                uncommencement.delete()
-            else:
-                uncommencement.all_provisions = False
-                uncommencement.save()
+        try:
+            # if the work was uncommenced and has now fully commenced, delete the uncommencement
+            # if it was uncommenced and has now partly commenced, edit it to be partial too
+            uncommencement = work.uncommenced_provisions
+            if uncommencement.all_provisions:
+                if self.all_provisions:
+                    uncommencement.delete()
+                else:
+                    uncommencement.all_provisions = False
+                    uncommencement.save()
+        except UncommencedProvisions.DoesNotExist:
+            pass
 
     @classmethod
     def commenceable_provisions(cls, work):

--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -463,6 +463,10 @@ class Commencement(models.Model):
 
     def rationalise(self):
         work = self.commenced_work
+        if not work.commenced:
+            work.commenced = True
+            work.save()
+
         try:
             # if the work was uncommenced and has now fully commenced, delete the uncommencement
             # if it was uncommenced and has now partly commenced, edit it to be partial too

--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -136,12 +136,13 @@ class WorkForm(forms.ModelForm):
 
         else:
             # if the work has either been created as commenced or edited to commence, update / create the commencement
-            commencement, _ = Commencement.objects.get_or_create(commenced_work=work)
+            commencement, created = Commencement.objects.get_or_create(commenced_work=work)
             commencement.commencing_work = self.cleaned_data['commencing_work']
             commencement.date = self.cleaned_data['commencement_date']
+            if created:
+                commencement.all_provisions = True
             # this is safe because we know there are no other commencement objects
             commencement.main = True
-            commencement.all_provisions = True
             commencement.rationalise()
             commencement.save()
 

--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -483,3 +483,16 @@ class CountryAdminForm(forms.ModelForm):
     def clean_italics_terms(self):
         # strip blanks and duplications
         return sorted(list(set(x for x in self.cleaned_data['italics_terms'] if x)))
+
+
+class CommencementForm(forms.ModelForm):
+    provisions = forms.MultipleChoiceField(required=False)
+
+    class Meta:
+        model = Commencement
+        fields = ('date', 'all_provisions', 'provisions', 'main')
+
+    def __init__(self, provisions, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.provisions = provisions
+        self.fields['provisions'].choices = [(p.id, p.title) for p in self.provisions]

--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -510,11 +510,11 @@ class CommencementForm(forms.ModelForm):
     def clean_all_provisions(self):
         if self.cleaned_data['all_provisions']:
             # there can be only one!
-            qs = Commencement.objects.filter(commenced_work=self.work, all_provisions=True)
+            qs = Commencement.objects.filter(commenced_work=self.work)
             if self.instance:
                 qs = qs.exclude(pk=self.instance.pk)
             if qs.exists():
-                raise ValidationError("A commencement for all provisions already exists.")
+                raise ValidationError("A commencement for all provisions must be the only commencement.")
         return self.cleaned_data['all_provisions']
 
     def clean(self):

--- a/indigo_app/static/javascript/indigo/utils.js
+++ b/indigo_app/static/javascript/indigo/utils.js
@@ -25,7 +25,7 @@ $(function() {
 
   // Toasts should disappear after a few seconds
   function nukeToasts() {
-    $('.alert-dismissible').alert('close');
+    $('.alert-dismissible.auto-dismiss').alert('close');
   }
   setTimeout(nukeToasts, 3 * 1000);
 });

--- a/indigo_app/static/javascript/indigo/views/work.js
+++ b/indigo_app/static/javascript/indigo/views/work.js
@@ -221,7 +221,10 @@
       }
       chooser.showModal().done(function(chosen) {
         if (chosen) {
-          self.model.set('commencing_work', chosen);
+          self.model.set({
+            'commencing_work': chosen,
+            'commencement_date': chosen.get('commencement_date') || chosen.get('publication_date'),
+          });
         }
       });
     },
@@ -229,6 +232,11 @@
     commencedChanged: function() {
       if (this.model.get('commenced')) {
         this.$('#commencement_details').removeClass('d-none');
+
+        if (!this.model.get('commencement_date')) {
+          this.model.set('commencement_date', this.model.get('publication_date'));
+        }
+
         this.commencementDateUnknown.checked = false;
         this.commencementDateUnknownChanged();
       } else {

--- a/indigo_app/static/javascript/indigo/views/work_commencements.js
+++ b/indigo_app/static/javascript/indigo/views/work_commencements.js
@@ -1,0 +1,51 @@
+(function(exports) {
+  "use strict";
+
+  if (!exports.Indigo) exports.Indigo = {};
+  Indigo = exports.Indigo;
+
+  /**
+   * Handle the work commencements display.
+   */
+  Indigo.WorkCommencementsView = Backbone.View.extend({
+    el: '#work-commencements-view',
+    events: {
+      'click .add-commencement': 'addCommencement',
+    },
+
+    initialize: function() {
+      this.model = new Indigo.Work(Indigo.Preloads.work);
+      this.$('.commencement-form').on('show.bs.collapse', _.bind(this.formShow, this));
+      this.$('.commencement-form').on('hide.bs.collapse', _.bind(this.formHide, this));
+    },
+
+    addCommencement: function(e) {
+      e.preventDefault();
+
+      var chooser = new Indigo.WorkChooserView({
+            country: this.model.get('country'),
+            locality: this.model.get('locality') || "-",
+          }),
+          form = document.getElementById('new-commencement-form'),
+          self = this;
+
+      chooser.showModal().done(function(chosen) {
+        if (chosen) {
+          form.elements.date.value = chosen.get('commencement_date') || chosen.get('publication_date');
+          form.elements.commencing_work.value = chosen.get('id');
+          form.submit();
+        }
+      });
+    },
+
+    formShow: function(e) {
+      // hide the details
+      e.target.parentElement.querySelector('.commencement-details').classList.remove('show');
+    },
+
+    formHide: function(e) {
+      // show the details
+      e.target.parentElement.querySelector('.commencement-details').classList.add('show');
+    },
+  });
+})(window);

--- a/indigo_app/static/javascript/indigo/views/work_commencements.js
+++ b/indigo_app/static/javascript/indigo/views/work_commencements.js
@@ -11,6 +11,8 @@
     el: '#work-commencements-view',
     events: {
       'click .add-commencement': 'addCommencement',
+      'click .all-provisions': 'allProvisionsChanged',
+      'submit .commencement-form': 'formSubmitted',
     },
 
     initialize: function() {
@@ -47,5 +49,19 @@
       // show the details
       e.target.parentElement.querySelector('.commencement-details').classList.add('show');
     },
+
+    allProvisionsChanged: function(e) {
+      $(e.target).closest('.card').find('.provisions-commenced').toggleClass('d-none', e.target.checked);
+    },
+
+    formSubmitted: function(e) {
+      var form = e.target;
+
+      // if we've selected all provisions, ensure we don't send back any selections
+      if (form.elements.all_provisions.checked) {
+        // we can't iterate over this in-place, so do this instead
+        while (form.elements.provisions.selectedOptions.length > 0) form.elements.provisions.selectedOptions[0].selected = false;
+      }
+    }
   });
 })(window);

--- a/indigo_app/static/stylesheets/_utilities.scss
+++ b/indigo_app/static/stylesheets/_utilities.scss
@@ -19,3 +19,7 @@
 .c-pointer {
   cursor: pointer;
 }
+
+.fa-rotate-315 {
+  transform: rotate(315deg);
+}

--- a/indigo_app/templates/indigo_api/work_commencements.html
+++ b/indigo_app/templates/indigo_api/work_commencements.html
@@ -144,7 +144,7 @@
     </div>
   {% endif %}
 
-  {% if work.commencements.count %}
+  {% if work.commencements.count and perms.indigo_api.delete_commencement %}
     <form method="post" class="mt-5" action="{% url 'work_uncommenced' frbr_uri=work.frbr_uri %}">
       {% csrf_token %}
       <h5>Not yet commenced?</h5>

--- a/indigo_app/templates/indigo_api/work_commencements.html
+++ b/indigo_app/templates/indigo_api/work_commencements.html
@@ -45,17 +45,14 @@
           <form action="{% url 'work_commencement_detail' frbr_uri=work.frbr_uri commencement_id=commencement.id %}" class="commencement-form" method="POST" id="commencement-{{ commencement.id|default:'initial' }}">
             {% csrf_token %}
 
-            {% if perms.indigo_api.change_commencement %}
-              <div class="dropdown float-right">
-                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-toggle="dropdown">Options <span class="caret"></span></button>
-                <div class="dropdown-menu">
-                  <a href=".commencement-form-{{ commencement.id }}" class="dropdown-item" data-toggle="collapse">Edit</a>
-                  {% if perms.indigo_api.delete_commencement %}
-                    <button class="dropdown-item" type="submit" name="delete" data-confirm="Really delete this commencement?">Delete</button>
-                  {% endif %}
-                </div>
-              </div>
-            {% endif %}
+            <div class="float-right">
+              {% if perms.indigo_api.delete_commencement %}
+                <button class="btn btn-link text-danger mr-2" type="submit" name="delete" data-confirm="Really delete this commencement?">Delete</button>
+              {% endif %}
+              {% if perms.indigo_api.change_commencement %}
+                <a href=".commencement-form-{{ commencement.id }}" class="btn btn-outline-primary" data-toggle="collapse">Edit</a>
+              {% endif %}
+            </div>
 
             <div class="mb-3">
               <h6>

--- a/indigo_app/templates/indigo_api/work_commencements.html
+++ b/indigo_app/templates/indigo_api/work_commencements.html
@@ -14,6 +14,10 @@
     <p class="alert alert-info">This work has not commenced.</p>
   {% endif %}
 
+  {% if uncommenced_provisions %}
+    <p class="alert alert-warning">This work has {{ uncommenced_provisions|length }} <a href="#uncommenced">uncommenced provision{{ uncommenced_provisions|length|pluralize }}</a>.</p>
+  {% endif %}
+
   <ol class="timeline">
     {% if perms.indigo_api.add_commencement %}
       <li class="timeline-item card">
@@ -66,14 +70,14 @@
               <h6>
                 {% if commencement.all_provisions %}Commences all provisions{% endif %}
                 {% if commencement.provisions %}
-                  Commences {{ commencement.provisions|length }} of {{ provisions|length }} provision{{ provisions|length|pluralize }}
+                  Commences {{ commencement.provisions|length }} of {{ provisions|length }} provision{{ provisions|length|pluralize }}:
                 {% endif %}
               </h6>
 
               {% if commencement.provisions %}
                 <ul class="list-unstyled">
-                  {% for prov in commencement.provisions %}
-                    <li>{{ prov }}</li>
+                  {% for prov in commencement.provision_items %}
+                    <li>{{ prov.title|default:prov }}</li>
                   {% endfor %}
                 </ul>
               {% endif %}
@@ -120,7 +124,20 @@
     {% endfor %}
   </ol>
 
-  {% if work.pk and work.commencements.count %}
+  {% if uncommenced_provisions %}
+    <div class="card mt-5">
+      <h5 id="uncommenced" class="card-header">Uncommenced provisions <span class="badge badge-warning">{{ uncommenced_provisions|length }}</span></h5>
+      <div class="card-body">
+        <ul class="list-unstyled mb-0">
+          {% for prov in uncommenced_provisions %}
+            <li>{{ prov.title }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if work.commencements.count %}
     <form method="post" class="mt-5" action="{% url 'work_uncommenced' frbr_uri=work.frbr_uri %}">
       {% csrf_token %}
       <h5>Not yet commenced?</h5>

--- a/indigo_app/templates/indigo_api/work_commencements.html
+++ b/indigo_app/templates/indigo_api/work_commencements.html
@@ -108,7 +108,7 @@
                 <label>Provisions commenced:</label>
                 <small class="form-text text-muted">Use SHIFT and Ctrl (or ⌘) to select multiple items.</small>
                 <select name="provisions" class="form-control" multiple size="{% if provisions|length > 20 %}20{% else %}10{% endif %}">
-                  {% for prov in provisions %}
+                  {% for prov in commencement.possible_provisions %}
                     <option value="{{ prov.id }}" {% if prov.id in commencement.provisions %}selected{% endif %}>{{ prov.title }}</option>
                   {% endfor %}
                 </select>

--- a/indigo_app/templates/indigo_api/work_commencements.html
+++ b/indigo_app/templates/indigo_api/work_commencements.html
@@ -6,6 +6,14 @@
 {% block work-content %}
   <h4>Commencements</h4>
 
+  {% if work.commenced and not work.commencement_date %}
+    <p class="alert alert-warning">This work has commenced, but the commencement date is unknown.</p>
+  {% endif %}
+
+  {% if not work.commenced %}
+    <p class="alert alert-info">This work has not commenced.</p>
+  {% endif %}
+
   <ol class="timeline">
     {% if perms.indigo_api.add_commencement %}
       <li class="timeline-item card">
@@ -24,7 +32,7 @@
 
     {% for commencement in commencements_timeline %}
       <li class="timeline-item card">
-        <h6 class="timeline-date">{{ commencement.date|date:"Y-m-d" }}</h6>
+        <h6 class="timeline-date">{% if commencement.date %}{{ commencement.date|date:"Y-m-d" }}{% else %}<em>Unknown</em>{% endif %}</h6>
         <div class="card-body">
           <form action="{% url 'work_commencement_detail' frbr_uri=work.frbr_uri commencement_id=commencement.id %}" class="commencement-form" method="POST" id="commencement-{{ commencement.id|default:'initial' }}">
             {% csrf_token %}
@@ -41,10 +49,17 @@
               </div>
             {% endif %}
 
-            <h6 class="mb-0">
-              {% if not commencement.date %}Future commencement by{% else %}Commenced by{% endif %}
-              <a href="{% url 'work' frbr_uri=commencement.commencing_work.frbr_uri %}" data-popup-url="{% url 'work_popup' frbr_uri=commencement.commencing_work.frbr_uri %}">{{ commencement.commencing_work.title }}</a></h6>
-            <div class="text-muted mb-3">{{ commencement.commencing_work.frbr_uri }}</div>
+            <div class="mb-3">
+              <h6>
+                Commenced
+                {% if commencement.commencing_work %}
+                  by <a href="{% url 'work' frbr_uri=commencement.commencing_work.frbr_uri %}" data-popup-url="{% url 'work_popup' frbr_uri=commencement.commencing_work.frbr_uri %}">{{ commencement.commencing_work.title }}</a>
+                {% endif %}
+              </h6>
+              {% if commencement.commencing_work %}
+                <div class="text-muted">{{ commencement.commencing_work.frbr_uri }}</div>
+              {% endif %}
+            </div>
 
             <div class="commencement-details collapse show">
               {% if commencement.main %}<h6>Main commencement</h6>{% endif %}
@@ -67,7 +82,7 @@
             <div class="mb-3 collapse commencement-form commencement-form-{{ commencement.id }}">
               <div class="form-row form-group">
                 <div class="col-md-4 col-lg-3">
-                  <input type="text" class="form-control commencement-date mr-2" data-provide="datepicker" placeholder="yyyy-mm-dd" pattern="\d{4}-\d\d-\d\d" required name="date" value="{{ commencement.date|date:"Y-m-d" }}" autocomplete="off">
+                  <input type="text" class="form-control commencement-date mr-2" data-provide="datepicker" placeholder="yyyy-mm-dd" pattern="\d{4}-\d\d-\d\d" name="date" value="{{ commencement.date|date:"Y-m-d" }}" autocomplete="off">
                 </div>
               </div>
 
@@ -104,6 +119,15 @@
       </li>
     {% endfor %}
   </ol>
+
+  {% if work.pk and work.commencements.count %}
+    <form method="post" class="mt-5" action="{% url 'work_uncommenced' frbr_uri=work.frbr_uri %}">
+      {% csrf_token %}
+      <h5>Not yet commenced?</h5>
+      <p>Remove all commencement detail and mark as not commenced.</p>
+      <button type="submit" class="btn btn-danger" data-confirm="Are you sure?" name="delete">This work has not commenced</button>
+    </form>
+  {% endif %}
 {% endblock %}
 
 

--- a/indigo_app/templates/indigo_api/work_commencements.html
+++ b/indigo_app/templates/indigo_api/work_commencements.html
@@ -26,7 +26,7 @@
       <li class="timeline-item card">
         <h6 class="timeline-date">{{ commencement.date|date:"Y-m-d" }}</h6>
         <div class="card-body">
-          <form action="{% url 'work_commencement_detail' frbr_uri=work.frbr_uri commencement_id=commencement.id %}" method="POST" id="commencement-{{ commencement.id|default:'initial' }}">
+          <form action="{% url 'work_commencement_detail' frbr_uri=work.frbr_uri commencement_id=commencement.id %}" class="commencement-form" method="POST" id="commencement-{{ commencement.id|default:'initial' }}">
             {% csrf_token %}
 
             {% if perms.indigo_api.change_commencement %}
@@ -50,7 +50,9 @@
               {% if commencement.main %}<h6>Main commencement</h6>{% endif %}
               <h6>
                 {% if commencement.all_provisions %}Commences all provisions{% endif %}
-                {% if commencement.provisions %}Commences {{ commencement.provisions|length }} provision{{ commencement.provisions|length|pluralize }}{% endif %}
+                {% if commencement.provisions %}
+                  Commences {{ commencement.provisions|length }} of {{ provisions|length }} provision{{ provisions|length|pluralize }}
+                {% endif %}
               </h6>
 
               {% if commencement.provisions %}
@@ -78,12 +80,12 @@
 
               <div class="form-group">
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="commencement-{{ commencement.id }}-all-provisions" {% if commencement.all_provisions %}checked{% endif %} value="true" name="all_provisions">
+                  <input class="form-check-input all-provisions" type="checkbox" id="commencement-{{ commencement.id }}-all-provisions" {% if commencement.all_provisions %}checked{% endif %} value="true" name="all_provisions">
                   <label class="form-check-label" for="commencement-{{ commencement.id }}-all-provisions">Commences all provisions</label>
                 </div>
               </div>
 
-              <div class="form-group">
+              <div class="form-group provisions-commenced {% if commencement.all_provisions %}d-none{% endif %}">
                 <label>Provisions commenced:</label>
                 <small class="form-text text-muted">Use SHIFT and Ctrl (or ⌘) to select multiple items.</small>
                 <select name="provisions" class="form-control" multiple size="{% if provisions|length > 20 %}20{% else %}10{% endif %}">

--- a/indigo_app/templates/indigo_api/work_commencements.html
+++ b/indigo_app/templates/indigo_api/work_commencements.html
@@ -1,25 +1,107 @@
 {% extends "indigo_api/work_layout.html" %}
 
+{% block view-id %}work-commencements-view{% endblock %}
 {% block title %}Commencements – {{ block.super }}{% endblock %}
 
 {% block work-content %}
   <h4>Commencements</h4>
 
   <ol class="timeline">
+    {% if perms.indigo_api.add_commencement %}
+      <li class="timeline-item card">
+        <div class="card-body">
+          {% block new-commencement-card %}
+            <button class="btn btn-primary add-commencement"><i class="fas fa-plus"></i> Add commencement</button>
+            <form action="{% url 'new_work_commencement' frbr_uri=work.frbr_uri %}" method="POST" id="new-commencement-form">
+              {% csrf_token %}
+              <input type="hidden" name="commencing_work" value="">
+              <input type="hidden" name="date" value="">
+            </form>
+          {% endblock %}
+        </div>
+      </li>
+    {% endif %}
+
     {% for commencement in commencements_timeline %}
       <li class="timeline-item card">
         <h6 class="timeline-date">{{ commencement.date|date:"Y-m-d" }}</h6>
         <div class="card-body">
-          <h6>
-            {% if commencement.main %}Main commencement{% else %}Commencement{% endif %}
-            {% if not commencement.date %}(future){% endif %}
-            {% if commencement.all_provisions %} – all provisions commenced{% endif %}
-          </h6>
+          <form action="{% url 'work_commencement_detail' frbr_uri=work.frbr_uri commencement_id=commencement.id %}" method="POST" id="commencement-{{ commencement.id|default:'initial' }}">
+            {% csrf_token %}
+
+            {% if perms.indigo_api.change_commencement %}
+              <div class="dropdown float-right">
+                <button class="btn btn-outline-secondary btn-sm dropdown-toggle" type="button" data-toggle="dropdown">Options <span class="caret"></span></button>
+                <div class="dropdown-menu">
+                  <a href=".commencement-form-{{ commencement.id }}" class="dropdown-item" data-toggle="collapse">Edit</a>
+                  {% if perms.indigo_api.delete_commencement %}
+                    <button class="dropdown-item" type="submit" name="delete" data-confirm="Really delete this commencement?">Delete</button>
+                  {% endif %}
+                </div>
+              </div>
+            {% endif %}
+
+            <h6 class="mb-0">
+              {% if not commencement.date %}Future commencement by{% else %}Commenced by{% endif %}
+              <a href="{% url 'work' frbr_uri=commencement.commencing_work.frbr_uri %}" data-popup-url="{% url 'work_popup' frbr_uri=commencement.commencing_work.frbr_uri %}">{{ commencement.commencing_work.title }}</a></h6>
+            <div class="text-muted mb-3">{{ commencement.commencing_work.frbr_uri }}</div>
+
+            <div class="commencement-details collapse show">
+              {% if commencement.main %}<h6>Main commencement</h6>{% endif %}
+              <h6>
+                {% if commencement.all_provisions %}Commences all provisions{% endif %}
+                {% if commencement.provisions %}Commences {{ commencement.provisions|length }} provision{{ commencement.provisions|length|pluralize }}{% endif %}
+              </h6>
+
+              {% if commencement.provisions %}
+                <ul class="list-unstyled">
+                  {% for prov in commencement.provisions %}
+                    <li>{{ prov }}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+            </div>
+
+            <div class="mb-3 collapse commencement-form commencement-form-{{ commencement.id }}">
+              <div class="form-row form-group">
+                <div class="col-md-4 col-lg-3">
+                  <input type="text" class="form-control commencement-date mr-2" data-provide="datepicker" placeholder="yyyy-mm-dd" pattern="\d{4}-\d\d-\d\d" required name="date" value="{{ commencement.date|date:"Y-m-d" }}" autocomplete="off">
+                </div>
+              </div>
+
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="commencement-{{ commencement.id }}-main" {% if commencement.main %}checked{% endif %} value="true" name="main">
+                  <label class="form-check-label" for="commencement-{{ commencement.id }}-main">Main commencement</label>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="commencement-{{ commencement.id }}-all-provisions" {% if commencement.all_provisions %}checked{% endif %} value="true" name="all_provisions">
+                  <label class="form-check-label" for="commencement-{{ commencement.id }}-all-provisions">Commences all provisions</label>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label>Provisions commenced:</label>
+                <small class="form-text text-muted">Use SHIFT and Ctrl (or ⌘) to select multiple items.</small>
+                <select name="provisions" class="form-control" multiple size="{% if provisions|length > 20 %}20{% else %}10{% endif %}">
+                  {% for prov in provisions %}
+                    <option value="{{ prov.id }}" {% if prov.id in commencement.provisions %}selected{% endif %}>{{ prov.title }}</option>
+                  {% endfor %}
+                </select>
+              </div>
+            </div>
+          </form>
+        </div>
+        <div class="card-footer text-right commencement-form-{{ commencement.id }} collapse">
+          <button class="btn btn-link" type="reset" form="commencement-{{ commencement.id }}" data-toggle="collapse" data-target=".commencement-form-{{ commencement.id }}">Cancel</button>
+          <button class="btn btn-success" type="submit" form="commencement-{{ commencement.id }}">Save</button>
         </div>
       </li>
     {% endfor %}
   </ol>
-
 {% endblock %}
 
 

--- a/indigo_app/templates/indigo_api/work_commencements.html
+++ b/indigo_app/templates/indigo_api/work_commencements.html
@@ -18,8 +18,12 @@
     <p class="alert alert-warning">This work has {{ uncommenced_provisions|length }} <a href="#uncommenced">uncommenced provision{{ uncommenced_provisions|length|pluralize }}</a>.</p>
   {% endif %}
 
+  {% if has_all_provisions %}
+    <p>All provisions have commenced, no additional commencement events are required.</p>
+  {% endif %}
+
   <ol class="timeline">
-    {% if perms.indigo_api.add_commencement %}
+    {% if perms.indigo_api.add_commencement and not has_all_provisions %}
       <li class="timeline-item card">
         <div class="card-body">
           {% block new-commencement-card %}
@@ -34,7 +38,7 @@
       </li>
     {% endif %}
 
-    {% for commencement in commencements_timeline %}
+    {% for commencement in commencements %}
       <li class="timeline-item card">
         <h6 class="timeline-date">{% if commencement.date %}{{ commencement.date|date:"Y-m-d" }}{% else %}<em>Unknown</em>{% endif %}</h6>
         <div class="card-body">
@@ -92,14 +96,20 @@
 
               <div class="form-group">
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" id="commencement-{{ commencement.id }}-main" {% if commencement.main %}checked{% endif %} value="true" name="main">
+                  <input class="form-check-input" type="checkbox" id="commencement-{{ commencement.id }}-main"
+                         value="true" name="main"
+                         {% if commencement.main %}checked{% endif %}
+                         {% if has_main_commencement and not commencement.main %}disabled{% endif %}>
                   <label class="form-check-label" for="commencement-{{ commencement.id }}-main">Main commencement</label>
                 </div>
               </div>
 
               <div class="form-group">
                 <div class="form-check">
-                  <input class="form-check-input all-provisions" type="checkbox" id="commencement-{{ commencement.id }}-all-provisions" {% if commencement.all_provisions %}checked{% endif %} value="true" name="all_provisions">
+                  <input class="form-check-input all-provisions" type="checkbox" id="commencement-{{ commencement.id }}-all-provisions"
+                         value="true" name="all_provisions"
+                         {% if commencement.all_provisions %}checked{% endif %}
+                         {% if commencements|length > 1 and not commencement.all_provisions %}disabled{% endif %}>
                   <label class="form-check-label" for="commencement-{{ commencement.id }}-all-provisions">Commences all provisions</label>
                 </div>
               </div>

--- a/indigo_app/templates/indigo_api/work_form.html
+++ b/indigo_app/templates/indigo_api/work_form.html
@@ -226,49 +226,55 @@
       <h5 class="card-header">Commencement and assent</h5>
       <div class="card-body">
 
-        <div class="form-row">
-          <div class="form-group">
-            <div class="form-check">
-              <input type="checkbox" class="form-check-input" id="{{ form.commenced.id_for_label }}" name="{{ form.commenced.html_name }}" value="on" {% if form.commenced.value %}checked{% endif %}>
-              <label class="ml-2 mr-2" for="{{ form.commenced.id_for_label }}">Commenced – this work has come into force, or has a future commencement date</label>
-            </div>
+        {% if work.pk and work.commencements.count > 1 %}
+          <div class="mb-3">
+            This work has mixed commencements, <a href="{% url 'work_commencements' frbr_uri=work.frbr_uri %}">edit them in the Commencements page</a>.
           </div>
-        </div>
-        <div id="commencement_details" {% if not work.commenced %}class="d-none"{% endif %}>
+        {% else %}
           <div class="form-row">
-            <div class="form-group col-md-4">
-              <label for="{{ form.commencement_date.id_for_label }}">Commencement date</label>
-              <input type="text" class="form-control" data-provide="datepicker" id="{{ form.commencement_date.id_for_label }}" name="{{ form.commencement_date.html_name }}" placeholder="yyyy-mm-dd" pattern="\d{4}-\d\d-\d\d" value="{{ form.commencement_date.value|date:"Y-m-d"|default:'' }}">
-              <p class="form-text text-muted">Date when most of the work comes into force</p>
-
+            <div class="form-group">
               <div class="form-check">
-                <input type="checkbox" class="form-check-input" id="commencement_date_unknown">
-                <label for="commencement_date_unknown">Commencement date is unknown</label>
+                <input type="checkbox" class="form-check-input" id="{{ form.commenced.id_for_label }}" name="{{ form.commenced.html_name }}" value="on" {% if form.commenced.value %}checked{% endif %}>
+                <label class="ml-2 mr-2" for="{{ form.commenced.id_for_label }}">Commenced – this work has come into force, or has a future commencement date</label>
               </div>
-              <p class="form-text text-muted">Check this box when a (usually old) work has come into force, but the exact commencement date is not known.</p>
-
-              {% if work.pk and work.commencement_date %}
-                {% if work.amendments_made.exists or work.repealed_works.exists %}
-                  <div class="alert alert-warning">If you change this commencement date, you may also have to manually change the dates for related <a href="{% url 'work_related' work.frbr_uri %}">amendments and repeals</a> made by this work.</div>
-                {% endif %}
-              {% endif %}
-            </div>
-
-            <div class="form-group col">
-              <button class="btn btn-outline-primary float-right change-commencing-work" type="button">Choose commencing work</button>
-              <label>Commenced by</label>
-              <div class="work-commencing-work form-control-static"></div>
-              <input type="hidden" id="{{ form.commencing_work.id_for_label }}" name="{{ form.commencing_work.html_name }}" value="{{ form.commencing_work.value|default:'' }}">
-              <p class="form-text text-muted">Work that gives the commencement date of this work</p>
             </div>
           </div>
-        </div>
+          <div id="commencement_details" {% if not work.commenced %}class="d-none"{% endif %}>
+            <div class="form-row">
+              <div class="form-group col-md-4">
+                <label for="{{ form.commencement_date.id_for_label }}">Commencement date</label>
+                <input type="text" class="form-control" data-provide="datepicker" id="{{ form.commencement_date.id_for_label }}" name="{{ form.commencement_date.html_name }}" placeholder="yyyy-mm-dd" pattern="\d{4}-\d\d-\d\d" value="{{ form.commencement_date.value|date:"Y-m-d"|default:'' }}">
+                <p class="form-text text-muted">Date when most of the work comes into force</p>
+
+                <div class="form-check">
+                  <input type="checkbox" class="form-check-input" id="commencement_date_unknown">
+                  <label for="commencement_date_unknown">Commencement date is unknown</label>
+                </div>
+                <p class="form-text text-muted">Check this box when a (usually old) work has come into force, but the exact commencement date is not known.</p>
+
+                {% if work.pk and work.commencement_date %}
+                  {% if work.amendments_made.exists or work.repealed_works.exists %}
+                    <div class="alert alert-warning">If you change this commencement date, you may also have to manually change the dates for related <a href="{% url 'work_related' work.frbr_uri %}">amendments and repeals</a> made by this work.</div>
+                  {% endif %}
+                {% endif %}
+              </div>
+
+              <div class="form-group col">
+                <button class="btn btn-outline-primary float-right change-commencing-work" type="button">Choose commencing work</button>
+                <label>Commenced by</label>
+                <div class="work-commencing-work form-control-static"></div>
+                <input type="hidden" id="{{ form.commencing_work.id_for_label }}" name="{{ form.commencing_work.html_name }}" value="{{ form.commencing_work.value|default:'' }}">
+                <p class="form-text text-muted">Work that gives the commencement date of this work</p>
+              </div>
+            </div>
+          </div>
+        {% endif %}
 
         <div class="form-row">
           <div class="form-group col-md-4">
             <label for="{{ form.assent_date.id_for_label }}">Assent date</label>
             <input type="text" class="form-control" data-provide="datepicker" id="{{ form.assent_date.id_for_label }}" name="{{ form.assent_date.html_name }}" placeholder="yyyy-mm-dd" pattern="\d{4}-\d\d-\d\d" value="{{ form.assent_date.value|date:"Y-m-d"|default:'' }}">
-            <p class="form-text text-muted">Date when approved by the responsible authority</p>
+            <div class="form-text text-muted">Date when approved by the responsible authority</div>
           </div>
         </div>
 

--- a/indigo_app/templates/indigo_api/work_layout.html
+++ b/indigo_app/templates/indigo_api/work_layout.html
@@ -41,7 +41,7 @@
               <i class="fas fa-fw fa-clock"></i> Points in time
             </a>
             <a class="nav-item nav-link {% if view.tab == 'commencements' %}active{% endif %}" href="{% url 'work_commencements' frbr_uri=work.frbr_uri %}">
-              <i class="fas fa-fw fa-rocket"></i> Commencements
+              <i class="fas fa-fw fa-rocket fa-rotate-315"></i> Commencements
             </a>
             <a class="nav-item nav-link {% if view.tab == 'tasks' %}active{% endif %}" href="{% url 'work_tasks' frbr_uri=work.frbr_uri %}">
               <i class="fas fa-fw fa-thumbtack"></i> Tasks

--- a/indigo_app/templates/indigo_api/work_layout.html
+++ b/indigo_app/templates/indigo_api/work_layout.html
@@ -37,11 +37,11 @@
             <a class="nav-item nav-link {% if view.tab == 'overview' %}active{% endif %}" href="{% url 'work' frbr_uri=work.frbr_uri %}">
               <i class="fas fa-fw fa-book"></i> Overview
             </a>
-            <a class="nav-item nav-link {% if view.tab == 'commencements' %}active{% endif %}" href="{% url 'work_commencements' frbr_uri=work.frbr_uri %}">
-              <i class="far fa-calendar"></i> Commencements
-            </a>
             <a class="nav-item nav-link {% if view.tab == 'amendments' %}active{% endif %}" href="{% url 'work_amendments' frbr_uri=work.frbr_uri %}">
               <i class="fas fa-fw fa-clock"></i> Points in time
+            </a>
+            <a class="nav-item nav-link {% if view.tab == 'commencements' %}active{% endif %}" href="{% url 'work_commencements' frbr_uri=work.frbr_uri %}">
+              <i class="fas fa-fw fa-rocket"></i> Commencements
             </a>
             <a class="nav-item nav-link {% if view.tab == 'tasks' %}active{% endif %}" href="{% url 'work_tasks' frbr_uri=work.frbr_uri %}">
               <i class="fas fa-fw fa-thumbtack"></i> Tasks

--- a/indigo_app/urls.py
+++ b/indigo_app/urls.py
@@ -55,6 +55,8 @@ urlpatterns = [
     url(r'^places/(?P<place>[a-z]{2}(-[^/]+)?)/works/new-batch/$', works.BatchAddWorkView.as_view(), name='new_batch_work'),
 
     url(r'^works(?P<frbr_uri>/\S+?)/commencements/$', works.WorkCommencementsView.as_view(), name='work_commencements'),
+    url(r'^works(?P<frbr_uri>/\S+?)/commencements/new$', works.AddWorkCommencementView.as_view(), name='new_work_commencement'),
+    url(r'^works(?P<frbr_uri>/\S+?)/commencements/(?P<commencement_id>\d+)$', works.WorkCommencementUpdateView.as_view(), name='work_commencement_detail'),
     url(r'^works(?P<frbr_uri>/\S+?)/amendments/$', works.WorkAmendmentsView.as_view(), name='work_amendments'),
     url(r'^works(?P<frbr_uri>/\S+?)/amendments/new$', works.AddWorkAmendmentView.as_view(), name='new_work_amendment'),
     url(r'^works(?P<frbr_uri>/\S+?)/arbitrary_expression_dates/new$', works.AddArbitraryExpressionDateView.as_view(), name='new_arbitrary_expression_date'),

--- a/indigo_app/urls.py
+++ b/indigo_app/urls.py
@@ -57,6 +57,7 @@ urlpatterns = [
     url(r'^works(?P<frbr_uri>/\S+?)/commencements/$', works.WorkCommencementsView.as_view(), name='work_commencements'),
     url(r'^works(?P<frbr_uri>/\S+?)/commencements/new$', works.AddWorkCommencementView.as_view(), name='new_work_commencement'),
     url(r'^works(?P<frbr_uri>/\S+?)/commencements/(?P<commencement_id>\d+)$', works.WorkCommencementUpdateView.as_view(), name='work_commencement_detail'),
+    url(r'^works(?P<frbr_uri>/\S+?)/commencements/uncommenced$', works.WorkUncommencedView.as_view(), name='work_uncommenced'),
     url(r'^works(?P<frbr_uri>/\S+?)/amendments/$', works.WorkAmendmentsView.as_view(), name='work_amendments'),
     url(r'^works(?P<frbr_uri>/\S+?)/amendments/new$', works.AddWorkAmendmentView.as_view(), name='new_work_amendment'),
     url(r'^works(?P<frbr_uri>/\S+?)/arbitrary_expression_dates/new$', works.AddArbitraryExpressionDateView.as_view(), name='new_arbitrary_expression_date'),

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -249,7 +249,9 @@ class WorkCommencementsView(WorkViewBase, DetailView):
         # to exclude those already commenced
         context['provisions'] = provisions = self.work.commenceable_provisions()
         context['uncommenced_provisions'] = self.get_uncommenced_provisions(provisions)
-        context['commencements_timeline'] = commencements = self.work.commencements.all().reverse()
+        context['commencements'] = commencements = self.work.commencements.all().reverse()
+        context['has_all_provisions'] = any(c.all_provisions for c in commencements)
+        context['has_main_commencement'] = any(c.main for c in commencements)
 
         provision_set = {p.id: p for p in provisions}
         for commencement in commencements:
@@ -371,7 +373,7 @@ class AddWorkCommencementView(WorkDependentView, CreateView):
         if not self.work.commencements.filter(main=True).exists():
             self.object.main = True
 
-        if not self.work.commencements.filter(all_provisions=True).exists():
+        if not self.work.commencements.exists():
             self.object.all_provisions = True
 
         self.object.rationalise()

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -278,7 +278,7 @@ class WorkCommencementUpdateView(WorkDependentView, UpdateView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs['work'] = self.work
-        kwargs['provisions'] = Commencement.commenceable_provisions(self.work)
+        kwargs['provisions'] = self.work.commenceable_provisions()
         return kwargs
 
     def post(self, request, *args, **kwargs):

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -298,12 +298,13 @@ class WorkCommencementUpdateView(WorkDependentView, UpdateView):
         return redirect(self.get_success_url())
 
     def delete(self, request, *args, **kwargs):
-        self.get_object().delete()
+        self.object = self.get_object()
+        self.object.delete()
         return redirect(self.get_success_url())
 
     def get_success_url(self):
         url = reverse('work_commencements', kwargs={'frbr_uri': self.kwargs['frbr_uri']})
-        if self.object and self.object.id:
+        if self.object.id:
             url += "#commencement-%s" % self.object.id
         return url
 

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -254,7 +254,7 @@ class WorkCommencementsView(WorkViewBase, DetailView):
 
         # TODO: these need to be attached and filtered for each commencement object,
         # to exclude those already commenced
-        context['provisions'] = Commencement.commenceable_provisions(self.work)
+        context['provisions'] = self.work.commenceable_provisions()
         return context
 
 

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -277,6 +277,7 @@ class WorkCommencementUpdateView(WorkDependentView, UpdateView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
+        kwargs['work'] = self.work
         kwargs['provisions'] = Commencement.commenceable_provisions(self.work)
         return kwargs
 
@@ -290,6 +291,10 @@ class WorkCommencementUpdateView(WorkDependentView, UpdateView):
         return super().form_valid(form)
 
     def form_invalid(self, form):
+        # send errors as messages, since we redirect back to the commencements page
+        errors = list(form.non_field_errors())
+        errors.extend([f'{fld}: ' + ', '.join(errs) for fld, errs in form.errors.items() if fld != '__all__'])
+        messages.error(self.request, '; '.join(errors))
         return redirect(self.get_success_url())
 
     def delete(self, request, *args, **kwargs):


### PR DESCRIPTION
* commencements editing page
* can add, edit and delete commencements
* handles unknown commencement date
* make work edit form play nicely with new commencements page

Outstanding (should be added before merging to master):
* multiple commencement dates are still not integrated into the PIT timeline.
* indicate multiple commencements in work overview page summary
* indicate multiple commencements in work popup

![Commencements – Funky commencements – Laws Africa 2020-02-14 17-04-56](https://user-images.githubusercontent.com/4178542/74542419-3e53a780-4f4c-11ea-9653-45d1e2cf1fa7.png)

![Commencements – Funky commencements – Laws Africa 2020-02-14 17-05-07](https://user-images.githubusercontent.com/4178542/74542418-3d227a80-4f4c-11ea-8c1c-4af1f7374c07.png)

![Commencements – Funky commencements – Laws Africa 2020-02-14 17-05-19](https://user-images.githubusercontent.com/4178542/74542412-398ef380-4f4c-11ea-8315-7cad66078b53.png)

