### PR TITLE
validate spreadsheet url

### DIFF
--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -1,4 +1,5 @@
 import json
+import re
 import urllib.parse
 from datetime import date
 
@@ -554,6 +555,10 @@ class PlaceSettingsForm(forms.ModelForm):
     spreadsheet_url = forms.URLField(required=False, validators=[
         URLValidator(
             schemes=['https'],
-            regex='^https:\/\/docs.google.com\/spreadsheets\/d\/\S+\/',
+            regex='^https:\/\/docs.google.com\/spreadsheets\/d\/\S+\/[\w#=]*',
             message="Please enter a valid Google Sheets URL, such as https://docs.google.com/spreadsheets/d/ABCXXX/", code='bad')
     ])
+
+    def clean_spreadsheet_url(self):
+        url = self.cleaned_data.get('spreadsheet_url')
+        return re.sub('/[\w#=]*$', '/', url)

--- a/indigo_app/forms.py
+++ b/indigo_app/forms.py
@@ -14,7 +14,7 @@ from allauth.account.forms import SignupForm
 from indigo_app.models import Editor
 from indigo_api.models import Document, Country, Language, Work, PublicationDocument, Task, TaskLabel, User, Subtype, \
     Workflow, \
-    VocabularyTopic, Commencement
+    VocabularyTopic, Commencement, PlaceSettings
 
 
 class WorkForm(forms.ModelForm):
@@ -544,3 +544,16 @@ class NewCommencementForm(forms.ModelForm):
         if not self.cleaned_data['date'] and not self.cleaned_data['commencing_work']:
             # create one for now
             self.cleaned_data['date'] = date.today()
+
+
+class PlaceSettingsForm(forms.ModelForm):
+    class Meta:
+        model = PlaceSettings
+        fields = ('spreadsheet_url', 'as_at_date', 'styleguide_url')
+
+    spreadsheet_url = forms.URLField(required=False, validators=[
+        URLValidator(
+            schemes=['https'],
+            regex='^https:\/\/docs.google.com\/spreadsheets\/d\/\S+\/',
+            message="Please enter a valid Google Sheets URL, such as https://docs.google.com/spreadsheets/d/ABCXXX/", code='bad')
+    ])

--- a/indigo_app/templates/place/settings.html
+++ b/indigo_app/templates/place/settings.html
@@ -27,7 +27,7 @@
         <div class="form-row">
           <div class="form-group col-md-4">
             <label for="{{ form.as_at_date.id_for_label }}">{{ form.as_at_date.label }}</label>
-            <input type="text" class="form-control" data-provide="datepicker" id="{{ form.as_at_date.id_for_label }}" placeholder="yyyy-mm-dd" pattern="\d{4}-\d\d-\d\d" name="{{ form.as_at_date.html_name }}" value="{{ form.as_at_date.value|date:"Y-m-d"|default:'' }}">
+            <input type="text" class="form-control" data-provide="datepicker" id="{{ form.as_at_date.id_for_label }}" placeholder="yyyy-mm-dd" pattern="\d{4}-\d\d-\d\d" name="{{ form.as_at_date.html_name }}" value="{{ form.as_at_date.value|default_if_none:''|stringformat:'s' }}">
             <p class="form-text text-muted">Date up to which all works have been consolidated.</p>
             {% if form.as_at_date.errors %}
               <div class="text-danger">

--- a/indigo_app/tests/test_places.py
+++ b/indigo_app/tests/test_places.py
@@ -67,3 +67,15 @@ class PlacesWebTest(WebTest):
         form['spreadsheet_url'].value = 'https://docs.google.com/spreadsheets/d/12auCcgbt6WYUsqt8m2uyRDQUYrYS-9iDmRDd-QqvqNQ/edit#gid=1003990263'
         form = form.submit().follow().forms[0]
         self.assertEqual(form['spreadsheet_url'].value, 'https://docs.google.com/spreadsheets/d/12auCcgbt6WYUsqt8m2uyRDQUYrYS-9iDmRDd-QqvqNQ/')
+
+    def test_place_settings_spreadsheet_url_bad(self):
+        form = self.app.get('/places/za/settings').forms[0]
+        form['spreadsheet_url'].value = 'https://docs.google.com/spreadsheets/d/12auCcgbt6WYUsqt8m2uyRDQUYrYS-9iDmRDd-QqvqNQ'
+        form['as_at_date'].value = '2020-01-01'
+        form['styleguide_url'].value = 'https://docs.laws.africa/style-guides/south-african-by-laws'
+        form = form.submit().forms[0]
+        # form should reload with all current values plus error message
+        self.assertIn('Please enter a valid Google Sheets URL, such as https://docs.google.com/spreadsheets/d/ABCXXX/', form.html.text)
+        self.assertEqual(form['spreadsheet_url'].value, 'https://docs.google.com/spreadsheets/d/12auCcgbt6WYUsqt8m2uyRDQUYrYS-9iDmRDd-QqvqNQ')
+        self.assertEqual(form['as_at_date'].value, '2020-01-01')
+        self.assertEqual(form['styleguide_url'].value, 'https://docs.laws.africa/style-guides/south-african-by-laws')

--- a/indigo_app/tests/test_places.py
+++ b/indigo_app/tests/test_places.py
@@ -54,10 +54,10 @@ class PlacesWebTest(WebTest):
 
     def test_place_settings(self):
         form = self.app.get('/places/za/settings').forms[0]
-        form['spreadsheet_url'].value = 'https://docs.google.com/spreadsheets/u/1/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/edit'
+        form['spreadsheet_url'].value = 'https://docs.google.com/spreadsheets/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/'
         form['as_at_date'].value = '2019-01-01'
         form['styleguide_url'].value = 'https://docs.laws.africa/editing-a-document/importing-a-document'
         form = form.submit().follow().forms[0]
-        self.assertEqual(form['spreadsheet_url'].value, 'https://docs.google.com/spreadsheets/u/1/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/edit')
+        self.assertEqual(form['spreadsheet_url'].value, 'https://docs.google.com/spreadsheets/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/')
         self.assertEqual(form['as_at_date'].value, '2019-01-01')
         self.assertEqual(form['styleguide_url'].value, 'https://docs.laws.africa/editing-a-document/importing-a-document')

--- a/indigo_app/tests/test_places.py
+++ b/indigo_app/tests/test_places.py
@@ -57,8 +57,7 @@ class PlacesWebTest(WebTest):
         form['spreadsheet_url'].value = 'https://docs.google.com/spreadsheets/u/1/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/edit'
         form['as_at_date'].value = '2019-01-01'
         form['styleguide_url'].value = 'https://docs.laws.africa/editing-a-document/importing-a-document'
-        form = form.submit().forms[0]
-
+        form = form.submit().follow().forms[0]
         self.assertEqual(form['spreadsheet_url'].value, 'https://docs.google.com/spreadsheets/u/1/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/edit')
         self.assertEqual(form['as_at_date'].value, '2019-01-01')
         self.assertEqual(form['styleguide_url'].value, 'https://docs.laws.africa/editing-a-document/importing-a-document')

--- a/indigo_app/tests/test_places.py
+++ b/indigo_app/tests/test_places.py
@@ -57,7 +57,8 @@ class PlacesWebTest(WebTest):
         form['spreadsheet_url'].value = 'https://docs.google.com/spreadsheets/u/1/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/edit'
         form['as_at_date'].value = '2019-01-01'
         form['styleguide_url'].value = 'https://docs.laws.africa/editing-a-document/importing-a-document'
-        form = form.submit().follow().forms[0]
+        form = form.submit().forms[0]
+
         self.assertEqual(form['spreadsheet_url'].value, 'https://docs.google.com/spreadsheets/u/1/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/edit')
         self.assertEqual(form['as_at_date'].value, '2019-01-01')
         self.assertEqual(form['styleguide_url'].value, 'https://docs.laws.africa/editing-a-document/importing-a-document')

--- a/indigo_app/tests/test_places.py
+++ b/indigo_app/tests/test_places.py
@@ -61,3 +61,9 @@ class PlacesWebTest(WebTest):
         self.assertEqual(form['spreadsheet_url'].value, 'https://docs.google.com/spreadsheets/d/1a2o-842lGliSwlLo3gSbYSRbaOYu-2PZhC1rOf8MgA4/')
         self.assertEqual(form['as_at_date'].value, '2019-01-01')
         self.assertEqual(form['styleguide_url'].value, 'https://docs.laws.africa/editing-a-document/importing-a-document')
+
+    def test_place_settings_spreadsheet_url_cleaned(self):
+        form = self.app.get('/places/za/settings').forms[0]
+        form['spreadsheet_url'].value = 'https://docs.google.com/spreadsheets/d/12auCcgbt6WYUsqt8m2uyRDQUYrYS-9iDmRDd-QqvqNQ/edit#gid=1003990263'
+        form = form.submit().follow().forms[0]
+        self.assertEqual(form['spreadsheet_url'].value, 'https://docs.google.com/spreadsheets/d/12auCcgbt6WYUsqt8m2uyRDQUYrYS-9iDmRDd-QqvqNQ/')

--- a/indigo_app/views/places.py
+++ b/indigo_app/views/places.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import logging
 from collections import defaultdict, Counter
-from datetime import datetime, timedelta, date
+from datetime import timedelta, date
 from itertools import chain, groupby
 import json
 
@@ -20,13 +20,13 @@ from django.views.generic.list import MultipleObjectMixin
 import io
 import xlsxwriter
 
-from indigo_api.models import Annotation, Country, PlaceSettings, Task, Work, Amendment, Subtype, Locality, TaskLabel
+from indigo_api.models import Annotation, Country, Task, Work, Amendment, Subtype, Locality, TaskLabel
 from indigo_api.views.documents import DocumentViewSet
 from indigo_metrics.models import DailyWorkMetrics, WorkMetrics, DailyPlaceMetrics
 
 from .base import AbstractAuthedIndigoView, PlaceViewBase
 
-from indigo_app.forms import WorkFilterForm
+from indigo_app.forms import WorkFilterForm, PlaceSettingsForm
 
 log = logging.getLogger(__name__)
 
@@ -691,16 +691,14 @@ class PlaceMetricsView(PlaceViewBase, AbstractAuthedIndigoView, TemplateView, Pl
 
 class PlaceSettingsView(PlaceViewBase, AbstractAuthedIndigoView, UpdateView):
     template_name = 'place/settings.html'
-    model = PlaceSettings
+    form_class = PlaceSettingsForm
     tab = 'place_settings'
 
     # permissions
     # TODO: this should be scoped to the country/locality
     permission_required = ('indigo_api.change_placesettings',)
 
-    fields = ('spreadsheet_url', 'as_at_date', 'styleguide_url')
-
-    def get_object(self):
+    def get_object(self, *args, **kwargs):
         return self.place.settings
 
     def form_valid(self, form):


### PR DESCRIPTION
The only annoying thing is that if an invalid URL is given, the as-at date clears. If the URL is then fixed and the form saved again, the empty as-at date value is saved.

I'm guessing we could fix this by messing with `form_invalid()`; does that sound right?
 
![image](https://user-images.githubusercontent.com/32566441/78264165-1d96df80-7503-11ea-97c1-0220f8098152.png)
