### PR TITLE
Try to work around intermittent JS bug in Firefox

### DIFF
--- a/indigo_app/static/javascript/indigo.js
+++ b/indigo_app/static/javascript/indigo.js
@@ -1,5 +1,8 @@
-$(function() {
+function bootstrapIndigo(exports) {
   "use strict";
+
+  if (!exports.Indigo) exports.Indigo = {};
+  var Indigo = exports.Indigo;
 
   Indigo.csrfToken = $('meta[name="csrf-token"]').attr('content');
 
@@ -165,4 +168,6 @@ $(function() {
       return 'You will lose your changes!';
     }
   });
-});
+}
+
+$(function() { bootstrapIndigo(window); });


### PR DESCRIPTION
There is an intermittent bug (seen mostly with Kenya) where sometimes `Indigo.view` is null, even though we're at a point where it should definitely not be null. I can't reproduce it, but this attempts to work around that.