### PR TITLE
Fix for `not repealed` filter bug on Works filter

### DIFF
--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -361,7 +361,7 @@ class WorkFilterForm(forms.Form):
         if self.cleaned_data.get('repeal') == 'yes':
             queryset = queryset.filter(repealed_date__isnull=False)
         elif self.cleaned_data.get('repeal') == 'no':
-            queryset = queryset.filter(repealed_date__isnull=False)
+            queryset = queryset.filter(repealed_date__isnull=True)
         elif self.cleaned_data.get('repeal') == 'range':
             if self.cleaned_data.get('repealed_date_start') and self.cleaned_data.get('repealed_date_end'):
                 start_date = self.cleaned_data['repealed_date_start']


### PR DESCRIPTION
#### What does this PR do?

Fix a bug where the `not repealed` works filter returned repealed works.

#### Description of Task to be completed?

The queryset filter when the `not repealed` option was selected fetched works with repeal dates. The fix is to filter the works where the repeal date is null. More details on file changed.

#### What are the relevant issues?

#937 
