### PR TITLE
don't automatically unblock a task when its blocked_by list is empty

### DIFF
--- a/indigo_api/models/tasks.py
+++ b/indigo_api/models/tasks.py
@@ -317,12 +317,8 @@ class Task(models.Model):
             # this task is no longer blocking other tasks
             task.blocking.clear()
             for blocked_task in blocked_tasks:
-                if has_transition_perm(blocked_task.unblock, user):
-                    # the other task no longer has blocking tasks; unblock it
-                    blocked_task.unblock(user)
-                else:
-                    action.send(user, verb='updated', action_object=blocked_task,
-                                place_code=blocked_task.place.place_code)
+                action.send(user, verb='partially unblocked', action_object=blocked_task,
+                            place_code=blocked_task.place.place_code)
 
     def resolve_anchor(self):
         if self.annotation:

--- a/indigo_api/models/tasks.py
+++ b/indigo_api/models/tasks.py
@@ -317,8 +317,8 @@ class Task(models.Model):
             # this task is no longer blocking other tasks
             task.blocking.clear()
             for blocked_task in blocked_tasks:
-                action.send(user, verb='partially unblocked', action_object=blocked_task,
-                            place_code=blocked_task.place.place_code)
+                action.send(user, verb='resolved a task previously blocking', action_object=blocked_task,
+                            target=task, place_code=blocked_task.place.place_code)
 
     def resolve_anchor(self):
         if self.annotation:

--- a/indigo_app/templates/indigo_app/actions/_action_task.html
+++ b/indigo_app/templates/indigo_app/actions/_action_task.html
@@ -44,6 +44,12 @@
     {% endwith %}
   {% endif %}
 
+  {% if action.target.target_actions.content_type.model == 'task' %}
+    {% with action.target as blocking_task %}
+      (<a href="{% url 'task_detail' place=blocking_task.place.place_code pk=blocking_task.pk %}">#{{ blocking_task.pk }} – {{ blocking_task.title }}</a>)
+    {% endwith %}
+  {% endif %}
+
   {% if action.verb == 'submitted' %}
     for review
   {% endif %}


### PR DESCRIPTION
User feedback indicates that it's better (sometimes) for a task to remain blocked because the work should ideally be signed off before the next task is done.

It'll be fairly tricky and I don't think failsafe to transfer the blockedness of a task from one (now closed) blocking task to a (created separately) signoff task, so for now let's err on the side of caution: The blocked task is still blocked, but not by the blocking task.

The new 'partially unblocked' actstream verb should also help to give users more insight into what happened.

![image](https://user-images.githubusercontent.com/32566441/107627192-9e685100-6c67-11eb-8035-ad0ec6adbc92.png)

After cancelling the two blocking tasks:
![image](https://user-images.githubusercontent.com/32566441/107627254-b049f400-6c67-11eb-8241-56d265dd0e6c.png)

![image](https://user-images.githubusercontent.com/32566441/107627303-c061d380-6c67-11eb-904a-02974845e8ee.png)
