### PR TITLE
Include 'amends_on_date' and other '_on_date's on bulk import

### DIFF
--- a/indigo/bulk_creator.py
+++ b/indigo/bulk_creator.py
@@ -55,6 +55,7 @@ class RowValidationFormBase(forms.Form):
     commences = forms.CharField(required=False)
     commences_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
     amends = forms.CharField(required=False)
+    amends_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
     amended_by = forms.CharField(required=False)
     repealed_by = forms.CharField(required=False)
     repeals = forms.CharField(required=False)
@@ -661,13 +662,13 @@ class BaseBulkCreator(LocaleBasedMatcher):
         if not amended_work:
             return self.create_task(row.work, row, task_type='link-amendment-active')
 
-        date = row.commencement_date or row.work.commencement_date
+        date = row.amends_on_date or row.commencement_date or row.work.commencement_date
         if not date:
             return self.create_task(row.work, row,
                                     task_type='link-amendment-pending-commencement',
                                     amended_work=amended_work)
 
-        row.relationships.append(f'Amends {amended_work}')
+        row.relationships.append(f'Amends {amended_work} on {date}')
         if self.dry_run:
             row.notes.append(f"An 'Apply amendment' task will be created on {amended_work}")
         else:

--- a/indigo/bulk_creator.py
+++ b/indigo/bulk_creator.py
@@ -32,11 +32,11 @@ class SpreadsheetRow:
 
 
 class RowValidationFormBase(forms.Form):
+    # See descriptions, examples of the fields at https://docs.laws.africa/managing-works/bulk-imports-spreadsheet
+    # core details
     country = forms.ChoiceField(required=True)
     locality = forms.ChoiceField(required=False)
     title = forms.CharField()
-    primary_work = forms.CharField(required=False)
-    subleg = forms.CharField(required=False)
     doctype = forms.ChoiceField(required=True)
     subtype = forms.ChoiceField(required=False)
     number = forms.CharField(validators=[
@@ -45,25 +45,31 @@ class RowValidationFormBase(forms.Form):
     year = forms.CharField(validators=[
         RegexValidator(r'\d{4}', 'Must be a year (yyyy).')
     ])
+    # publication details
     publication_name = forms.CharField(required=False)
     publication_number = forms.CharField(required=False)
     publication_date = forms.DateField(error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
+    # other relevant dates
     assent_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
     commencement_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
+    # other info
     stub = forms.BooleanField(required=False)
+    taxonomy = forms.CharField(required=False)
+    # passive relationships
+    primary_work = forms.CharField(required=False)
     commenced_by = forms.CharField(required=False)
     commenced_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
+    amended_by = forms.CharField(required=False)
+    amended_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
+    repealed_by = forms.CharField(required=False)
+    repealed_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
+    # active relationships
+    subleg = forms.CharField(required=False)
     commences = forms.CharField(required=False)
     commences_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
     amends = forms.CharField(required=False)
     amends_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
-    amended_by = forms.CharField(required=False)
-    amended_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
-    repealed_by = forms.CharField(required=False)
     repeals = forms.CharField(required=False)
-    taxonomy = forms.CharField(required=False)
-
-    repealed_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
     repeals_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
 
     def __init__(self, country, locality, subtypes, *args, **kwargs):

--- a/indigo/bulk_creator.py
+++ b/indigo/bulk_creator.py
@@ -63,6 +63,9 @@ class RowValidationFormBase(forms.Form):
     repeals = forms.CharField(required=False)
     taxonomy = forms.CharField(required=False)
 
+    repealed_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
+    repeals_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
+
     def __init__(self, country, locality, subtypes, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['country'].choices = [(country.code, country.name)]
@@ -527,7 +530,7 @@ class BaseBulkCreator(LocaleBasedMatcher):
             # the work was not already repealed; link the new repeal information
             row.relationships.append(f'Repealed by {repealing_work}')
             if not self.dry_run:
-                repeal_date = repealing_work.commencement_date
+                repeal_date = row.repealed_on_date or repealing_work.commencement_date
 
                 if not repeal_date:
                     # there's no date for the repeal (yet), so create a task on the repealing work for once it commences
@@ -560,8 +563,8 @@ class BaseBulkCreator(LocaleBasedMatcher):
 
         if isinstance(repealed_work, Work) and not repealed_work.repealed_by or self.dry_run:
             # the work was not already repealed (or we're in preview); link the new repeal information
+            repeal_date = row.repeals_on_date or row.commencement_date
             row.relationships.append(f'Repeals {repealed_work}')
-            repeal_date = row.commencement_date
 
             if not repeal_date:
                 # there's no date for the repeal (yet), so create a task on the repealing work for once it commences

--- a/indigo/bulk_creator.py
+++ b/indigo/bulk_creator.py
@@ -52,6 +52,7 @@ class RowValidationFormBase(forms.Form):
     commencement_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
     stub = forms.BooleanField(required=False)
     commenced_by = forms.CharField(required=False)
+    commenced_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
     commences = forms.CharField(required=False)
     commences_on_date = forms.DateField(required=False, error_messages={'invalid': 'Date format should be yyyy-mm-dd.'})
     amends = forms.CharField(required=False)
@@ -379,6 +380,7 @@ class BaseBulkCreator(LocaleBasedMatcher):
         # if the commencement date has an error, the row won't have the attribute
         row.commenced = bool(
             getattr(row, 'commencement_date', None) or
+            getattr(row, 'commenced_on_date', None) or
             row.commenced_by)
         if self.dry_run:
             if not row.commenced:
@@ -439,7 +441,7 @@ class BaseBulkCreator(LocaleBasedMatcher):
     def link_commencement_passive(self, row):
         # if the work has commencement details, try linking it
         # make a task if a `commenced_by` FRBR URI is given but not found
-        date = row.commencement_date
+        date = row.commenced_on_date or row.commencement_date
 
         commencing_work = None
         if row.commenced_by:
@@ -731,7 +733,7 @@ Find it and upload it manually.'''
 
         elif task_type == 'link-commencement-passive':
             task.title = 'Link commencement (passive)'
-            task.description = f'''It looks like this work was commenced by "{row.commenced_by}" on {row.commencement_date or "(unknown)"} (see row {row.row_number} of the spreadsheet), but it couldn't be linked automatically. This work has thus been recorded as 'Not commenced'.
+            task.description = f'''It looks like this work was commenced by "{row.commenced_by}" on {row.commenced_on_date or row.commencement_date or "(unknown)"} (see row {row.row_number} of the spreadsheet), but it couldn't be linked automatically. This work has thus been recorded as 'Not commenced'.
 
 Possible reasons:
 – a typo in the spreadsheet

--- a/indigo/tests/bulk_creator/amendments_active.csv
+++ b/indigo/tests/bulk_creator/amendments_active.csv
@@ -1,5 +1,5 @@
-country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
-ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,,,,,,,,,,,,
-ZA,,Amendment,,,2,2020,,,,2020-01-01,2020-06-01,x,,,,,,,,,/akn/za/act/2020/1 – Main,,,,,,
-ZA,,Second amendment,,,3,2020,,,,2020-01-01,2020-07-01,x,,,,,,,,,/akn/za/act/2020/1 – Main,,,,,,
-ZA,,Error,,,4,2020,,,,2020-01-01,2020-07-01,x,,,,,,,,,/akn/za/act/2020/xx – Doesn’t exist,,,,,,
+country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,subleg,commences,commences_on_date,amends,amends_on_date,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
+ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,,,,,,,,,,,,,
+ZA,,Amendment,,,2,2020,,,,2020-01-01,2020-06-01,x,,,,,,,,,/akn/za/act/2020/1 – Main,,,,,,,
+ZA,,Second amendment,,,3,2020,,,,2020-01-01,2020-07-01,x,,,,,,,,,/akn/za/act/2020/1 – Main,2020-08-01,,,,,,
+ZA,,Error,,,4,2020,,,,2020-01-01,2020-07-01,x,,,,,,,,,/akn/za/act/2020/xx – Doesn’t exist,,,,,,,

--- a/indigo/tests/bulk_creator/amendments_passive.csv
+++ b/indigo/tests/bulk_creator/amendments_passive.csv
@@ -1,8 +1,8 @@
-country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
-ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,/akn/za/act/2020/2 – First,,,,,,,,,,,
-ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,/akn/za/act/2020/3 – Second,,,,,,,,,,,
-ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,/akn/za/act/2020/4 – Third,,,,,,,,,,,
-ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,/akn/za/act/2020/xx - Error,,,,,,,,,,,
-ZA,,Amendment,,,2,2020,,,,2020-01-01,2020-06-01,x,,,,,,,,,,,,,,,
-ZA,,Second amendment,,,3,2020,,,,2020-01-01,2020-07-01,x,,,,,,,,,,,,,,,
-ZA,,Third amendment,,,4,2020,,,,2020-01-01,,x,,,,,,,,,,,,,,,
+country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,amended_on_date,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
+ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,/akn/za/act/2020/2 – First,,,,,,,,,,,,
+ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,/akn/za/act/2020/3 – Second,2020-08-01,,,,,,,,,,,
+ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,/akn/za/act/2020/4 – Third,,,,,,,,,,,,
+ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,/akn/za/act/2020/xx - Error,,,,,,,,,,,,
+ZA,,Amendment,,,2,2020,,,,2020-01-01,2020-06-01,x,,,,,,,,,,,,,,,,
+ZA,,Second amendment,,,3,2020,,,,2020-01-01,2020-07-01,x,,,,,,,,,,,,,,,,
+ZA,,Third amendment,,,4,2020,,,,2020-01-01,,x,,,,,,,,,,,,,,,,

--- a/indigo/tests/bulk_creator/commencements_passive.csv
+++ b/indigo/tests/bulk_creator/commencements_passive.csv
@@ -1,7 +1,9 @@
-country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
-ZA,,Uncommenced,,,1,2020,,,,2020-01-01,,,,,,,,,,,,,,,,,
-ZA,,Both date and commenced_by,,,2,2020,,,,2020-01-01,2020-06-05,,,,/akn/za/act/2020/5 - Commencement notice 1,,,,,,,,,,,,
-ZA,,Date only,,,3,2020,,,,2020-01-01,2020-06-05,,,,,,,,,,,,,,,,
-ZA,,Commenced_by only,,,4,2020,,,,2020-01-01,,,,,/akn/za/act/2020/5 - Commencement notice 1,,,,,,,,,,,,
-ZA,,Commencement notice 1,,,5,2020,,,,2020-06-01,2020-07-01,x,,,,,,,,,,,,,,,
-ZA,,Error,,,6,2020,,,,2020-06-01,2020-06-05,,,,/akn/za/act/2020/xx – Doesn’t exist,,,,,,,,,,,,
+country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,commenced_on_date,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
+ZA,,Uncommenced,,,1,2020,,,,2020-01-01,,,,,,,,,,,,,,,,,,
+ZA,,Both date and commenced_by,,,2,2020,,,,2020-01-01,2020-06-05,,,,/akn/za/act/2020/5 - Commencement notice 1,,,,,,,,,,,,,
+ZA,,Date only,,,3,2020,,,,2020-01-01,2020-06-05,,,,,,,,,,,,,,,,,
+ZA,,Commenced_by only,,,4,2020,,,,2020-01-01,,,,,/akn/za/act/2020/5 - Commencement notice 1,,,,,,,,,,,,,
+ZA,,Commencement notice 1,,,5,2020,,,,2020-06-01,2020-07-01,x,,,,,,,,,,,,,,,,
+ZA,,Error,,,6,2020,,,,2020-06-01,2020-06-05,,,,/akn/za/act/2020/xx – Doesn’t exist,,,,,,,,,,,,,
+ZA,,Both commenced_by and commenced_on_date,,,7,2020,,,,2020-01-01,,,,,/akn/za/act/2020/5 - Commencement notice 1,2020-08-01,,,,,,,,,,,,
+ZA,,commenced_on_date only,,,8,2020,,,,2020-01-01,,,,,,2020-08-01,,,,,,,,,,,,

--- a/indigo/tests/bulk_creator/commencements_passive_later.csv
+++ b/indigo/tests/bulk_creator/commencements_passive_later.csv
@@ -1,3 +1,3 @@
-country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
-ZA,,Now commenced,,,1,2020,,,,2020-01-01,2020-09-01,,,,/akn/za/act/2020/7 - Commencement notice 2,,,,,,,,,,,,
-ZA,,Commencement notice 2,,,7,2020,,,,2020-08-01,2020-07-01,x,,,,,,,,,,,,,,,
+country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,commenced_on_date,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
+ZA,,Now commenced,,,1,2020,,,,2020-01-01,,,,,/akn/za/act/2020/9 - Commencement notice 2,2020-09-01,,,,,,,,,,,,
+ZA,,Commencement notice 2,,,9,2020,,,,2020-08-01,2020-07-01,x,,,,,,,,,,,,,,,,

--- a/indigo/tests/bulk_creator/repeals_active.csv
+++ b/indigo/tests/bulk_creator/repeals_active.csv
@@ -1,7 +1,9 @@
-country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
-ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,,,,,,,,,,,,
-ZA,,Repealing work,,,2,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,/akn/za/act/2020/1,,,,,
-ZA,,Trying to repeal the same main,,,6,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,/akn/za/act/2020/1,,,,,
-ZA,,Other main,,,3,2020,,,,2020-01-01,2020-01-01,,,,,,,,,,,,,,,,
-ZA,,"Repealing work, no commencement",,,4,2020,,,,2020-06-01,,x,,,,,,,,,,/akn/za/act/2020/3,,,,,
-ZA,,Repealer of nothing,,,5,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,/akn/za/act/2020/xx,,,,,
+country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,repeals_on_date,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
+ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,,,,,,,,,,,,,
+ZA,,Repealing work,,,2,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,/akn/za/act/2020/1,2020-06-03,,,,,
+ZA,,Trying to repeal the same main,,,6,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,/akn/za/act/2020/1,,,,,,
+ZA,,Other main,,,3,2020,,,,2020-01-01,2020-01-01,,,,,,,,,,,,,,,,,
+ZA,,"Repealing work, no commencement",,,4,2020,,,,2020-06-01,,x,,,,,,,,,,/akn/za/act/2020/3,,,,,,
+ZA,,Repealer of nothing,,,5,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,/akn/za/act/2020/xx,,,,,,
+ZA,,Yet another main,,,7,2020,,,,2020-01-01,2020-01-01,,,,,,,,,,,,,,,,,
+ZA,,Repealing work (also successful),,,8,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,/akn/za/act/2020/7,,,,,,

--- a/indigo/tests/bulk_creator/repeals_passive.csv
+++ b/indigo/tests/bulk_creator/repeals_passive.csv
@@ -1,6 +1,8 @@
-country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
-ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,,/akn/za/act/2020/2,,,,,,,,,,
-ZA,,Repealing work,,,2,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,,,,,,
-ZA,,Other main,,,3,2020,,,,2020-01-01,2020-01-01,,,,,,/akn/za/act/2020/4,,,,,,,,,,
-ZA,,"Repealing work, no commencement",,,4,2020,,,,2020-06-01,,x,,,,,,,,,,,,,,,
-ZA,,Last main,,,5,2020,,,,2020-06-01,2020-06-01,,,,,,/akn/za/act/2020/xx,,,,,,,,,,
+country,locality,title,cap,subtype (blank for Acts),number,year,publication_name,publication_number,assent_date,publication_date,commencement_date,stub (✔),taxonomy,primary_work,commenced_by,amended_by,repealed_by,repealed_on_date,subleg,commences,commences_on_date,amends,repeals,Ignore (x) or in (✔),frbr_uri,frbr_uri_title,comments,LINKS ETC (add columns as needed)
+ZA,,Main,,,1,2020,,,,2020-01-01,2020-01-01,,,,,,/akn/za/act/2020/2,2020-06-03,,,,,,,,,,
+ZA,,Repealing work,,,2,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,,,,,,,
+ZA,,Other main,,,3,2020,,,,2020-01-01,2020-01-01,,,,,,/akn/za/act/2020/4,,,,,,,,,,,
+ZA,,"Repealing work, no commencement",,,4,2020,,,,2020-06-01,,x,,,,,,,,,,,,,,,,
+ZA,,Last main,,,5,2020,,,,2020-06-01,2020-06-01,,,,,,/akn/za/act/2020/xx,,,,,,,,,,,
+ZA,,Yet another main,,,6,2020,,,,2020-01-01,2020-01-01,,,,,,/akn/za/act/2020/7,,,,,,,,,,,
+ZA,,Repealing work (also successful),,,7,2020,,,,2020-06-01,2020-06-01,x,,,,,,,,,,,,,,,,

--- a/indigo/tests/bulk_creator/test_bulk_creator.py
+++ b/indigo/tests/bulk_creator/test_bulk_creator.py
@@ -633,13 +633,13 @@ class BaseBulkCreatorTest(testcases.TestCase):
         self.assertEqual(
             ['Stub', "An 'Apply amendment' task will be created on /akn/za/act/2020/1 – Main (about to be imported)"],
             amend1.notes)
-        self.assertEqual(['Amends /akn/za/act/2020/1 – Main (about to be imported)'], amend1.relationships)
+        self.assertEqual(['Amends /akn/za/act/2020/1 – Main (about to be imported) on 2020-06-01'], amend1.relationships)
         self.assertEqual(['link gazette'], amend1.tasks)
 
         self.assertEqual(
             ['Stub', "An 'Apply amendment' task will be created on /akn/za/act/2020/1 – Main (about to be imported)"],
             amend2.notes)
-        self.assertEqual(['Amends /akn/za/act/2020/1 – Main (about to be imported)'], amend2.relationships)
+        self.assertEqual(['Amends /akn/za/act/2020/1 – Main (about to be imported) on 2020-08-01'], amend2.relationships)
         self.assertEqual(['link gazette'], amend2.tasks)
 
         self.assertEqual(['Stub'], error.notes)
@@ -658,6 +658,9 @@ class BaseBulkCreatorTest(testcases.TestCase):
         amenders = [a.amending_work for a in amendments]
         self.assertIn(amend1, amenders)
         self.assertIn(amend2, amenders)
+        dates = [a.date for a in amendments]
+        self.assertIn(datetime.date(2020, 6, 1), dates)
+        self.assertIn(datetime.date(2020, 8, 1), dates)
 
         main_tasks = [t.title for t in main.tasks.all()]
         self.assertEqual(2, main_tasks.count('Apply amendment'))

--- a/indigo/tests/bulk_creator/test_bulk_creator.py
+++ b/indigo/tests/bulk_creator/test_bulk_creator.py
@@ -846,13 +846,18 @@ class BaseBulkCreatorTest(testcases.TestCase):
         main2 = works[2].work
         repeal2 = works[3].work
         main3 = works[4].work
+        main4 = works[5].work
+        repeal3 = works[6].work
 
         self.assertEqual(main1.repealed_by, repeal1)
+        self.assertEqual(main1.repealed_date, datetime.date(2020, 6, 3))
         self.assertNotIn('Link repeal', [t.title for t in main1.tasks.all()])
         self.assertIsNone(main2.repealed_by)
         self.assertIn('Link repeal (pending commencement)', [t.title for t in repeal2.tasks.all()])
         self.assertIsNone(main3.repealed_by)
         self.assertIn('Link repeal', [t.title for t in main3.tasks.all()])
+        self.assertEqual(main4.repealed_by, repeal3)
+        self.assertEqual(main4.repealed_date, datetime.date(2020, 6, 1))
 
     def test_link_repeals_active(self):
         # TODO: add test for check-update-repeal
@@ -905,14 +910,19 @@ class BaseBulkCreatorTest(testcases.TestCase):
         main2 = works[3].work
         repeal2 = works[4].work
         repeal3 = works[5].work
+        main3 = works[6].work
+        repeal4 = works[7].work
 
         self.assertEqual(main1.repealed_by, repeal1)
+        self.assertEqual(main1.repealed_date, datetime.date(2020, 6, 3))
         self.assertNotIn('Link repeal', [t.title for t in main1.tasks.all()])
         self.assertIn('Check / update repeal', [t.title for t in main1.tasks.all()])
         self.assertNotIn(main1, repealfail.repealed_works.all())
         self.assertIsNone(main2.repealed_by)
         self.assertIn('Link repeal (pending commencement)', [t.title for t in repeal2.tasks.all()])
         self.assertIn('Link repeal', [t.title for t in repeal3.tasks.all()])
+        self.assertEqual(main3.repealed_by, repeal4)
+        self.assertEqual(main3.repealed_date, datetime.date(2020, 6, 1))
 
     def test_duplicates(self):
         # preview

--- a/indigo/tests/bulk_creator/test_bulk_creator.py
+++ b/indigo/tests/bulk_creator/test_bulk_creator.py
@@ -737,10 +737,10 @@ class BaseBulkCreatorTest(testcases.TestCase):
         self.assertEqual([], amend_1.notes)
         self.assertEqual([], amend_2.notes)
         self.assertEqual([], amend_3.notes)
-        self.assertEqual(['Amended by /akn/za/act/2020/2 (Amendment)'], main.relationships)
-        self.assertEqual(['Amended by /akn/za/act/2020/3 (Second amendment)'], dupe1.relationships)
+        self.assertEqual(['Amended by /akn/za/act/2020/2 (Amendment) on 2020-06-01'], main.relationships)
+        self.assertEqual(['Amended by /akn/za/act/2020/3 (Second amendment) on 2020-08-01'], dupe1.relationships)
         # TODO: this should show up as an error (pending commencement) in preview
-        self.assertEqual(['Amended by /akn/za/act/2020/4 (Third amendment)'], dupe2.relationships)
+        self.assertEqual([], dupe2.relationships)
         self.assertEqual([], dupe3.relationships)
         self.assertEqual([], amend_1.relationships)
         self.assertEqual([], amend_2.relationships)
@@ -751,6 +751,9 @@ class BaseBulkCreatorTest(testcases.TestCase):
         amenders = [a.amending_work for a in amendments]
         self.assertIn(amend_1.work, amenders)
         self.assertIn(amend_2.work, amenders)
+        dates = [a.date for a in amendments]
+        self.assertIn(datetime.date(2020, 6, 1), dates)
+        self.assertIn(datetime.date(2020, 8, 1), dates)
 
         tasks = main.work.tasks.all()
         task_titles = [t.title for t in tasks]


### PR DESCRIPTION
These are exported but have been ignored on import so far (other than for active commencements).

`repealed_on_date` and `repeals_on_date` would still be ignored on import after this PR; they should eventually be pulled in on import too.

closes #1253 