### PR TITLE
Fix revisions bug

### DIFF
--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -246,7 +246,7 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
     publication_date = serializers.DateField(read_only=True)
     commencement_date = serializers.DateField(read_only=True)
     assent_date = serializers.DateField(read_only=True)
-    numbered_title = serializers.DateField(read_only=True, source='work.numbered_title')
+    numbered_title = serializers.CharField(read_only=True, source='work.numbered_title')
 
     tags = TagListSerializerField(required=False)
     amendments = AmendmentEventSerializer(many=True, read_only=True, source='amendment_events')

--- a/indigo_app/revisions.py
+++ b/indigo_app/revisions.py
@@ -15,6 +15,13 @@ def decorate_versions(versions, ignore=IGNORE_FIELDS):
                 if fld in d:
                     del d[fld]
 
+        for d in [curr_d, prev_d]:
+            for fld in d:
+                try:
+                    d[fld] = d[fld].isoformat()
+                except AttributeError:
+                    pass
+
         patch = jsonpatch.make_patch(curr_d, prev_d)
 
         curr.previous = prev


### PR DESCRIPTION
jsonpatch now uses json.dumps, so we need to turn our date objects into strings before getting the patch