### PR TITLE
Send errors to server, rather than GA

### DIFF
--- a/indigo_app/static/javascript/indigo.js
+++ b/indigo_app/static/javascript/indigo.js
@@ -64,12 +64,17 @@ $(function() {
 
   // error tracking with GA
   window.addEventListener('error', function(e) {
-    if (typeof ga === 'function') {
-      ga('send', 'exception', {
-        'exDescription': e.message + ' @ ' + e.filename + ': ' + e.lineno,
-        'exFatal': true,
-      });
-    }
+    $.ajax({
+      type: 'POST',
+      url: '/jserror',
+      data: {
+        message: e.message,
+        filename: e.filename,
+        lineno: e.lineno,
+        colno: e.colno,
+      },
+      global: false,
+    });
   });
 
   // datepicker

--- a/indigo_app/static/javascript/indigo.js
+++ b/indigo_app/static/javascript/indigo.js
@@ -72,6 +72,8 @@ $(function() {
         filename: e.filename,
         lineno: e.lineno,
         colno: e.colno,
+        url: document.location.href,
+        stack: e.error.stack,
       },
       global: false,
     });

--- a/indigo_app/static/javascript/indigo/views/document.js
+++ b/indigo_app/static/javascript/indigo/views/document.js
@@ -143,7 +143,7 @@
       this.document.on('change:draft', this.draftChanged, this);
 
       this.documentContent = new Indigo.DocumentContent({document: this.document});
-      this.documentContentx.on('change', this.setDirty, this);
+      this.documentContent.on('change', this.setDirty, this);
 
       this.cheatsheetView = new Indigo.CheatsheetView();
       this.titleView = new Indigo.DocumentTitleView({model: this.document});

--- a/indigo_app/static/javascript/indigo/views/document.js
+++ b/indigo_app/static/javascript/indigo/views/document.js
@@ -143,7 +143,7 @@
       this.document.on('change:draft', this.draftChanged, this);
 
       this.documentContent = new Indigo.DocumentContent({document: this.document});
-      this.documentContent.on('change', this.setDirty, this);
+      this.documentContentx.on('change', this.setDirty, this);
 
       this.cheatsheetView = new Indigo.CheatsheetView();
       this.titleView = new Indigo.DocumentTitleView({model: this.document});

--- a/indigo_app/urls.py
+++ b/indigo_app/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url, include
 from django.views.generic.base import RedirectView, TemplateView
 
-from .views import users, works, documents, tasks, places, workflows
+from .views import users, works, documents, tasks, places, workflows, misc
 
 
 urlpatterns = [
@@ -82,5 +82,6 @@ urlpatterns = [
     url(r'^tasks/available/$', tasks.AvailableTasksView.as_view(), name='available_tasks'),
 
     url(r'^comments/', include('django_comments.urls')),
+    url(r'^jserror$', misc.JSErrorView.as_view(), name='jserror'),
 
 ]

--- a/indigo_app/views/misc.py
+++ b/indigo_app/views/misc.py
@@ -14,7 +14,14 @@ class JSErrorView(AbstractAuthedIndigoView, View):
     authentication_required = True
 
     def post(self, request, *args, **kwargs):
-        info = request.POST.dict()
+        # ensure empty value for expected variables
+        info = {k: request.POST.get(k, '') for k in ['message', 'url', 'filename', 'lineno', 'colno', 'stack']}
+
         # This will email the admins if the 'mail_admin' logging handler is enabled.
-        log.error(f"JS error:\n\n{info['message']}\n\n{info['filename']} @ {info['lineno']}:{info['colno']}")
+        log.error(f"""JS error: {info['message']}
+URL: {info['url']}
+File: {info['filename']} @ {info['lineno']}:{info['colno']}
+
+{info['stack']}
+""")
         return HttpResponse(status=200)

--- a/indigo_app/views/misc.py
+++ b/indigo_app/views/misc.py
@@ -1,0 +1,20 @@
+import logging
+
+from django.http import HttpResponse
+from django.views.generic import View
+
+from indigo_app.views.base import AbstractAuthedIndigoView
+
+
+log = logging.getLogger(__name__)
+
+
+class JSErrorView(AbstractAuthedIndigoView, View):
+    http_method_names = ['post']
+    authentication_required = True
+
+    def post(self, request, *args, **kwargs):
+        info = request.POST.dict()
+        # This will email the admins if the 'mail_admin' logging handler is enabled.
+        log.error(f"JS error:\n\n{info['message']}\n\n{info['filename']} @ {info['lineno']}:{info['colno']}")
+        return HttpResponse(status=200)


### PR DESCRIPTION
Currently, we don't see what we send to Google Analytics, and these are lost if GA isn't installed.

Instead, use the global error handler mechanism to mail the admins on a JS error.

Example:
```
2020-03-08 13:12:29,208 ERROR misc 22590 123145561239552 JS error: Uncaught TypeError: Cannot read property 'on' of undefined
URL: http://localhost:8000/documents/113/
File: http://localhost:8000/static/javascript/indigo/views/document.js @ 146:29
Stack:
TypeError: Cannot read property 'on' of undefined
    at child.initialize (http://localhost:8000/static/javascript/indigo/views/document.js:146:29)
    at child.Backbone.View (http://localhost:8000/static/bower_components/backbone/backbone.js:1224:21)
    at new child (http://localhost:8000/static/bower_components/backbone/backbone.js:1884:41)
    at http://localhost:8000/static/javascript/indigo.js:147:18
    at Function.m.map.m.collect (http://localhost:8000/static/bower_components/underscore/underscore-min.js:5:2566)
    at HTMLDocument.<anonymous> (http://localhost:8000/static/javascript/indigo.js:145:29)
    at j (http://localhost:8000/static/bower_components/jquery/dist/jquery.min.js:2:26911)
    at Object.fireWith [as resolveWith] (http://localhost:8000/static/bower_components/jquery/dist/jquery.min.js:2:27724)
    at Function.ready (http://localhost:8000/static/bower_components/jquery/dist/jquery.min.js:2:29518)
    at HTMLDocument.I (http://localhost:8000/static/bower_components/jquery/dist/jquery.min.js:2:29709)

```