### PR TITLE
Uppercase work number

### DIFF
--- a/indigo/analysis/work_detail/base.py
+++ b/indigo/analysis/work_detail/base.py
@@ -30,7 +30,7 @@ class BaseWorkDetail(LocaleBasedMatcher):
             return None
 
         work_type = self.work_friendly_type(work)
-        return _('%(type)s %(number)s of %(year)s') % {'type': _(work_type), 'number': number, 'year': work.year}
+        return _('%(type)s %(number)s of %(year)s') % {'type': _(work_type), 'number': number.upper(), 'year': work.year}
 
     def work_friendly_type(self, work):
         """ Return a friendly document type for this work, such as "Act" or "By-law".

--- a/indigo/tests/test_work_detail.py
+++ b/indigo/tests/test_work_detail.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from indigo.analysis.work_detail import BaseWorkDetail
+from indigo_api.models import Work
+
+
+class BaseWorkDetailTestCase(TestCase):
+    fixtures = ['countries']
+
+    def setUp(self):
+        self.plugin = BaseWorkDetail()
+
+    def test_numbered_title_simple(self):
+        work = Work(frbr_uri='/za/act/1999/32')
+        self.assertEqual('Act 32 of 1999', self.plugin.work_numbered_title(work))
+
+    def test_numbered_title_caps(self):
+        work = Work(frbr_uri='/za/act/gn/1999/r32')
+        self.assertEqual('Government Notice R32 of 1999', self.plugin.work_numbered_title(work))
+
+    def test_numbered_title_none(self):
+        work = Work(frbr_uri='/za/act/1999/constitution')
+        self.assertIsNone(self.plugin.work_numbered_title(work))
+
+    def test_numbered_title_ignore_subtype(self):
+        plugin = BaseWorkDetail()
+        plugin.no_numbered_title_subtypes = ['gn']
+        work = Work(frbr_uri='/za/act/gn/1999/32')
+        self.assertIsNone(plugin.work_numbered_title(work))

--- a/indigo_za/work_detail.py
+++ b/indigo_za/work_detail.py
@@ -19,7 +19,7 @@ class WorkDetailZAAfr(WorkDetailZA):
         if not super().work_numbered_title(work):
             return
 
-        number = work.number
+        number = work.number.upper()
         work_type = self.work_friendly_type(work)
         return f'{work_type} {number} van {work.year}'
 


### PR DESCRIPTION
FRBR URIs are lowercase. This change means that notices such as
/za/act/gn/1999/r32 becomes "GN R32". This is the better case for when
the number contains letters.

For work subtypes where the number is ONLY letters (eg. a by-law), we
already opt out of those having numbered titles.