### PR TITLE
Check for invalid FRBR URI.

### DIFF
--- a/indigo_content_api/tests/v2/test_content_api.py
+++ b/indigo_content_api/tests/v2/test_content_api.py
@@ -191,6 +191,12 @@ class ContentAPIV2TestMixin:
         self.assertEqual(self.client.get(self.api_path + '/akn/zm/').status_code, 404)
         self.assertEqual(self.client.get(self.api_path + '/akn/za-foo/').status_code, 404)
 
+    def test_bad_toc_url(self):
+        response = self.client.get(self.api_path + '/akn/za/act/2014/toc.json')
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get(self.api_path + '/akn/za/act/by-law/2014/toc.json')
+        self.assertEqual(response.status_code, 404)
+
     def test_published_toc(self):
         response = self.client.get(self.api_path + '/akn/za/act/2014/10/eng/toc.json')
         self.assertEqual(response.status_code, 200)

--- a/indigo_content_api/v2/views.py
+++ b/indigo_content_api/v2/views.py
@@ -90,6 +90,9 @@ class FrbrUriViewMixin(PlaceAPIBase):
     def get_document(self):
         """ Find and return one document based on the FRBR URI
         """
+        if not self.frbr_uri:
+            raise Http404
+
         try:
             obj = self.get_document_queryset().get_for_frbr_uri(self.frbr_uri)
             if not obj:


### PR DESCRIPTION
Fixes LAWSAFRICA-3D in sentry.

Fixes https://api.laws.africa/v2/akn/za-cpt/act/by-law/2011/toc.json