### PR TITLE
Simplify numbered title exceptions

### DIFF
--- a/indigo/analysis/work_detail/base.py
+++ b/indigo/analysis/work_detail/base.py
@@ -11,14 +11,24 @@ class BaseWorkDetail(LocaleBasedMatcher):
     Subclasses should implement `work_numbered_title`.
     """
 
+    no_numbered_title_subtypes = []
+    """ These subtypes don't have numbered titles. """
+    no_numbered_title_numbers = ['constitution']
+    """ These numbers don't have numbered titles. """
+
     def work_numbered_title(self, work):
         """ Return a formatted title using the number for this work, such as "Act 5 of 2009".
         This usually differs from the short title. May return None.
         """
+        # these don't have numbered titles
         number = work.number
-        if number == 'constitution':
+        if number in self.no_numbered_title_numbers:
             return None
-        uri = work.work_uri
+
+        # these don't have numbered titles
+        if work.work_uri.subtype in self.no_numbered_title_subtypes:
+            return None
+
         work_type = self.work_friendly_type(work)
         return _('%(type)s %(number)s of %(year)s') % {'type': _(work_type), 'number': number, 'year': work.year}
 

--- a/indigo_za/work_detail.py
+++ b/indigo_za/work_detail.py
@@ -7,35 +7,20 @@ from indigo_api.models import Subtype
 class WorkDetailZA(BaseWorkDetail):
     locale = ('za', None, None)
     """ Locale for this object, as a tuple: (country, language, locality). None matches anything."""
-
-    def work_numbered_title(self, work):
-        uri = work.work_uri
-
-        # by-laws don't have numbered titles
-        if uri.subtype == 'by-law':
-            return None
-
-        return super().work_numbered_title(work)
+    no_numbered_title_subtypes = ['by-law', 'mo']
 
 
 @plugins.register('work-detail')
-class WorkDetailZAAfr(BaseWorkDetail):
+class WorkDetailZAAfr(WorkDetailZA):
     locale = ('za', 'afr', None)
     """ Locale for this object, as a tuple: (country, language, locality). None matches anything."""
 
     def work_numbered_title(self, work):
-        uri = work.work_uri
-
-        # by-laws don't have numbered titles
-        if uri.subtype == 'by-law':
-            return None
+        if not super().work_numbered_title(work):
+            return
 
         number = work.number
-        if number == 'constitution':
-            return None
-
         work_type = self.work_friendly_type(work)
-
         return f'{work_type} {number} van {work.year}'
 
     def work_friendly_type(self, work):


### PR DESCRIPTION
This removes the "Ministerial Order xxx of 2019" from regs.