### PR TITLE
When inlining css, ensure strings

### DIFF
--- a/indigo_api/templatetags/inline_scss.py
+++ b/indigo_api/templatetags/inline_scss.py
@@ -14,4 +14,4 @@ def inline_scss(path):
     processor = SassProcessor()
     path = processor(path)
     with processor.storage.open(path) as f:
-        return mark_safe(f.read())
+        return mark_safe(f.read().decode('utf-8'))


### PR DESCRIPTION
Otherwise we get this, which isn't valid CSS:

```
<style type="text/css">b'.akn-div....'</style>
```