### PR TITLE
Task table: don't wrap place name, doc/work link is not muted, include frbr_uri

### DIFF
--- a/indigo_app/templates/indigo_api/_task_list.html
+++ b/indigo_app/templates/indigo_api/_task_list.html
@@ -55,7 +55,9 @@
     {% if place %}
       <td>
         {% block col-place %}
-          <a href="{% url 'tasks' place=task.place.place_code %}">{{ task.place }}</a>
+          <div class="text-nowrap">
+            <a href="{% url 'tasks' place=task.place.place_code %}">{{ task.place }}</a>
+          </div>
         {% endblock %}
       </td>
     {% endif %}
@@ -63,16 +65,16 @@
     <td>
       {% block col-work %}
       {% if task.document %}
-        <a href="{% url 'document' doc_id=task.document.id %}"
-           class="text-muted"
-           data-popup-url="{% url 'document_popup' doc_id=task.document.id %}">
+        <a href="{% url 'document' doc_id=task.document.id %}" data-popup-url="{% url 'document_popup' doc_id=task.document.id %}">
           {% if not hide_works %}{{ task.document.title }} @{% endif %}
           {{ task.document.expression_date|date:'Y-m-d' }} · {{ task.document.language }}
         </a>
+        <br>
+        <span class="text-muted text-nowrap">{{ task.document.frbr_uri }}</span>
       {% elif task.work and not hide_works %}
-        <a href="{% url 'work' frbr_uri=task.work.frbr_uri %}"
-           class="text-muted"
-           data-popup-url="{% url 'work_popup' frbr_uri=task.work.frbr_uri %}">{{ task.work.title }}</a>
+        <a href="{% url 'work' frbr_uri=task.work.frbr_uri %}" data-popup-url="{% url 'work_popup' frbr_uri=task.work.frbr_uri %}">{{ task.work.title }}</a>
+        <br>
+        <span class="text-muted text-nowrap">{{ task.work.frbr_uri }}</span>
       {% endif %}
       {% endblock %}
     </td>


### PR DESCRIPTION
In particular, this makes https://edit.laws.africa/tasks/available/ a bit easier to work with.

![Tasks – South Africa – Laws Africa 2020-04-20 12-29-29](https://user-images.githubusercontent.com/4178542/79742160-b3ec4300-8302-11ea-859d-add2fa3891f9.png)


![Available tasks – Laws Africa 2020-04-20 12-30-41](https://user-images.githubusercontent.com/4178542/79742233-cbc3c700-8302-11ea-91ad-7aa7c925e2bd.png)
