### PR TITLE
When changing a work's title, matching document titles must also change

### DIFF
--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -155,6 +155,14 @@ class EditWorkView(WorkViewBase, UpdateView):
                     doc.expression_date = self.work.publication_date
                     doc.save()
 
+        # if the work title changes, ensure matching document titles do too
+        if 'title' in form.changed_data:
+            old_title = form.initial['title']
+            if old_title:
+                for doc in Document.objects.filter(work=self.work, title=old_title):
+                    doc.title = self.work.title
+                    doc.save()
+
         if form.has_changed():
             # signals
             work_changed.send(sender=self.__class__, work=self.work, request=self.request)


### PR DESCRIPTION
Fixes #1086

This is the natural thing to happen when renaming a work, except
when the documents have different titles, such as for different
languages or when a work title has changed due to an amendment.