### PR TITLE
Faster workflow detail page

### DIFF
--- a/indigo_api/models/tasks.py
+++ b/indigo_api/models/tasks.py
@@ -34,7 +34,7 @@ class TaskManager(models.Manager):
         from .documents import Document
 
         return super(TaskManager, self).get_queryset() \
-            .select_related('created_by_user', 'assigned_to') \
+            .select_related('created_by_user', 'assigned_to', 'country', 'country__country', 'locality') \
             .prefetch_related(Prefetch('work', queryset=Work.objects.filter())) \
             .prefetch_related(Prefetch('document', queryset=Document.objects.no_xml())) \
             .prefetch_related('labels')

--- a/indigo_app/templates/indigo_api/_task_card_single.html
+++ b/indigo_app/templates/indigo_api/_task_card_single.html
@@ -14,7 +14,7 @@
             {% if task.state == 'open' and task.submit_task_permission %}
               <button type="submit"
                       class="dropdown-item"
-                      formaction="{% url 'submit_task' place=place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}"
+                      formaction="{% url 'submit_task' place=task.place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}"
                       data-confirm="{{ task.submission_message }}">
                 Submit for review
               </button>
@@ -22,7 +22,7 @@
             {% if task.state == 'pending_review' and task.unsubmit_task_permission %}
               <button type="submit"
                       class="dropdown-item"
-                      formaction="{% url 'unsubmit_task' place=place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}"
+                      formaction="{% url 'unsubmit_task' place=task.place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}"
                       data-confirm="Are you sure you want to request changes to this task?">
                 Request changes
               </button>
@@ -30,14 +30,14 @@
             {% if task.state == 'pending_review' and task.close_task_permission %}
               <button type="submit"
                       class="dropdown-item"
-                      formaction="{% url 'close_task' place=place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}"
+                      formaction="{% url 'close_task' place=task.place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}"
                       data-confirm="Are you sure you want to approve this task?">
                 Approve
               </button>
             {% endif %}
             <button type="submit"
                     class="dropdown-item"
-                    formaction="{% url 'workflow_remove_task' place=place.place_code pk=workflow.pk task_pk=task.pk %}"
+                    formaction="{% url 'workflow_remove_task' place=task.place.place_code pk=workflow.pk task_pk=task.pk %}"
                     data-confirm="Are you sure you want to remove this task?">
               Remove from workflow
             </button>
@@ -101,7 +101,7 @@
 
         <!-- assign button-->
           {% if assign_button and perms.indigo_api.change_task %}
-            <form method="POST" class="assign-task-form" action="{% url 'assign_task' place=place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}#task-{{ task.id }}">
+            <form method="POST" class="assign-task-form" action="{% url 'assign_task' place=task.place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}#task-{{ task.id }}">
             {% csrf_token %}
 
               <div class="dropdown">
@@ -109,7 +109,7 @@
                   Reassign
                 </button>
                 <div class="dropdown-menu" aria-labelledby="unassignDropdownMenuButton">
-                <button class="dropdown-item mb-1" type="submit" data-confirm="Are you sure you want to unassign this task?" formaction="{% url 'unassign_task' place=place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}#task-{{ task.id }}">
+                <button class="dropdown-item mb-1" type="submit" data-confirm="Are you sure you want to unassign this task?" formaction="{% url 'unassign_task' place=task.place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}#task-{{ task.id }}">
                   Unassign
                 </button>
                 <div class="dropdown-divider"></div>
@@ -123,7 +123,7 @@
         </div>
         {% elif task.state == 'open' or task.state == 'pending_review' %}
           {% if perms.indigo_api.change_task and task.potential_assignees %}
-            <form method="POST" class="assign-task-form" action="{% url 'assign_task' place=place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}#task-{{ task.id }}">
+            <form method="POST" class="assign-task-form" action="{% url 'assign_task' place=task.place.place_code pk=task.pk %}?next={{ request.get_full_path|urlencode }}#task-{{ task.id }}">
             {% csrf_token %}
               <div class="dropdown">
                 <button class="btn btn-outline-primary mt-2 btn-sm dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/indigo_app/views/workflows.py
+++ b/indigo_app/views/workflows.py
@@ -74,7 +74,7 @@ class WorkflowDetailView(WorkflowViewBase, DetailView):
         self.object.pct_done = self.object.n_done / (self.object.n_tasks or 1) * 100.0
 
         context['form'] = self.form
-        tasks = self.form.filter_queryset(self.object.tasks) \
+        tasks = self.form.filter_queryset(Task.objects.filter(workflows=self.object)) \
             .select_related('document__language', 'document__language__language')\
             .defer('document__document_xml', 'document__search_text', 'document__search_vector')\
             .all()
@@ -82,7 +82,7 @@ class WorkflowDetailView(WorkflowViewBase, DetailView):
         context['tasks'] = tasks
         context['has_tasks'] = self.object.n_tasks > 0
         context['task_groups'] = Task.task_columns(['open', 'pending_review', 'assigned'], tasks)
-        context['possible_tasks'] = self.place.tasks\
+        context['possible_tasks'] = Task.objects.filter(country=self.country, locality=self.locality)\
             .unclosed()\
             .exclude(workflows=self.object) \
             .select_related('document__language', 'document__language__language') \


### PR DESCRIPTION
Use object managers to reduce the number of DB queries for workflow page.

This more than halves the number of db queries on the page (in my tests,
with a handful of tasks, it goes from over 100 to 40-odd), and should
make it much faster to load.

1. updated the default select_related for tasks to include the country
and locality details

2. place.tasks and workflow.tasks don't use the Task's object manager,
and so the default selected_related aren't used; change to using
Task.objects... (I really need to remember this!)

3. limit 'possible tasks' to those with the matching country and
locality