### PR TITLE
Toggle bold and italics in table editor view

### DIFF
--- a/indigo_app/static/stylesheets/_documents.scss
+++ b/indigo_app/static/stylesheets/_documents.scss
@@ -360,8 +360,7 @@ button.btn-link.help {
   }
 
   .table-editor-buttons {
-    padding: 5px 0px;
-    margin: 0px 2px;
+    margin: 5px 0px;
   }
 
   .when-active {
@@ -379,10 +378,17 @@ button.btn-link.help {
 
     .table-editor-buttons {
       position: sticky;
-      top: -23px;
+      top: -18px;
       background-color: white;
       z-index: 10;
     }
+  }
+}
+
+// hide the CKEditor toolbar
+.document-editor-view {
+  .cke.cke_float {
+    display: none !important;
   }
 }
 

--- a/indigo_app/templates/indigo_api/document/_toolbar.html
+++ b/indigo_app/templates/indigo_api/document/_toolbar.html
@@ -152,12 +152,17 @@
         </div>
       </div>
 
-      <div class="btn-group btn-group-sm">
+      <div class="btn-group btn-group-sm mr-2">
         <button type="button" class="btn btn-outline-secondary table-text-left"><i class="fas fa-align-left"></i></button>
         <button type="button" class="btn btn-outline-secondary table-text-center"><i class="fas fa-align-center"></i></button>
         <button type="button" class="btn btn-outline-secondary table-text-right"><i class="fas fa-align-right"></i></button>
         <button type="button" class="btn btn-outline-secondary table-merge-cells">Merge cells</button>
         <button type="button" class="btn btn-outline-secondary table-toggle-heading"><i class="fas fa-heading"></i> Heading</button>
+      </div>
+
+      <div class="btn-group btn-group-sm">
+        <button type="button" class="btn btn-outline-secondary table-text-bold"><i class="fas fa-bold"></i></button>
+        <button type="button" class="btn btn-outline-secondary table-text-italic"><i class="fas fa-italic"></i></button>
       </div>
     </div>
   </div>

--- a/indigo_app/templates/indigo_api/document/show.html
+++ b/indigo_app/templates/indigo_api/document/show.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block title %}{{ document.title }}{% endblock %}
-{% block body-class %}{{ block.super }} no-site-footer sidebar-minimized
+{% block body-class %}{{ block.super }} document-editor-view no-site-footer sidebar-minimized
   {% if document.draft %}is-draft{% else %}is-published{% endif %}
   {% if work.repealed_date %}is-repealed{% endif %}
 {% endblock %}


### PR DESCRIPTION
We add our own buttons because the CKEditor toolbar is placed
over our own toolbar, and we can't move it.