### PR TITLE
Place Names on Browser Tabs

### DIFF
--- a/indigo_app/templates/indigo_api/task_detail.html
+++ b/indigo_app/templates/indigo_api/task_detail.html
@@ -1,7 +1,7 @@
 {% extends "place/tabbed_layout.html" %}
 {% load activity_tags humanize indigo_app account comments %}
 
-{% block title %}{{ task.title }}{% endblock %}
+{% block title %}{{ task.title }} – {{ place.name }}{% endblock %}
 
 {% block content %}
   <div class="container mt-3 mb-5">

--- a/indigo_app/templates/indigo_api/task_detail.html
+++ b/indigo_app/templates/indigo_api/task_detail.html
@@ -1,7 +1,7 @@
 {% extends "place/tabbed_layout.html" %}
 {% load activity_tags humanize indigo_app account comments %}
 
-{% block title %}{{ task.title }} – {{ place.name }}{% endblock %}
+{% block title %}{{ task.title }} {{ block.super }}{% endblock %}
 
 {% block content %}
   <div class="container mt-3 mb-5">

--- a/indigo_app/templates/indigo_api/task_form.html
+++ b/indigo_app/templates/indigo_api/task_form.html
@@ -1,7 +1,7 @@
 {% extends "place/tabbed_layout.html" %}
 {% load humanize indigo_app %}
 
-{% block title %}{% if task.pk %}{{ task.title }}{% else %}New task{% endif %} – {{ locality.name|default:country.name }}{% endblock %}
+{% block title %}{% if task.pk %}{{ task.title }}{% else %}New task{% endif %} {{ block.super }}{% endblock %}
 {% block view-id %}edit-task-view{% endblock %}
 
 {% block content %}

--- a/indigo_app/templates/indigo_api/task_list.html
+++ b/indigo_app/templates/indigo_api/task_list.html
@@ -1,7 +1,7 @@
 {% extends "place/tabbed_layout.html" %}
 {% load humanize indigo_app %}
 
-{% block title %}Tasks – {{ place.name }}{% endblock %}
+{% block title %}Tasks {{ block.super }}{% endblock %}
 
 {% block content %}
 

--- a/indigo_app/templates/indigo_api/workflow_detail.html
+++ b/indigo_app/templates/indigo_api/workflow_detail.html
@@ -2,7 +2,7 @@
 {% load activity_tags %}
 {% load humanize indigo_app %}
 
-{% block title %}{{ workflow.title }} – {{ place.name }}{% endblock %}
+{% block title %}{{ workflow.title }} {{ block.super }}{% endblock %}
 
 {% block content %}
 <div class="container mt-3 mb-5">

--- a/indigo_app/templates/indigo_api/workflow_detail.html
+++ b/indigo_app/templates/indigo_api/workflow_detail.html
@@ -2,7 +2,7 @@
 {% load activity_tags %}
 {% load humanize indigo_app %}
 
-{% block title %}{{ workflow.title }}{% endblock %}
+{% block title %}{{ workflow.title }} – {{ place.name }}{% endblock %}
 
 {% block content %}
 <div class="container mt-3 mb-5">

--- a/indigo_app/templates/indigo_api/workflow_form.html
+++ b/indigo_app/templates/indigo_api/workflow_form.html
@@ -1,6 +1,6 @@
 {% extends "place/tabbed_layout.html" %}
 
-{% block title %}{% if workflow.pk %}{{ workflow.title }}{% else %}New workflow{% endif %} – {{ place.name }}{% endblock %}
+{% block title %}{% if workflow.pk %}{{ workflow.title }}{% else %}New workflow{% endif %} {{ block.super }}{% endblock %}
 
 {% block content %}
   {% if perms.indigo_api.add_work %}

--- a/indigo_app/templates/indigo_api/workflow_list.html
+++ b/indigo_app/templates/indigo_api/workflow_list.html
@@ -1,7 +1,7 @@
 {% extends "place/tabbed_layout.html" %}
 {% load humanize indigo_app %}
 
-{% block title %}Workflows – {{ place.name }}{% endblock %}
+{% block title %}Workflows {{ block.super }}{% endblock %}
 
 {% block content %}
 

--- a/indigo_app/templates/place/activity.html
+++ b/indigo_app/templates/place/activity.html
@@ -1,6 +1,6 @@
 {% extends "place/tabbed_layout.html" %}
 
-{% block title %}Activity – {{ place.name }}{% endblock %}
+{% block title %}Activity {{ block.super }}{% endblock %}
 
 {% block content %}
 <div class="container mt-3 mb-5">

--- a/indigo_app/templates/place/layout.html
+++ b/indigo_app/templates/place/layout.html
@@ -1,5 +1,7 @@
 {% extends "main.html" %}
 
+{% block title %} – {{ place.name }}{% endblock %}
+
 {% block main-header-title %}
   <h4 class="text-muted">
     <a href="{% url 'place' place=country.code %}">{{ country.name }} · {{ country.code }}</a>

--- a/indigo_app/templates/place/localities.html
+++ b/indigo_app/templates/place/localities.html
@@ -1,7 +1,7 @@
 {% extends "place/tabbed_layout.html" %}
 {% load staticfiles %}
 
-{% block title %}Localities {{ block.super }}{% endblock %}
+{% block title %}Localities – {{ place.name }}{{ block.super }}{% endblock %}
 
 {% block content %}
 <div class="container mt-3 mb-5 pt-3">

--- a/indigo_app/templates/place/localities.html
+++ b/indigo_app/templates/place/localities.html
@@ -1,7 +1,7 @@
 {% extends "place/tabbed_layout.html" %}
 {% load staticfiles %}
 
-{% block title %}Localities – {{ place.name }}{{ block.super }}{% endblock %}
+{% block title %}Localities {{ block.super }}{% endblock %}
 
 {% block content %}
 <div class="container mt-3 mb-5 pt-3">

--- a/indigo_app/templates/place/metrics.html
+++ b/indigo_app/templates/place/metrics.html
@@ -1,7 +1,7 @@
 {% extends "place/insights_layout.html" %}
 {% load staticfiles %}
 
-{% block title %}Metrics – {{ place.name }}{% endblock %}
+{% block title %}Metrics {{ block.super }}{% endblock %}
 
 {% block insights-content %}
 <div class="container">

--- a/indigo_app/templates/place/settings.html
+++ b/indigo_app/templates/place/settings.html
@@ -1,6 +1,6 @@
 {% extends "place/tabbed_layout.html" %}
 
-{% block title %}Settings – {{ place.name }}{% endblock %}
+{% block title %}Settings {{ block.super }}{% endblock %}
 
 {% block content %}
 <div class="container mt-3 mb-5">

--- a/indigo_app/templates/place/works.html
+++ b/indigo_app/templates/place/works.html
@@ -1,7 +1,7 @@
 {% extends "place/tabbed_layout.html" %}
 {% load indigo_app humanize staticfiles %}
 
-{% block title %}{{ place.name }} – Works{% endblock %}
+{% block title %}Works {{ block.super }}{% endblock %}
 {% block view-id %}library-view{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
#### Description
This PR adds place name(locality name if appropriate) in the tab title in the browser for the following place-based pages:
- Workflow detail page
- Task detail page
- Place localities listing page

#### Manual Testing
Navigate to the pages listed above.

#### Relevant Issue
closes #1007 

#### Screenshots
Localities listing:
![localities](https://user-images.githubusercontent.com/8082197/78758856-71804900-7987-11ea-916a-efc271fc291f.png)

Workflow details page:
![Locality_workflow_detail](https://user-images.githubusercontent.com/8082197/78758945-8f4dae00-7987-11ea-8194-64546f3afd10.png)

Task details page:
![Task_detail](https://user-images.githubusercontent.com/8082197/78758979-9d033380-7987-11ea-8068-4c55d2ce154c.png)



