### PR TITLE
resolve points in time / timeline confusion

### DIFF
--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -617,6 +617,11 @@ class ArbitraryExpressionDate(models.Model):
     def can_delete(self):
         return not self.expressions().exists()
 
+    def save(self):
+        if self.work.amendments.filter(date=self.date).all():
+            return
+        return super().save()
+
     @property
     def amended_work(self):
         return self.work

--- a/indigo_api/tests/test_work.py
+++ b/indigo_api/tests/test_work.py
@@ -4,7 +4,7 @@ import datetime
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 
-from indigo_api.models import Document, Work, Country
+from indigo_api.models import Document, Work, Country, Amendment, ArbitraryExpressionDate
 
 
 class WorkTestCase(TestCase):
@@ -41,3 +41,117 @@ class WorkTestCase(TestCase):
 
         work = Work(frbr_uri='', country=country)
         self.assertRaises(ValidationError, work.full_clean)
+
+    def test_possible_expression_dates_basic(self):
+        self.work.publication_date = datetime.date(2018, 2, 23)
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2019-09-13', created_by_user_id=1)
+        amendment.save()
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2020-12-05', created_by_user_id=1)
+        amendment.save()
+        dates = self.work.possible_expression_dates()
+        self.assertEqual(
+            dates,
+            [
+                {'date': datetime.date(2020, 12, 5),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': False},
+                {'date': datetime.date(2019, 9, 13),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': False},
+                {'date': datetime.date(2018, 2, 23),
+                 'initial': True},
+            ]
+        )
+
+    def test_possible_expression_dates_commencement(self):
+        self.work.publication_date = None
+        # the commencements fixture commences work 1 on 2016-07-15
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2020-09-13', created_by_user_id=1)
+        amendment.save()
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2018-12-05', created_by_user_id=1)
+        amendment.save()
+        dates = self.work.possible_expression_dates()
+        self.assertEqual(
+            dates,
+            [
+                {'date': datetime.date(2020, 9, 13),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': False},
+                {'date': datetime.date(2018, 12, 5),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': False},
+                {'date': datetime.date(2016, 7, 15),
+                 'initial': True},
+            ]
+        )
+
+    def test_possible_expression_dates_amendment_first(self):
+        self.work.publication_date = datetime.date(2017, 2, 23)
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2020-09-13', created_by_user_id=1)
+        amendment.save()
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2016-12-05', created_by_user_id=1)
+        amendment.save()
+        dates = self.work.possible_expression_dates()
+        self.assertEqual(
+            dates,
+            [
+                {'date': datetime.date(2020, 9, 13),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': False},
+                {'date': datetime.date(2017, 2, 23),
+                 'initial': True},
+                {'date': datetime.date(2016, 12, 5),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': False},
+            ]
+        )
+
+    def test_possible_expression_dates_amended_on_publication(self):
+        self.work.publication_date = datetime.date(2017, 2, 23)
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2020-09-13', created_by_user_id=1)
+        amendment.save()
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2017-02-23', created_by_user_id=1)
+        amendment.save()
+        dates = self.work.possible_expression_dates()
+        self.assertEqual(
+            dates,
+            [
+                {'date': datetime.date(2020, 9, 13),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': False},
+                {'date': datetime.date(2017, 2, 23),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': True},
+            ]
+        )
+
+    def test_possible_expression_dates_consolidation(self):
+        self.work.publication_date = datetime.date(2017, 2, 23)
+        consolidation = ArbitraryExpressionDate(work=self.work, date='2020-09-13', created_by_user_id=1)
+        consolidation.save()
+        amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2018-12-05', created_by_user_id=1)
+        amendment.save()
+        dates = self.work.possible_expression_dates()
+        self.assertEqual(
+            dates,
+            [
+                {'date': datetime.date(2020, 9, 13),
+                 'amendment': False,
+                 'consolidation': True,
+                 'initial': False},
+                {'date': datetime.date(2018, 12, 5),
+                 'amendment': True,
+                 'consolidation': False,
+                 'initial': False},
+                {'date': datetime.date(2017, 2, 23),
+                 'initial': True},
+            ]
+        )

--- a/indigo_app/templates/indigo_api/document/_properties.html
+++ b/indigo_app/templates/indigo_api/document/_properties.html
@@ -29,13 +29,15 @@
           <div class="form-row">
             <div class="col-sm-8">
               <select class="form-control" id="document_expression_date">
-                {% for amendment in work.amendments_with_initial_and_arbitrary %}
-                <option value="{{ amendment.date|date:"Y-m-d" }}">
-                  {{ amendment.date|date:"Y-m-d"}} -
-                  {% if amendment.initial %}
-                  initial publication
-                  {% else %}
-                  amendment
+                {% for date in work.possible_expression_dates %}
+                  <option value="{{ date.date|date:"Y-m-d" }}">
+                  {{ date.date|date:"Y-m-d"}} –
+                  {% if date.initial %}
+                    initial publication
+                  {% elif date.amendment %}
+                    amendment
+                  {% elif date.consolidation %}
+                    consolidation
                   {% endif %}
                 {% endfor %}
               </select>

--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -9,7 +9,8 @@ from webtest import Upload
 
 import reversion
 
-from indigo_api.models import Work, Commencement
+from indigo_app.views.works import WorkViewBase
+from indigo_api.models import Work, Commencement, Amendment, ArbitraryExpressionDate
 
 
 @override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
@@ -120,6 +121,50 @@ class WorksTest(testcases.TestCase):
         doc = work.expressions().filter(expression_date=datetime.date(2019, 1, 1)).first()
         self.assertEqual(doc.draft, True)
         self.assertNotIn('tester', doc.content)
+
+    def test_no_consolidation_at_existing_amendment(self):
+        amendment = Amendment(amended_work_id=1, amending_work_id=2, date='2019-01-01', created_by_user_id=1)
+        amendment.save()
+
+        response = self.client.post('/works/za/act/2014/10/arbitrary_expression_dates/new', {
+            'date': '2019-01-01',
+            'work': '1'
+        })
+        self.assertEqual(response.status_code, 302)
+
+        work = Work.objects.get(pk=1)
+        # check that consolidation wasn't saved
+        self.assertQuerysetEqual(ArbitraryExpressionDate.objects.filter(work=work), [])
+
+    def test_get_work_timeline(self):
+        view = WorkViewBase()
+        work = Work.objects.get(pk=1)
+        work.assent_date = datetime.date(2014, 3, 20)
+        amendment = Amendment(amended_work_id=1, amending_work_id=2, date='2019-01-01', created_by_user_id=1)
+        amendment.save()
+
+        consolidation = ArbitraryExpressionDate(work=work, date='2018-01-01', created_by_user_id=1)
+        consolidation.save()
+
+        timeline = WorkViewBase.get_work_timeline(view, work)
+        # most recent event first
+        self.assertEqual(timeline[0]['date'], datetime.date(2019, 1, 1))
+        self.assertEqual(timeline[0]['amendments'][0].date, datetime.date(2019, 1, 1))
+        self.assertEqual(timeline[0]['initial'], False)
+
+        # consolidation
+        self.assertEqual(timeline[1]['date'], datetime.date(2018, 1, 1))
+        self.assertEqual(timeline[1]['consolidations'][0].date, datetime.date(2018, 1, 1))
+        self.assertEqual(timeline[1]['initial'], False)
+
+        # publication date on fixture
+        self.assertEqual(timeline[2]['date'], datetime.date(2014, 4, 2))
+        self.assertEqual(timeline[2]['publication_date'], True)
+        self.assertEqual(timeline[2]['initial'], True)
+
+        # assent date (oldest)
+        self.assertEqual(timeline[-1]['date'], datetime.date(2014, 3, 20))
+        self.assertEqual(timeline[-1]['assent_date'], True)
 
 
 @override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')


### PR DESCRIPTION
closes #952 

still to do:
- [ ] use possible_expression_dates() in metrics
- [ ] check what else uses points_in_time() and whether it can use possible_expression_dates() instead, or needs something else
- [ ] get rid of amendments_initial_commencement_arbitrary() and points_in_time() on Work