### PR TITLE
Smarter reversion version lookup

### DIFF
--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.db import models
 from django.db.models import signals
 from django.contrib.auth.models import User
-from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.search import SearchVectorField
 from django.contrib.postgres.fields import JSONField
 from django.dispatch import receiver
@@ -19,7 +18,7 @@ from allauth.account.utils import user_display
 from iso8601 import parse_date, ParseError
 from taggit.managers import TaggableManager
 import reversion.revisions
-import reversion.models
+from reversion.models import Version
 from cobalt.act import Act, FrbrUri, AmendmentEvent, datestring
 
 from indigo.plugins import plugins
@@ -409,12 +408,7 @@ class Document(DocumentMixin, models.Model):
         """ Return a queryset of `reversion.models.Version` objects for
         revisions for this work, most recent first.
         """
-        content_type = ContentType.objects.get_for_model(self)
-        return reversion.models.Version.objects \
-            .select_related('revision') \
-            .filter(content_type=content_type) \
-            .filter(object_id=self.id) \
-            .order_by('-id')
+        return Version.objects.get_for_object(self).select_related('revision', 'revision__user')
 
     def manifestation_url(self, fqdn=''):
         """ Fully-qualified manifestation URL.

--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -12,7 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.dispatch import receiver
 from django.utils.functional import cached_property
 import reversion.revisions
-import reversion.models
+from reversion.models import Version
 from cobalt.act import FrbrUri, RepealEvent
 
 from indigo.plugins import plugins
@@ -421,12 +421,7 @@ class Work(WorkMixin, models.Model):
         """ Return a queryset of `reversion.models.Version` objects for
         revisions for this work, most recent first.
         """
-        content_type = ContentType.objects.get_for_model(self)
-        return reversion.models.Version.objects \
-            .select_related('revision', 'revision__user') \
-            .filter(content_type=content_type) \
-            .filter(object_id=self.id) \
-            .order_by('-id')
+        return Version.objects.get_for_object(self).select_related('revision', 'revision__user')
 
     def as_at_date(self):
         # the as-at date is the maximum of the most recent, published expression date,

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -245,10 +245,7 @@ class RevisionViewSet(DocumentResourceView, viewsets.ReadOnlyModelViewSet):
         version = self.get_object()
 
         # most recent version just before this one
-        old_version = self.document.versions()\
-            .filter(id__lt=version.id)\
-            .order_by('-id')\
-            .first()
+        old_version = self.get_queryset().filter(id__lt=version.id).first()
 
         differ = AttributeDiffer()
 
@@ -277,7 +274,7 @@ class RevisionViewSet(DocumentResourceView, viewsets.ReadOnlyModelViewSet):
         })
 
     def get_queryset(self):
-        return self.document.versions()
+        return self.document.versions().defer('serialized_data')
 
 
 class DocumentActivityViewSet(DocumentResourceView,

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -709,7 +709,7 @@ class WorkVersionsView(WorkViewBase, MultipleObjectMixin, DetailView):
         actions = self.work.action_object_actions.all()
         amendment_actions = [aa for a in self.work.amendments.all() for aa in a.action_object_actions.all()]
         commencement_actions = [c for a in self.work.commencements.all() for c in a.action_object_actions.all()]
-        versions = self.work.versions().all()
+        versions = self.work.versions().defer('serialized_data').all()
         task_actions = self.get_task_actions()
         entries = sorted(chain(actions, amendment_actions, commencement_actions, versions, task_actions),
                          key=lambda x: x.revision.date_created if hasattr(x, 'revision') else x.timestamp,


### PR DESCRIPTION
1. use Version.objects.get_for_object because it makes use of the underlying db index
2. defer fetching serialized data unless it's actually needed.

Without this, in some cases we're fetching ~1GB of data and then never using it.