### PR TITLE
Remember finished session nonces across browser tabs

### DIFF
--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -301,6 +301,11 @@ class DocumentActivityViewSet(DocumentResourceView,
         return super(DocumentActivityViewSet, self).list(request, *args, **kwargs)
 
     def create(self, request, *args, **kwargs):
+        # if they've provided additional finished nonces, clear those out
+        if request.data.get('finished_nonces'):
+            nonces = request.data['finished_nonces'].split(',')
+            self.get_queryset().filter(user=request.user, nonce__in=nonces).delete()
+
         # either create a new activity object, or update it
         self.get_queryset().update_or_create(
             document=self.document, user=request.user, nonce=request.data['nonce'],

--- a/indigo_app/static/javascript/indigo/views/document_activity.js
+++ b/indigo_app/static/javascript/indigo/views/document_activity.js
@@ -125,7 +125,7 @@
           if (data) {
             try {
               data = JSON.parse(data);
-            } catch {
+            } catch(err) {
               localStorage.removeItem(key);
               continue;
             }


### PR DESCRIPTION
This fixes the issue where the window unload event cannot send its
DELETE call to the server. Instead, we remember that a session was finished
by storing the document id and nonce in the browser's localStorage.

The next time the same user opens that document in the same browser,
it tells the server that those old sessions are dead.