### PR TITLE
Ensure rows have entries for all headers

### DIFF
--- a/indigo/bulk_creator.py
+++ b/indigo/bulk_creator.py
@@ -161,9 +161,11 @@ class BaseBulkCreator(LocaleBasedMatcher):
         # clean up headers
         headers = [h.split(' ')[0].lower() for h in table[0]]
 
-        # transform rows into list of dicts for easy access
+        # Transform rows into list of dicts for easy access.
+        # The rows in table only have entries up to the last non-empty cell,
+        # so we ensure that we have at least an empty string for every header.
         rows = [
-            {header: row[i] for i, header in enumerate(headers) if header and i < len(row)}
+            {header: (row[i] if i < len(row) else '') for i, header in enumerate(headers) if header}
             for row in table[1:]
         ]
 


### PR DESCRIPTION
This fixes an issue where the last text value in a row comes before
the last column, eg. commencement date is filled in, but columns such
as stub come after that. Before this fix, the stub column would
not have been included at all, and so it assumes that 'stub' wasn't
present in the spreadsheet, so falls back to checking for the old
'principal' value.

Now, we correctly see that stub is present and so don't override it.