### PR TITLE
don't assume default doctype if work doesn't have a subtype

### DIFF
--- a/indigo_app/templates/indigo_api/work_new_batch.html
+++ b/indigo_app/templates/indigo_api/work_new_batch.html
@@ -139,7 +139,7 @@
                   {% if row.work.subtype %}
                     {{ row.work.subtype }}
                   {% elif not row.errors %}
-                    {{ view.bulk_creator.default_doctype|capfirst }}
+                    {{ row.work.nature }}
                   {% endif %}
                 </td>
                 <td>
@@ -256,7 +256,7 @@
                   {% if row.work.subtype %}
                     {{ row.work.subtype }}
                   {% elif not row.errors %}
-                    {{ view.bulk_creator.default_doctype|capfirst }}
+                    {{ row.work.nature }}
                   {% endif %}
                 </td>
                 <td>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32566441/106453316-c6023100-6491-11eb-970b-186a49a75edb.png)
