### PR TITLE
Fix table edit bug

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -161,7 +161,7 @@
     },
 
     setComparisonDocumentId: function(id) {
-      this.comparisonDocumentid = id;
+      this.comparisonDocumentId = id;
       this.render();
     },
 
@@ -414,12 +414,11 @@
     },
 
     renderComparisonDiff: function() {
-      // TODO: decide what to compare it against
       var self = this,
           $akn = this.$('.document-workspace-content .akoma-ntoso'),
           data = {};
 
-      if (this.comparisonDocumentid === null) return;
+      if (!this.comparisonDocumentId) return;
 
       data.document = this.parent.model.toJSON();
       data.document.content = this.parent.documentContent.toXml();
@@ -430,9 +429,8 @@
         data.element_id = this.parent.fragment.tagName;
       }
 
-      // HACK HACK HACK
       $.ajax({
-        url: '/api/documents/' + this.comparisonDocumentid + '/diff',
+        url: '/api/documents/' + this.comparisonDocumentId + '/diff',
         type: "POST",
         data: JSON.stringify(data),
         contentType: "application/json; charset=utf-8",

--- a/indigo_app/static/javascript/indigo/views/table_editor.js
+++ b/indigo_app/static/javascript/indigo/views/table_editor.js
@@ -161,7 +161,7 @@
         $(table).closest('.table-editor-wrapper').addClass('table-editor-active');
 
         editable = table.parentElement;
-        editable.contentEditable = true;
+        editable.contentEditable = 'true';
 
         CKEDITOR.on('instanceReady', function(evt) {
           evt.removeListener();
@@ -181,7 +181,8 @@
         this.observers.forEach(function(observer) { observer.disconnect(); });
         this.observers = [];
 
-        this.table.parentElement.contentEditable = false;
+        // don't break if our table has, for some reason, got abandoned and has no parent
+        if (this.table.parentElement) this.table.parentElement.contentEditable = 'false';
         $(this.table).closest('.table-editor-wrapper').removeClass('table-editor-active');
 
         this.ckeditor.destroy();

--- a/indigo_app/static/xsl/html_to_akn.xsl
+++ b/indigo_app/static/xsl/html_to_akn.xsl
@@ -10,7 +10,7 @@
 
   <xsl:template match="html:table">
     <table>
-      <xsl:apply-templates select="@id | //html:tr" />
+      <xsl:apply-templates select="@data-id | //html:tr" />
     </table>
   </xsl:template>
 
@@ -81,8 +81,13 @@
 
   <!-- attributes -->
 
-  <xsl:template match="@id | @colspan | @rowspan | @style | @class">
+  <xsl:template match="@colspan | @rowspan | @style | @class">
     <xsl:attribute name="{name(.)}"><xsl:value-of select="." /></xsl:attribute>
+  </xsl:template>
+
+  <!-- map data-id to id -->
+  <xsl:template match="@data-id">
+    <xsl:attribute name="id"><xsl:value-of select="." /></xsl:attribute>
   </xsl:template>
 
   <!-- text -->


### PR DESCRIPTION
Fixes an issue where editing a table in a schedule in wysiwyg mode gives the table an incorrect id, and breaks further editing.

Also guards against broken table editing, and fixes a small comparison bug.