### PR TITLE
Correctly handle work without a publication document

### DIFF
--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -152,6 +152,13 @@ class WorksTest(testcases.TestCase):
         self.assertEqual(timeline[-1]['date'], datetime.date(2014, 3, 20))
         self.assertEqual(timeline[-1]['assent_date'], True)
 
+    def test_no_publication_document(self):
+        # this work has no publication document
+        resp = self.client.get('/works/za/act/2010/1/media/publication/')
+        self.assertEqual(resp.status_code, 404)
+        resp = self.client.get('/works/za/act/2010/1/media/publication/test.pdf')
+        self.assertEqual(resp.status_code, 404)
+
 
 @override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
 class WorksWebTest(WebTest):

--- a/indigo_app/urls.py
+++ b/indigo_app/urls.py
@@ -72,7 +72,7 @@ urlpatterns = [
     url(r'^works(?P<frbr_uri>/\S+?)/revisions/$', works.WorkVersionsView.as_view(), name='work_versions'),
     url(r'^works(?P<frbr_uri>/\S+?)/tasks/$', works.WorkTasksView.as_view(), name='work_tasks'),
     url(r'^works(?P<frbr_uri>/\S+?)/revisions/(?P<version_id>\d+)/restore$', works.RestoreWorkVersionView.as_view(), name='work_restore_version'),
-    url(r'^works(?P<frbr_uri>/\S+?)/media/publication/(?P<filename>.*)$', works.WorkPublicationDocumentView.as_view(), name='work_publication_document'),
+    url(r'^works(?P<frbr_uri>/\S+?)/media/publication/(?P<filename>.+)$', works.WorkPublicationDocumentView.as_view(), name='work_publication_document'),
     url(r'^works(?P<frbr_uri>/\S+?)/$', works.WorkOverviewView.as_view(), name='work'),
 
     url(r'^documents/(?P<doc_id>\d+)/$', documents.DocumentDetailView.as_view(), name='document'),

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -796,10 +796,13 @@ class RestoreWorkVersionView(WorkViewBase, DetailView):
 
 class WorkPublicationDocumentView(WorkViewBase, View):
     def get(self, request, filename, *args, **kwargs):
-        if self.work.publication_document and self.work.publication_document.filename == filename:
-            if self.work.publication_document.trusted_url:
-                return redirect(self.work.publication_document.trusted_url)
-            return view_attachment(self.work.publication_document)
+        try:
+            if self.work.publication_document.filename == filename:
+                if self.work.publication_document.trusted_url:
+                    return redirect(self.work.publication_document.trusted_url)
+                return view_attachment(self.work.publication_document)
+        except PublicationDocument.DoesNotExist:
+            pass
         raise Http404()
 
 


### PR DESCRIPTION
This fixes the link https://edit.laws.africa/works/za/act/1993/45/media/publication/ that should return a 404, but currently errors with this stack trace:

```
File "/app/.heroku/src/indigo/indigo_app/views/works.py" in get
  799.         if self.work.publication_document and self.work.publication_document.filename == filename:

File "/app/.heroku/python/lib/python3.6/site-packages/django/db/models/fields/related_descriptors.py" in __get__
  407.                     self.related.get_accessor_name()

Exception Type: RelatedObjectDoesNotExist at /works/za/act/1993/45/media/publication/
Exception Value: Work has no publication_document.
```