### PR TITLE
Doctypes

### DIFF
--- a/docs/running/configuration.rst
+++ b/docs/running/configuration.rst
@@ -77,6 +77,11 @@ Config options are mostly passed to Indigo as environment variables. These are t
 
   Should Indigo require authentication to view read-only pages? Default is True.
 
+* ``INDIGO.DOCTYPES``
+
+  A list of ``(label, code)`` pairs of Akoma Ntoso document types that can be
+  created, such as ``('Act', 'act')``. See http://docs.oasis-open.org/legaldocml/akn-core/v1.0/os/part1-vocabulary/akn-core-v1.0-os-part1-vocabulary.html#_Toc523925025
+
 * ``INDIGO.EMAIL_FAIL_SILENTLY``
 
   Should email sending fail silently?

--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -124,7 +124,11 @@ INDIGO = {
     'EMAIL_FAIL_SILENTLY': False,
 
     # Key-value pairs for custom properties, per place code.
-    'WORK_PROPERTIES': {}
+    'WORK_PROPERTIES': {},
+
+    # AKN document types the platform supports, as a list of (name, code) tuples
+    # see http://docs.oasis-open.org/legaldocml/akn-core/v1.0/os/part1-vocabulary/akn-core-v1.0-os-part1-vocabulary.html#_Toc523925025
+    'DOCTYPES': [('Act', 'act')],
 }
 
 # Database

--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -110,6 +110,10 @@ class DocumentMixin(object):
     this document functionality.
     """
     @property
+    def date(self):
+        return self.work_uri.date
+
+    @property
     def year(self):
         return self.work_uri.date.split('-', 1)[0]
 
@@ -132,6 +136,10 @@ class DocumentMixin(object):
     @property
     def locality(self):
         return self.work_uri.locality
+
+    @property
+    def actor(self):
+        return self.work_uri.actor
 
     @property
     def django_language(self):
@@ -344,12 +352,11 @@ class Document(DocumentMixin, models.Model):
         if from_model:
             self.copy_attributes_from_work()
 
-            self.doc.title = self.title
             self.doc.frbr_uri = self.frbr_uri
+            self.doc.title = self.title
             self.doc.language = self.language.code
 
-            self.doc.work_date = self.doc.publication_date
-            self.doc.expression_date = self.expression_date or self.doc.publication_date or timezone.now()
+            self.doc.expression_date = self.expression_date or self.publication_date or timezone.now()
             self.doc.manifestation_date = self.updated_at or timezone.now()
             self.doc.publication_number = self.publication_number
             self.doc.publication_name = self.publication_name

--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -100,6 +100,10 @@ class WorkMixin(object):
         return self._work_uri
 
     @property
+    def date(self):
+        return self.work_uri.date
+
+    @property
     def year(self):
         return self.work_uri.date.split('-', 1)[0]
 
@@ -114,6 +118,10 @@ class WorkMixin(object):
     @property
     def subtype(self):
         return self.work_uri.subtype
+
+    @property
+    def actor(self):
+        return self.work_uri.actor
 
     @property
     def repeal(self):

--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -13,7 +13,7 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 from rest_framework.exceptions import ValidationError
 from taggit_serializer.serializers import TagListSerializerField
-from cobalt import StructuredDocument
+from cobalt import StructuredDocument, FrbrUri
 from cobalt.akn import AKN_NAMESPACES
 import reversion
 
@@ -271,7 +271,7 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
             'created_at', 'updated_at', 'updated_by_user', 'created_by_user',
 
             # frbr_uri components
-            'country', 'locality', 'nature', 'subtype', 'year', 'number', 'frbr_uri', 'expression_frbr_uri',
+            'country', 'locality', 'nature', 'subtype', 'date', 'actor', 'number', 'frbr_uri', 'expression_frbr_uri',
 
             'publication_date', 'publication_name', 'publication_number',
             'expression_date', 'commencement_date', 'assent_date',
@@ -279,7 +279,7 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
 
             'links',
         )
-        read_only_fields = ('country', 'locality', 'nature', 'subtype', 'year', 'number', 'created_at', 'updated_at')
+        read_only_fields = ('country', 'locality', 'nature', 'subtype', 'date', 'actor', 'number', 'created_at', 'updated_at')
 
     def get_links(self, doc):
         return [
@@ -321,6 +321,14 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
                 raise ValidationError(f"Document must have namespace {AKN_NAMESPACES['3.0']}, but it has {doc.namespace} instead.")
 
         return attrs
+
+    def validate_frbr_uri(self, value):
+        try:
+            if not value:
+                raise ValueError()
+            return FrbrUri.parse(value.lower()).work_uri()
+        except ValueError:
+            raise ValidationError("Invalid FRBR URI: %s" % value)
 
     def validate_language(self, value):
         try:
@@ -579,7 +587,7 @@ class WorkSerializer(serializers.ModelSerializer):
             'repealed_date', 'repealed_by',
 
             # frbr_uri components
-            'country', 'locality', 'nature', 'subtype', 'year', 'number', 'frbr_uri',
+            'country', 'locality', 'nature', 'subtype', 'date', 'actor', 'number', 'frbr_uri',
 
             # taxonomies
             'taxonomies',

--- a/indigo_api/tests/data_migrations/test_akn3_laggards.py
+++ b/indigo_api/tests/data_migrations/test_akn3_laggards.py
@@ -147,7 +147,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za-cpt/act/by-law/2010/liquor-trading-days-and-hours/!main"/>
           <FRBRuri value="/akn/za-cpt/act/by-law/2010/liquor-trading-days-and-hours"/>
           <FRBRalias value="Liquor Trading Days and Hours" name="title"/>
-          <FRBRdate date="2010-09-10" name="Generation"/>
+          <FRBRdate date="2010" name="Generation"/>
           <FRBRauthor href="#council"/>
           <FRBRcountry value="za-cpt"/>
           <FRBRsubtype value="by-law"/><FRBRnumber value="liquor-trading-days-and-hours"/>
@@ -209,7 +209,7 @@ class MigrationTestCase(TestCase):
                 <FRBRthis value="/akn/za-cpt/act/by-law/2010/liquor-trading-days-and-hours/!schedule"/>
                 <FRBRuri value="/akn/za-cpt/act/by-law/2010/liquor-trading-days-and-hours"/>
                 <FRBRalias value="Schedule" name="title"/>
-                <FRBRdate date="1980-01-01" name="Generation"/>
+                <FRBRdate date="2010" name="Generation"/>
                 <FRBRauthor href="#council"/>
                 <FRBRcountry value="za-cpt"/>
                 <FRBRsubtype value="by-law"/><FRBRnumber value="liquor-trading-days-and-hours"/>
@@ -313,7 +313,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za/act/gn/2020/650/!main"/>
           <FRBRuri value="/akn/za/act/gn/2020/650"/>
           <FRBRalias value="A work" name="title"/>
-          <FRBRdate date="1990-01-01" name="Generation"/>
+          <FRBRdate date="2020" name="Generation"/>
           <FRBRauthor href=""/>
           <FRBRcountry value="za"/><FRBRsubtype value="gn"/>
         

--- a/indigo_api/tests/data_migrations/test_ids_eIds.py
+++ b/indigo_api/tests/data_migrations/test_ids_eIds.py
@@ -529,7 +529,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za/act/2014/10/!main"/>
           <FRBRuri value="/akn/za/act/2014/10"/>
           <FRBRalias value="Air Quality Management" name="title"/>
-          <FRBRdate date="2014-04-02" name="Generation"/>
+          <FRBRdate date="2014" name="Generation"/>
           <FRBRauthor href="#council"/>
           <FRBRcountry value="za"/><FRBRnumber value="10"/>
         </FRBRWork>
@@ -742,7 +742,7 @@ class MigrationTestCase(TestCase):
               <FRBRthis value="/akn/za/act/2014/10/!schedule1"/>
               <FRBRuri value="/akn/za/act/2014/10"/>
               <FRBRalias value="Schedule 1"/>
-              <FRBRdate date="1980-01-01" name="Generation"/>
+              <FRBRdate date="2014" name="Generation"/>
               <FRBRauthor href="#council"/>
               <FRBRcountry value="za"/><FRBRnumber value="10"/>
             </FRBRWork>
@@ -907,7 +907,7 @@ class MigrationTestCase(TestCase):
               <FRBRthis value="/akn/za/act/2014/10/!schedule2"/>
               <FRBRuri value="/akn/za/act/2014/10"/>
               <FRBRalias value="Schedule 2"/>
-              <FRBRdate date="1980-01-01" name="Generation"/>
+              <FRBRdate date="2014" name="Generation"/>
               <FRBRauthor href="#council"/>
               <FRBRcountry value="za"/><FRBRnumber value="10"/>
             </FRBRWork>
@@ -2163,7 +2163,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za-ec443/act/by-law/2009/aerodrome/main"/>
           <FRBRuri value="/akn/za-ec443/act/by-law/2009/aerodrome"/>
           <FRBRalias value="Aerodromes"/>
-          <FRBRdate date="2009-02-27" name="Generation"/>
+          <FRBRdate date="2009" name="Generation"/>
           <FRBRauthor href="#council"/>
           <FRBRcountry value="za"/>
         </FRBRWork>
@@ -2362,7 +2362,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za-ec443/act/by-law/2009/aerodrome/!main"/>
           <FRBRuri value="/akn/za-ec443/act/by-law/2009/aerodrome"/>
           <FRBRalias value="Aerodromes"/>
-          <FRBRdate date="2009-02-27" name="Generation"/>
+          <FRBRdate date="2009" name="Generation"/>
           <FRBRauthor href="#council"/>
           <FRBRcountry value="za-ec443"/><FRBRsubtype value="by-law"/><FRBRnumber value="aerodrome"/>
         </FRBRWork>
@@ -2629,7 +2629,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za/act/2014/10/!main"/>
           <FRBRuri value="/akn/za/act/2014/10"/>
           <FRBRalias value="Air Quality Management" name="title"/>
-          <FRBRdate date="" name="Generation"/>
+          <FRBRdate date="2014" name="Generation"/>
           <FRBRauthor href="#council"/>
           <FRBRcountry value="za"/><FRBRnumber value="10"/>
         </FRBRWork>
@@ -3338,7 +3338,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za/act/2014/10/!main"/>
           <FRBRuri value="/akn/za/act/2014/10"/>
           <FRBRalias value="Air Quality Management" name="title"/>
-          <FRBRdate date="" name="Generation"/>
+          <FRBRdate date="2014" name="Generation"/>
           <FRBRauthor href="#council"/>
           <FRBRcountry value="za"/><FRBRnumber value="10"/>
         </FRBRWork>
@@ -3370,7 +3370,7 @@ class MigrationTestCase(TestCase):
                 <FRBRthis value="/akn/za/act/2014/10/!att_1"/>
                 <FRBRuri value="/akn/za/act/2014/10"/>
                 <FRBRalias value="Schedule 1"/>
-                <FRBRdate date="1980-01-01" name="Generation"/>
+                <FRBRdate date="2014" name="Generation"/>
                 <FRBRauthor href="#council"/>
                 <FRBRcountry value="za"/><FRBRnumber value="10"/>
               </FRBRWork>
@@ -3472,7 +3472,7 @@ class MigrationTestCase(TestCase):
                 <FRBRthis value="/akn/za/act/2014/10/!att_2"/>
                 <FRBRuri value="/akn/za/act/2014/10"/>
                 <FRBRalias value="Schedule 1"/>
-                <FRBRdate date="1980-01-01" name="Generation"/>
+                <FRBRdate date="2014" name="Generation"/>
                 <FRBRauthor href="#council"/>
                 <FRBRcountry value="za"/><FRBRnumber value="10"/>
               </FRBRWork>
@@ -3554,7 +3554,7 @@ class MigrationTestCase(TestCase):
                 <FRBRthis value="/akn/za/act/2014/10/!att_3"/>
                 <FRBRuri value="/akn/za/act/2014/10"/>
                 <FRBRalias value="Schedule 1"/>
-                <FRBRdate date="1980-01-01" name="Generation"/>
+                <FRBRdate date="2014" name="Generation"/>
                 <FRBRauthor href="#council"/>
                 <FRBRcountry value="za"/><FRBRnumber value="10"/>
               </FRBRWork>
@@ -3624,7 +3624,7 @@ class MigrationTestCase(TestCase):
                 <FRBRthis value="/akn/za/act/2014/10/!att_4"/>
                 <FRBRuri value="/akn/za/act/2014/10"/>
                 <FRBRalias value="Schedule 1"/>
-                <FRBRdate date="1980-01-01" name="Generation"/>
+                <FRBRdate date="2014" name="Generation"/>
                 <FRBRauthor href="#council"/>
                 <FRBRcountry value="za"/><FRBRnumber value="10"/>
               </FRBRWork>
@@ -3704,7 +3704,7 @@ class MigrationTestCase(TestCase):
                 <FRBRthis value="/akn/za/act/2014/10/!att_5"/>
                 <FRBRuri value="/akn/za/act/2014/10"/>
                 <FRBRalias value="Schedule 1"/>
-                <FRBRdate date="1980-01-01" name="Generation"/>
+                <FRBRdate date="2014" name="Generation"/>
                 <FRBRauthor href="#council"/>
                 <FRBRcountry value="za"/><FRBRnumber value="10"/>
               </FRBRWork>
@@ -3893,7 +3893,7 @@ class MigrationTestCase(TestCase):
                 <FRBRthis value="/akn/za/act/2014/10/!att_6"/>
                 <FRBRuri value="/akn/za/act/2014/10"/>
                 <FRBRalias value="Schedule 1"/>
-                <FRBRdate date="1980-01-01" name="Generation"/>
+                <FRBRdate date="2014" name="Generation"/>
                 <FRBRauthor href="#council"/>
                 <FRBRcountry value="za"/><FRBRnumber value="10"/>
               </FRBRWork>
@@ -4034,7 +4034,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za/act/2014/10/!main"/>
           <FRBRuri value="/akn/za/act/2014/10"/>
           <FRBRalias value="Air Quality Management" name="title"/>
-          <FRBRdate date="" name="Generation"/>
+          <FRBRdate date="2014" name="Generation"/>
           <FRBRauthor href="#council"/>
           <FRBRcountry value="za"/><FRBRnumber value="10"/>
         </FRBRWork>
@@ -4194,7 +4194,7 @@ class MigrationTestCase(TestCase):
           <FRBRthis value="/akn/za/act/2014/10/!main"/>
           <FRBRuri value="/akn/za/act/2014/10"/>
           <FRBRalias value="Air Quality Management" name="title"/>
-          <FRBRdate date="" name="Generation"/>
+          <FRBRdate date="2014" name="Generation"/>
           <FRBRauthor href="#council"/>
           <FRBRcountry value="za"/><FRBRnumber value="10"/>
         </FRBRWork>

--- a/indigo_app/static/javascript/indigo/models.js
+++ b/indigo_app/static/javascript/indigo/models.js
@@ -198,7 +198,7 @@
 
     initialize: function(options) {
       // keep frbr_uri up to date
-      this.on('change:country change:locality change:subtype change:number change:year', this.updateFrbrUri, this);
+      this.on('change:country change:locality change:nature change:subtype change:actor change:number change:date', this.updateFrbrUri, this);
     },
 
     parse: function(json) {
@@ -229,7 +229,10 @@
       if (this.get('subtype')) {
         parts.push(this.get('subtype'));
       }
-      parts.push(this.get('year'));
+      if (this.get('actor')) {
+        parts.push(this.get('actor'));
+      }
+      parts.push(this.get('date'));
       parts.push(this.get('number'));
 
       // clean the parts
@@ -243,7 +246,7 @@
 
       if (!attrs.title) errors.title = 'A title must be specified';
       if (!attrs.country) errors.country = 'A country must be specified';
-      if (!attrs.year) errors.year = 'A year must be specified';
+      if (!attrs.date) errors.date = 'A year (or date) must be specified';
       if (!attrs.number) errors.number = 'A number must be specified';
 
       if (!_.isEmpty(errors)) return errors;
@@ -434,24 +437,6 @@
       return Indigo.traditions.get(this.get('country'));
     },
   });
-
-  /** Create a new document by parsing an frbr URI */
-  Indigo.Document.newFromFrbrUri = function(frbr_uri) {
-    // /akn/za-cpt/act/by-law/2011/foo
-    var parts = frbr_uri.split('/'),
-        place = parts[2].split('-'),
-        country = place[0],
-        locality = place.length > 1 ? place.slice(1).join('-') : null,
-        bump = parts.length > 6 ? 1 : 0;
-
-    return new Indigo.Document({
-      country: country,
-      locality: locality,
-      subtype: parts.length > 6 ? parts[4] : null,
-      year: parts[4 + bump],
-      number: parts[5 + bump],
-    });
-  };
 
   Indigo.Library = Backbone.Collection.extend({
     model: Indigo.Document,

--- a/indigo_app/static/javascript/indigo/views/work.js
+++ b/indigo_app/static/javascript/indigo/views/work.js
@@ -99,8 +99,10 @@
           defaultOption: {label: "(none)", value: null},
         }
       },
+      '#work_doctype': 'nature',
       '#work_subtype': 'subtype',
-      '#work_year': 'year',
+      '#work_actor': 'actor',
+      '#work_date': 'date',
       '#work_number': 'number',
     },
 

--- a/indigo_app/templates/indigo_api/work_form.html
+++ b/indigo_app/templates/indigo_api/work_form.html
@@ -47,7 +47,7 @@
 
     {% block work-form-details %}
     <div class="card mb-3">
-      <h5 class="card-header">Work details</h5>
+      <h5 class="card-header">Work identification</h5>
       <div class="card-body">
 
         <div class="form-row">
@@ -58,30 +58,61 @@
         </div>
 
         <div class="form-row">
-          <div class="form-group col-md-3">
-            <label for="work_year" class="required">Year of introduction</label>
-            <input type="text" class="form-control" id="work_year" required pattern="\d{4}" placeholder="yyyy">
-          </div>
-
-          <div class="form-group col-md-6 offset-md-3">
-            <label for="work_number" class="required">Number within year</label>
-            <input type="text" class="form-control" id="work_number" required pattern="[^\s]+">
-            <p class="form-text text-muted">Number or short name that uniquely identifies this legislation within the year of introduction. Numbers, letters and '-' only.</p>
-          </div>
-        </div>
-
-        <div class="form-row">
-          <div class="form-group col-md-4">
-            <label for="work_subtype">Work subtype</label>
-            <select id="work_subtype" class="form-control">
-              <option value="">(none)</option>
-              {% for subtype in subtypes %}
-              <option value="{{ subtype.abbreviation }}">{{ subtype }}</option>
+          <div class="form-group col-4">
+            <label for="work_doctype" class="required">Work type</label>
+            <select id="work_doctype" class="form-control">
+              {% for label, code in doctypes %}
+                <option value="{{ code }}" selected>{{ label }} ({{ code }})</option>
               {% endfor %}
             </select>
           </div>
 
-          <div class="form-group col-md-6 offset-md-2">
+          <div class="form-group col-4">
+            <label for="work_subtype">Work subtype</label>
+            <select id="work_subtype" class="form-control">
+              <option value="">(none)</option>
+              {% for subtype in subtypes %}
+                <option value="{{ subtype.abbreviation }}">{{ subtype }}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="form-group col-4">
+            <label for="work_actor">Responsible organisation (actor)</label>
+            <input type="text" class="form-control" id="work_actor">
+            <div class="form-text text-muted">Organisation that created this work. Not normally used for acts.</div>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group col-md-3 mb-0">
+            <label for="work_date" class="required">Year (or date) of introduction</label>
+            <input type="text" class="form-control" id="work_date" required pattern="\d{4}(-\d{2}-\d{2})?" placeholder="yyyy(-mm-dd)">
+          </div>
+
+          <div class="form-group col-md-6 offset-md-3 mb-0">
+            <label for="work_number" class="required">Number within year</label>
+            <input type="text" class="form-control" id="work_number" required pattern="[^\s]+">
+            <div class="form-text text-muted">Number or short name that uniquely identifies this legislation within the year of introduction. Numbers, letters and '-' only.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">Classification</h5>
+      <div class="card-body">
+
+        <div class="form-row">
+          <div class="form-group col-md-6">
+            <div class="form-check">
+              <input type="checkbox" class="form-check-input" id="{{ form.stub.id_for_label }}" name="{{ form.stub.html_name }}" value="on" {% if form.stub.value %}checked{% endif %}>
+              <label class="mb-0" for="{{ form.stub.id_for_label }}">Stub – this work will have no content</label>
+              <p class="form-text text-muted">Check this option for commencing or amending works that are not captured in detail.</p>
+            </div>
+          </div>
+
+          <div class="form-group col-md-6">
             <button class="btn btn-outline-primary choose-parent float-right" type="button">Choose primary work</button>
             <label>Primary work</label>
             <p class="form-text text-muted">The primary work for regulations and notices is the primary Act</p>
@@ -111,14 +142,6 @@
                 {% endfor %}
               </select>
             {% endif %}
-          </div>
-
-          <div class="form-group col-md-6">
-            <div class="form-check">
-              <input type="checkbox" class="form-check-input" id="{{ form.stub.id_for_label }}" name="{{ form.stub.html_name }}" value="on" {% if form.stub.value %}checked{% endif %}>
-              <label class="mb-0" for="{{ form.stub.id_for_label }}">Stub – this work will have no content</label>
-              <p class="form-text text-muted">Check this option for commencing or amending works that are not captured in detail.</p>
-            </div>
           </div>
         </div>
 

--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -297,6 +297,13 @@ class WorksWebTest(WebTest):
         doc.refresh_from_db()
         self.assertEqual("Different Title", doc.title)
 
+    def test_create_non_act_work(self):
+        form = self.app.get('/places/za/works/new/').forms['edit-work-form']
+        form['work-title'] = "Title"
+        form['work-frbr_uri'] = '/akn/za/statement/deliberation/my-org/2018-02-02/123-45'
+        response = form.submit()
+        self.assertRedirects(response, '/works/akn/za/statement/deliberation/my-org/2018-02-02/123-45/', fetch_redirect_response=False)
+
 
 class BulkCreateWorksTest(testcases.TestCase):
     fixtures = ['languages_data', 'countries', 'user', 'taxonomies', 'work']

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -215,6 +215,7 @@ class AddWorkView(PlaceViewBase, AbstractAuthedIndigoView, CreateView):
         context['work_json'] = json.dumps(work)
 
         context['subtypes'] = Subtype.objects.order_by('name').all()
+        context['doctypes'] = settings.INDIGO['DOCTYPES']
         context['publication_date_optional'] = self.country.code in self.PUB_DATE_OPTIONAL_COUNTRIES
 
         return context

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -8,7 +8,8 @@ from datetime import timedelta
 from django.core.exceptions import ValidationError
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.db.models import Count, Q
+from django.conf import settings
+from django.db.models import Count
 from django.views.generic import DetailView, FormView, UpdateView, CreateView, DeleteView, View
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.list import MultipleObjectMixin
@@ -135,6 +136,7 @@ class EditWorkView(WorkViewBase, UpdateView):
 
     def get_context_data(self, **kwargs):
         context = super(EditWorkView, self).get_context_data(**kwargs)
+        context['doctypes'] = settings.INDIGO['DOCTYPES']
         context['subtypes'] = Subtype.objects.order_by('name').all()
         return context
 

--- a/indigo_content_api/v2/serializers.py
+++ b/indigo_content_api/v2/serializers.py
@@ -82,7 +82,8 @@ class PublishedDocumentSerializer(DocumentSerializer, PublishedDocUrlMixin):
             'created_at', 'updated_at',
 
             # frbr_uri components
-            'country', 'locality', 'nature', 'subtype', 'year', 'number', 'frbr_uri', 'expression_frbr_uri',
+            # year is for backwards compatibility
+            'country', 'locality', 'nature', 'subtype', 'date', 'year', 'actor', 'number', 'frbr_uri', 'expression_frbr_uri',
 
             'publication_date', 'publication_name', 'publication_number', 'publication_document',
             'expression_date', 'commenced', 'commencement_date', 'commencements', 'assent_date',


### PR DESCRIPTION
Very basic support for FRBR URIs with arbitrary doc types, dates (not just years) and actors.

This doesn't add grammar support or differentiate between different document types that may not have legislation-related attributes. It simply lays the foundation for creating works with FRBR URIs that are expressive.

Because this uses the latest Cobalt, it effectively makes the FRBRdate element on a work read-only and ensures it matches the date element in the FRBR URI (see https://github.com/laws-africa/cobalt/issues/41)

![A short title – Indigo 2020-07-14 12-25-04](https://user-images.githubusercontent.com/4178542/87415253-26508480-c5cd-11ea-9cbf-50ba7b126b47.png)
