### PR TITLE
Always re-render when tree changes

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -623,8 +623,8 @@
           this.fragment = updated;
           this.sourceEditor.editFragment(updated);
           this.xmlEditor.editFragment(updated);
-          this.sourceEditor.render();
         }
+        this.sourceEditor.render();
       } finally {
         this.updating = false;
       }


### PR DESCRIPTION
During a quick edit, the `this.fragment` isn't the old node, so the normal code path isn't followed.