### PR TITLE
Commencements tweaks

### DIFF
--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -562,6 +562,7 @@ class CommencementsBeautifier(LocaleBasedMatcher):
         # e.g. section 1–3; section 5–8
         elif self.previous_in_run:
             self.end_current()
+            self.previous_in_run = False
 
     def make_beautiful(self, provisions, assess_against):
         self.current_run = []

--- a/indigo/tests/test_beautiful_provisions.py
+++ b/indigo/tests/test_beautiful_provisions.py
@@ -37,7 +37,7 @@ class BeautifulProvisionsTestCase(TestCase):
                 return f'{n}.'
             elif with_brackets:
                 return f'({n})'
-            return n
+            return f'{n}'
 
         return [TOCElement(
             element=None, component=None, children=[], type_=type,
@@ -157,6 +157,15 @@ class BeautifulProvisionsTestCase(TestCase):
         self.assertEqual('Chapter 1, Part A, section 2–3; Part B (section 4–5); Chapter 2 (section 6–7)', self.run_nested(provision_ids))
         self.beautifier.commenced = False
         self.assertEqual('Chapter 1, Part A, section 2–3; Part B (section 4–5); Chapter 2 (section 6–7)', self.run_nested(provision_ids))
+
+    def test_nested_mix(self):
+        provision_ids = [
+            'sec_1__subsec_1', 'sec_6',
+        ]
+        self.beautifier.commenced = True
+        self.assertEqual('Chapter 1, Part A, section 1(1); Chapter 2, section 6', self.run_nested(provision_ids))
+        self.beautifier.commenced = False
+        self.assertEqual('Chapter 1, Part A, section 1(1); Chapter 2, section 6', self.run_nested(provision_ids))
 
     def test_nested_partial_containers(self):
         # Chapter 1 is mentioned regardless because it's given

--- a/indigo_app/templates/indigo_api/_provisions_tree_commenced.html
+++ b/indigo_app/templates/indigo_api/_provisions_tree_commenced.html
@@ -11,7 +11,7 @@
           {{ prov.title|default:prov.id }}
         </span>
         {% if prov.commenced and prov.all_descendants_same %}
-          (Commenced in full)
+          <em>(Commenced in full)</em>
         {% elif prov.children %}
           <ul class="provisions-list">
             {% include "indigo_api/_provisions_tree_commenced.html" with provisions=prov.children %}

--- a/indigo_app/templates/indigo_api/_provisions_tree_commenced.html
+++ b/indigo_app/templates/indigo_api/_provisions_tree_commenced.html
@@ -1,13 +1,11 @@
 {% for prov in provisions %}
   {% if prov.commenced or prov.children and not prov.all_descendants_same %}
     <li>
-      {% if prov.commenced %}
-        <div class="item-indent">
+      <div class="item-indent">
+        {% if prov.commenced %}
           <input type="checkbox" disabled checked>
-        </div>
-      {% else %}
-        <div class="item-indent"></div>
-      {% endif %}
+        {% endif %}
+      </div>
       <div class="content">
         <span class="{% if prov.commenced %}text-body{% else %}text-black-50{% endif %}">
           {{ prov.title|default:prov.id }}

--- a/indigo_app/templates/indigo_api/_provisions_tree_uncommenced.html
+++ b/indigo_app/templates/indigo_api/_provisions_tree_uncommenced.html
@@ -1,13 +1,11 @@
 {% for prov in provisions %}
   {% if not prov.commenced or prov.children and not prov.all_descendants_same %}
     <li>
-      {% if prov.commenced %}
-        <div class="item-indent">
+      <div class="item-indent">
+        {% if prov.commenced %}
           <input type="checkbox" disabled checked>
-        </div>
-      {% else %}
-        <div class="item-indent"></div>
-      {% endif %}
+        {% endif %}
+      </div>
       <div class="content">
         <span class="{% if prov.commenced %}text-black-50{% else %}alert-warning{% endif %}">
           {{ prov.title|default:prov.id }}

--- a/indigo_app/templates/indigo_api/_provisions_tree_uncommenced.html
+++ b/indigo_app/templates/indigo_api/_provisions_tree_uncommenced.html
@@ -9,8 +9,11 @@
       <div class="content">
         <span class="{% if prov.commenced %}text-black-50{% else %}alert-warning{% endif %}">
           {{ prov.title|default:prov.id }}
+          {% if not prov.commenced and prov.all_descendants_same %}
+            <em>(in full)</em>
+          {% endif %}
         </span>
-        {% if prov.children %}
+        {% if prov.children and not prov.all_descendants_same %}
           <ul>
             {% include "indigo_api/_provisions_tree_uncommenced.html" with provisions=prov.children %}
           </ul>

--- a/indigo_app/templates/indigo_api/template_parts/provisions_tree_view.html
+++ b/indigo_app/templates/indigo_api/template_parts/provisions_tree_view.html
@@ -4,19 +4,14 @@
     <li class="provisions-list__item">
       <div class="provisions-list__item__body">
         <label>
-          {% if prov.visible %}
-            <input value="{{ prov.id }}"
-                   type="checkbox"
-                   {% if prov.id in checked %}checked{% endif %}
-                   name="provisions"
-                   class="mr-2"
-            />
-          {% else %}
-            <input type="checkbox"
-                   disabled
-                   class="mr-2"
-            >
-          {% endif %}
+          <input type="checkbox" class="mr-2"
+            {% if prov.visible %}
+              value="{{ prov.id }}" name="provisions"
+              {% if prov.id in checked %}checked{% endif %}
+            {% else %}
+              disabled
+            {% endif %}
+          >
         </label>
         <div class="provision-title">
           {{ prov.title }}


### PR DESCRIPTION
will resolve https://edit.laws.africa/places/za/tasks/14107/

Chapter 5 here is not uncommenced:
![image](https://user-images.githubusercontent.com/32566441/126225801-11504edf-5328-485d-b492-8cc619f7aaab.png)

Also tweaks existing commencements view:
- italicise _(Commenced in full)_
- collapses uncommenced provisions (open to discussing this)

![image](https://user-images.githubusercontent.com/32566441/126226671-28552c5f-c00a-4a5b-a947-31b63805cb9b.png)

item (ii) here contains items (a) and (B):
![image](https://user-images.githubusercontent.com/32566441/126226604-e3fb8e0d-a165-4301-85f3-ab9450e9b12c.png)
