### PR TITLE
Fix Workflow Pagination Bug

### DIFF
--- a/indigo_app/templates/indigo_api/workflow_list.html
+++ b/indigo_app/templates/indigo_api/workflow_list.html
@@ -107,15 +107,15 @@
     <nav class="mt-3">
       <ul class="pagination justify-content-center">
         {% if page_obj.has_previous %}
-          <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a></li>
+          <li class="page-item"><a class="page-link" href="?state={{ form.state.value }}&page={{ page_obj.previous_page_number }}">Previous</a></li>
         {% endif %}
 
         {% for num in paginator.page_range %}
-        <li class="page-item {% if num == page_obj.number %}active{% endif %}"><a class="page-link" href="?page={{ num }}">{{ num }}</a></li>
+        <li class="page-item {% if num == page_obj.number %}active{% endif %}"><a class="page-link" href="?state={{ form.state.value }}&page={{ num }}">{{ num }}</a></li>
         {% endfor %}
 
         {% if page_obj.has_next %}
-          <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a></li>
+          <li class="page-item"><a class="page-link" href="?state={{ form.state.value }}&page={{ page_obj.next_page_number }}">Next</a></li>
         {% endif %}
       </ul>
     </nav>


### PR DESCRIPTION
#### Description
For instance: https://edit.laws.africa/places/na/workflows/?state=closed – clicking `2` or `Next` takes you to https://edit.laws.africa/places/na/workflows/?page=2 instead of https://edit.laws.africa/places/na/workflows/?state=closed&page=2

The closed state filter gets omitted when navigating to different pages of closed workflows.

#### How should this be manually tested
With a sufficient number of closed workflows, navigate the different pages using the paginator at the bottom. 

#### Any background context you want to provide?
The state filter was being omitted when moving from one page of closed workflows to another, and hence would default to the open workflows. In case, open workflows listing did not have content on that page, an error would occur. 
By adding the state to the paginator buttons, the filter applied to workflows gets maintained across pages.

#### What are the relevant issues?
closes #903 
