### PR TITLE
Filter correctly

### DIFF
--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -154,10 +154,10 @@ class AnnotationViewSet(DocumentResourceView, viewsets.ModelViewSet):
     permission_classes = DEFAULT_PERMS + (DjangoModelPermissionsOrAnonReadOnly, AnnotationPermissions)
 
     def filter_queryset(self, queryset):
-        return queryset.filter(document=self.document).all()
+        return super().filter_queryset(queryset).filter(document=self.document)
     
     def list(self, request, **kwargs):
-        queryset = list(Annotation.objects.filter(document=self.document).all())
+        queryset = list(self.filter_queryset(self.get_queryset()))
         task_content_type = ContentType.objects.get_for_model(Task)
 
         fake_annotations = []

--- a/indigo_api/views/works.py
+++ b/indigo_api/views/works.py
@@ -58,4 +58,4 @@ class WorkAmendmentViewSet(WorkResourceView, viewsets.ReadOnlyModelViewSet):
     permission_classes = (DjangoModelPermissions,)
 
     def filter_queryset(self, queryset):
-        return queryset.filter(amended_work=self.work).all()
+        return super().filter_queryset(queryset).filter(amended_work=self.work).all()

--- a/indigo_content_api/tests/v1/test_content_api.py
+++ b/indigo_content_api/tests/v1/test_content_api.py
@@ -393,7 +393,7 @@ class ContentAPIV1TestMixin(object):
         assert_equal(len(response.data['results']), 0)
 
         # should not exist
-        response = self.client.get(self.api_path + '/za/act/2001/8/eng/media/test.txt')
+        response = self.client.get(self.api_path + '/za/act/2001/8/eng/media/test.png')
         assert_equal(response.status_code, 404)
 
         # create a doc with an attachment
@@ -407,24 +407,26 @@ class ContentAPIV1TestMixin(object):
         assert_equal(len(response.data['results']), 1)
 
         # now should exist
-        response = self.client.get(self.api_path + '/za/act/2001/8/eng/media/test.txt')
+        response = self.client.get(self.api_path + '/za/act/2001/8/eng/media/test.png')
         assert_equal(response.status_code, 200)
 
         # 403 for anonymous
         self.client.logout()
-        response = self.client.get(self.api_path + '/za/act/2001/8/eng/media/test.txt')
+        response = self.client.get(self.api_path + '/za/act/2001/8/eng/media/test.png')
         assert_equal(response.status_code, 403)
 
         # even for a non-existent one
-        response = self.client.get(self.api_path + '/za/act/2001/8/eng/media/bad.txt')
+        response = self.client.get(self.api_path + '/za/act/2001/8/eng/media/bad.png')
         assert_equal(response.status_code, 403)
 
     def upload_attachment(self, doc_id):
-        tmp_file = tempfile.NamedTemporaryFile(suffix='.txt')
-        tmp_file.write("hello!".encode())
+        tmp_file = tempfile.NamedTemporaryFile(suffix='.png')
+        # this is the smallest possible transparent png
+        # see https://github.com/mathiasbynens/small
+        tmp_file.write(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82')
         tmp_file.seek(0)
         response = self.client.post('/api/documents/%s/attachments' % doc_id,
-                                    {'file': tmp_file, 'filename': 'test.txt'}, format='multipart')
+                                    {'file': tmp_file, 'filename': 'test.png'}, format='multipart')
         assert_equal(response.status_code, 201)
 
     def test_published_zipfile(self):

--- a/indigo_content_api/v1/views.py
+++ b/indigo_content_api/v1/views.py
@@ -339,7 +339,7 @@ class PublishedDocumentMediaView(FrbrUriViewMixin,
         .published()
 
     def filter_queryset(self, queryset):
-        return queryset.filter(document=self.get_document())
+        return super().filter_queryset(queryset).filter(document=self.get_document())
 
     def get_file(self, request, filename, *args, **kwargs):
         """ Download a media file.


### PR DESCRIPTION
Call super's `filter_queryset()` correctly. This means we can more easily integrate filter backends.