### PR TITLE
Include task view url in API, rather than constructing manually

### DIFF
--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -456,6 +456,7 @@ class TaskSerializer(serializers.ModelSerializer):
     work = serializers.CharField(source='work.frbr_uri')
     annotation = serializers.PrimaryKeyRelatedField(queryset=Annotation.objects, required=False, allow_null=True)
     assigned_to = UserSerializer(read_only=True)
+    view_url = serializers.SerializerMethodField()
 
     class Meta:
         model = Task
@@ -471,9 +472,18 @@ class TaskSerializer(serializers.ModelSerializer):
             'labels',
             'assigned_to',
             'annotation',
+            'view_url',
             'created_at', 'updated_at', 'updated_by_user', 'created_by_user',
         )
         read_only_fields = fields
+
+    def get_view_url(self, instance):
+        if not instance.pk:
+            return None
+        return reverse('task_detail', request=self.context['request'], kwargs={
+            'place': instance.work.place.place_code,
+            'pk': instance.pk,
+        })
 
 
 class AnnotationSerializer(serializers.ModelSerializer):

--- a/indigo_app/static/javascript/indigo/views/annotations.js
+++ b/indigo_app/static/javascript/indigo/views/annotations.js
@@ -53,13 +53,6 @@
         json.html = html;
         if (json.task) {
           json.task = json.task.toJSON();
-
-          json.task.view_url =
-            "/places/" +
-            self.document.work.get('country') +
-            (self.document.work.get('locality') ? ('-' + self.document.work.get('locality')) : '') +
-            "/tasks/" +
-            json.task.id;
         }
         json.created_at_text = moment(json.created_at).fromNow();
 


### PR DESCRIPTION
Fixes LAWSAFRICA-5M in Sentry. This means that JS code doesn't have to have extra details to construct the URL.