### PR TITLE
Fix expression dates dropdown

### DIFF
--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -312,14 +312,16 @@ class Work(models.Model):
         if plugin:
             return plugin.work_friendly_type(self)
 
-    def amendments_initial_commencement_arbitrary(self):
+    def amendments_initial_commencement_arbitrary(self, no_commencements=False):
         """ Return a list of Amendment, Commencement and ArbitraryExpressionDate objects, including a fake one at the end
         that represents the initial point-in-time. This will include multiple
         objects at the same date, if there were multiple events at the same date.
         """
         initial = ArbitraryExpressionDate(work=self, date=self.publication_date or self.commencement_date)
         initial.initial = True
-        amendments_expressions = list(self.amendments.all()) + list(self.arbitrary_expression_dates.all()) + list(self.commencements.exclude(date=None))
+        amendments_expressions = list(self.amendments.all()) + list(self.arbitrary_expression_dates.all())
+        if not no_commencements:
+            amendments_expressions = amendments_expressions + list(self.commencements.exclude(date=None))
         amendments_expressions.sort(key=lambda x: x.date)
 
         if initial.date:

--- a/indigo_api/templatetags/indigo.py
+++ b/indigo_api/templatetags/indigo.py
@@ -19,3 +19,8 @@ def work_resolver_url(context, work):
         frbr_uri = '/akn' + frbr_uri
 
     return context.get('resolver_url', settings.RESOLVER_URL) + frbr_uri
+
+
+@register.simple_tag()
+def possible_expression_dates(work):
+    return work.amendments_initial_commencement_arbitrary(no_commencements=True)

--- a/indigo_app/templates/indigo_api/document/_properties.html
+++ b/indigo_app/templates/indigo_api/document/_properties.html
@@ -1,3 +1,4 @@
+{% load indigo %}
 <div class="modal fade" id="properties-modal" tabindex="-1">
   <div class="modal-dialog modal-lg document-properties-view">
     <div class="modal-content">
@@ -29,10 +30,11 @@
           <div class="form-row">
             <div class="col-sm-8">
               <select class="form-control" id="document_expression_date">
-                {% for amendment in work.amendments_with_initial_and_arbitrary %}
-                <option value="{{ amendment.date|date:"Y-m-d" }}">
-                  {{ amendment.date|date:"Y-m-d"}} -
-                  {% if amendment.initial %}
+                {% possible_expression_dates work as possible_dates %}
+                {% for date in possible_dates %}
+                <option value="{{ date.date|date:"Y-m-d" }}">
+                  {{ date.date|date:"Y-m-d"}} –
+                  {% if date.initial %}
                   initial publication
                   {% else %}
                   amendment


### PR DESCRIPTION
currently nothing is showing because that method was renamed:
![image](https://user-images.githubusercontent.com/32566441/74949887-05617a00-5407-11ea-92b8-04bc2078d173.png)

but using the method as changed would incorrectly allow a user to change the expression date of a document to a date that has just a commencement, so I made some tweaks to get around that