### PR TITLE
Attachment subheadings as akn-subheading, don't italicise.

### DIFF
--- a/indigo_api/static/xsl/html_act.xsl
+++ b/indigo_api/static/xsl/html_act.xsl
@@ -188,8 +188,9 @@
 
   <xsl:template match="a:meta" />
 
-  <xsl:template match="a:hcontainer[@name='schedule']/a:heading | a:hcontainer[@name='schedule']/a:subheading">
-    <h2 class="akn-heading">
+  <xsl:template match="a:attachment/a:heading | a:attachment/a:subheading">
+    <h2 class="akn-{local-name()}">
+      <xsl:apply-templates select="@*" />
       <xsl:apply-templates />
     </h2>
   </xsl:template>

--- a/indigo_app/static/lib/indigo-web/scss/_core.scss
+++ b/indigo_app/static/lib/indigo-web/scss/_core.scss
@@ -96,10 +96,10 @@
     margin-bottom: $akn-section-spacing;
   }
 
-  /* Schedules */
-  // When a schedule has a title and a heading, there should be no space between them.
-  .akn-hcontainer[data-name=schedule] > .akn-heading + .akn-heading {
-    margin-top: -$akn-para-spacing;
+  /* Schedules and attachments */
+  .akn-attachment > .akn-subheading {
+    // don't italicise sub-headings for attachments
+    font-style: normal;
   }
 
   /* Indent list-like containers that have margin numbers.


### PR DESCRIPTION
The indigo-web changes also need to be applied in that repo.

Fixes #1091

old:

![Air Quality Management - Open By-laws South Africa 2020-06-03 10-33-58](https://user-images.githubusercontent.com/4178542/83614671-d0c49900-a585-11ea-87b3-ffe8577b6e80.png)

new (different doc):

![Water and Sanitation Services @ 2015-09-11 2020-06-03 10-33-40](https://user-images.githubusercontent.com/4178542/83614681-d4582000-a585-11ea-96b6-00ddb6f8fc70.png)
