### PR TITLE
Watch dom for changes; resize; prevent unnecessary updates to xml

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -550,7 +550,7 @@
       this.editorReady = this.sourceEditor.editorReady;
       this.editFragment(null);
 
-      this.xmlEditor = new Indigo.XMLEditorView({parent: this});
+      this.xmlEditor = new Indigo.XMLEditorView({parent: this, documentContent: this.documentContent});
     },
 
     tocSelectionChanged: function(selection) {

--- a/indigo_app/static/javascript/indigo/views/document_xml_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_xml_editor.js
@@ -40,20 +40,18 @@
     },
 
     render: function() {
-      if (this.visible) {
-        // pretty-print the xml
-        const xml = prettyPrintXml(Indigo.toXml(this.fragment));
-        if (this.editor.getValue() !== xml) {
-          const posn = this.editor.getPosition();
+      // pretty-print the xml
+      const xml = prettyPrintXml(Indigo.toXml(this.fragment));
+      if (this.editor.getValue() !== xml) {
+        const posn = this.editor.getPosition();
 
-          // ignore the onDidChangeModelContent event triggered by setValue
-          this.updating = true;
-          this.editor.setValue(xml);
-          this.updating = false;
+        // ignore the onDidChangeModelContent event triggered by setValue
+        this.updating = true;
+        this.editor.setValue(xml);
+        this.updating = false;
 
-          this.editor.setPosition(posn);
-          this.editor.layout();
-        }
+        this.editor.setPosition(posn);
+        this.editor.layout();
       }
     },
 

--- a/indigo_app/static/javascript/indigo/views/document_xml_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_xml_editor.js
@@ -16,7 +16,7 @@
       this.documentContent.on('change:dom', () => {
         // if the fragment has been swapped out, don't use a stale fragment; our parent will
         // call editFragment() to update our fragment
-        if (this.fragment.ownerDocument === this.documentContent.xmlDocument) {
+        if (this.visible && this.fragment && this.fragment.ownerDocument === this.documentContent.xmlDocument) {
           this.render();
         }
       });


### PR DESCRIPTION
* add a resize observer to re-layout the xml editor when the window changes
* add a guard to prevent the onDidChangeModelContent from firing when we're force updating the content when rendering the XML from the dom tree
* watch the dom model and ensure what is rendered is kept up to date with changes