### PR TITLE
Redirect to GazetteMachine Post-login

### DIFF
--- a/indigo/middleware.py
+++ b/indigo/middleware.py
@@ -1,0 +1,11 @@
+from django.http import HttpResponsePermanentRedirect
+
+
+class GazettesRedirectMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.get_raw_uri() == "https://edit.laws.africa/next-task":
+            return HttpResponsePermanentRedirect("https://gazettes.laws.africa/next-task")
+        return self.get_response(request)

--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -103,6 +103,7 @@ MIDDLEWARE = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'indigo.middleware.GazettesRedirectMiddleware',
 )
 
 ROOT_URLCONF = 'indigo.urls'


### PR DESCRIPTION
#### Description
If a user tries to go to https://gazettes.laws.africa/next-task to do a task and they aren't logged in, they're sent to edit.laws.africa to sign in (by design). However, they are sent to https://edit.laws.africa/accounts/login/?next=/next-task which doesn't have the correct domain.

This PR adds a middleware to facilitate the redirection back to gazettes domain post-login.

#### Manual Testing
Log out of Indigo and access Gazettes. After logging in again, the page will redirect to Gazettes and not raise an error.

#### Relevant Issue
[Gazettemachine #31](https://github.com/laws-africa/gazettemachine/issues/31)