### PR TITLE
Helper to support reversing content API URLs.

### DIFF
--- a/indigo_content_api/apps.py
+++ b/indigo_content_api/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class IndigoContentAPIConfig(AppConfig):
     name = 'indigo_content_api'
     verbose_name = 'Indigo Content API'
+
+    def ready(self):
+        # intercept calls to reverse to use django_host's reverse
+        from indigo_content_api.reverse import intercept_drf_reverse
+        intercept_drf_reverse()

--- a/indigo_content_api/reverse.py
+++ b/indigo_content_api/reverse.py
@@ -13,7 +13,7 @@ CONTENT_API_HOST = 'api'
 
 
 def using_django_hosts():
-    return settings.get('ROOT_HOSTCONF')
+    return getattr(settings, 'ROOT_HOSTCONF', None)
 
 
 def reverse_content_api(*args, **kwargs):

--- a/indigo_content_api/reverse.py
+++ b/indigo_content_api/reverse.py
@@ -1,0 +1,45 @@
+""" This module has helper routines to assist with reverse Content API URLs when the Content API
+might be running on a separate domain using django_hosts. In such a case, the App still needs to
+reverse certain API URLs and by default Django would try to use the App's URLs, not the API's URLs.
+"""
+
+from django.conf import settings
+from django.urls import reverse as django_reverse
+from rest_framework.reverse import reverse as drf_reverse
+
+
+# the host alias that runs the content_api, if django_hosts is in use
+CONTENT_API_HOST = 'api'
+
+
+def using_django_hosts():
+    return settings.get('ROOT_HOSTCONF')
+
+
+def reverse_content_api(*args, **kwargs):
+    """ Reverses an Indigo Content API url by delegating to the django_rest_framework reverse.
+
+    If django_hosts is in use, then a host parameter is added so that the appropriate API urlconf is used.
+
+    While the base Indigo doesn't enable django_hosts by default, this allows Indigo users to
+    opt-in to django_hosts and host the API on a separate hostname.
+    """
+    if using_django_hosts():
+        kwargs.setdefault('host', CONTENT_API_HOST)
+    return drf_reverse(*args, **kwargs)
+
+
+def intercept_drf_reverse():
+    """ Intercept DRF's call to django_reverse to first try calling django_hosts's reverse.
+    """
+    if using_django_hosts():
+        import rest_framework.reverse
+        rest_framework.reverse.django_reverse = host_aware_reverse
+
+
+def host_aware_reverse(*args, **kwargs):
+    if 'host' in kwargs:
+        from django_hosts import reverse as dh_reverse
+        return dh_reverse(*args, **kwargs)
+
+    return django_reverse(*args, **kwargs)

--- a/indigo_content_api/v2/serializers.py
+++ b/indigo_content_api/v2/serializers.py
@@ -1,7 +1,6 @@
 from itertools import groupby
 
 from rest_framework import serializers
-from rest_framework.reverse import reverse
 
 from cobalt import datestring
 
@@ -9,6 +8,7 @@ from indigo_api.models import Document, Attachment, Country, Locality, Publicati
 from indigo_api.serializers import \
     DocumentSerializer, AttachmentSerializer, VocabularyTopicSerializer, CommencementSerializer, \
     PublicationDocumentSerializer as PublicationDocumentSerializerBase
+from indigo_content_api.reverse import reverse_content_api
 
 
 class PublishedDocUrlMixin:
@@ -17,13 +17,13 @@ class PublishedDocUrlMixin:
         eg. /api/v2/akn/za/act/2005/01/eng@2006-02-03
         """
         uri = (frbr_uri or doc.expression_uri.expression_uri())[1:]
-        uri = reverse('published-document-detail', request=request, kwargs={'frbr_uri': uri})
+        uri = reverse_content_api('published-document-detail', request=request, kwargs={'frbr_uri': uri})
         return uri.replace('%40', '@')
 
     def place_url(self, request, code):
         if self.prefix:
             code = 'akn/' + code
-        return reverse('published-document-detail', request=request, kwargs={'frbr_uri': code})
+        return reverse_content_api('published-document-detail', request=request, kwargs={'frbr_uri': code})
 
 
 class ExpressionSerializer(serializers.Serializer, PublishedDocUrlMixin):


### PR DESCRIPTION
This is needed for the case when the content API is run on a separate
domain using django_hosts. Sometimes non-API code (such as indigo_app)
needs to reverse indigo_content_api urls. When django_hosts is in use,
this fails, because the API urlconf is not loaded.

With this patch, we detect if django_hosts is in use and inject a
host='api' parameter into the call to DRF's reverse(), AND we ensure that
DRF's reverse() call makes use of django_host's reverse(), which will
load the correct urlconf.