### PR TITLE
FIX bug with diff view

### DIFF
--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -642,3 +642,7 @@ class DocumentDiffSerializer(serializers.Serializer):
     """
     document = DocumentSerializer(required=True)
     element_id = serializers.CharField(required=False, allow_null=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['document'].instance = self.instance

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -519,7 +519,7 @@ class DocumentDiffView(DocumentResourceView, APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request, document_id):
-        serializer = DocumentDiffSerializer(data=self.request.data)
+        serializer = DocumentDiffSerializer(instance=self.document, data=self.request.data)
         serializer.is_valid(raise_exception=True)
 
         differ = AttributeDiffer()


### PR DESCRIPTION
The nested serializer requires the document instance so that it has access to the work frbr_uri

Fixes LAWSAFRICA-1R in sentry.