### PR TITLE
FIX ensure ids for 'show source' dropdowns

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_source_att.js
+++ b/indigo_app/static/javascript/indigo/views/document_source_att.js
@@ -42,11 +42,14 @@
         this.amendments = _.filter(Indigo.Preloads.amendments, function(am) {
           return am.amending_work.publication_document && am.amending_work.publication_document.url;
         }).map(function(am) {
-          return {
+          var x = {
             'title': am.date + ' – ' + am.amending_work.frbr_uri,
             'url': am.amending_work.publication_document.url,
             'group': 'Amendments',
           };
+          // something to make it unique
+          x.id = x.title;
+          return x;
         });
         this.amendments = _.sortBy(this.amendments, 'date').reverse();
       },


### PR DESCRIPTION
Without this, you can't select the two different amendments in https://edit.laws.africa/documents/3840/ for example.