### PR TITLE
Commencement tweaks

### DIFF
--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -495,6 +495,9 @@ class CommencementsBeautifier(LocaleBasedMatcher):
         if p.children and not p.all_descendants_same:
             # don't continue run if we're giving subprovisions
             end_at_next_add = True
+            # e.g. section 1-5; section 6(1)
+            if p.type in [r['type'] for r in self.current_run]:
+                self.end_current()
             for c in p.children:
                 add_to_subs(c, p.num)
 

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -428,7 +428,7 @@ class CommencementsBeautifier(LocaleBasedMatcher):
 
     def stringify_run(self, run):
         # first (could be only) item, e.g. 'section 1'
-        run_str = f"{run[0]['type']} {run[0]['num']}"
+        run_str = f"{run[0]['type']} {run[0]['num']}" if run[0]['num'] else run[0]['type']
         # common case: e.g. section 1–5 (all the same type)
         if len(run) > 1 and not any(r['new_run'] for r in run):
             run_str += f"–{run[-1]['num']}"
@@ -442,7 +442,7 @@ class CommencementsBeautifier(LocaleBasedMatcher):
             # get all e.g. articles, then all e.g. regulations
             for subsequent_type in [r['type'] for r in run if r['new_run']]:
                 this_type = [r for r in run if r['type'] == subsequent_type]
-                run_str += f", {subsequent_type} {this_type[0]['num']}"
+                run_str += f", {subsequent_type} {this_type[0]['num']}" if this_type[0]['num'] else f", {subsequent_type}"
                 run_str += f"–{this_type[-1]['num']}" if len(this_type) > 1 else ''
 
         return run_str

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -467,9 +467,9 @@ class CommencementsBeautifier(LocaleBasedMatcher):
         p.num += f' ({self.stringify_run(basics)})' if basics else ''
 
     def stash_current(self):
-        # TODO: comma-separate runs in stash
-        self.current_stash += self.current_run
-        self.current_run = []
+        if self.current_run:
+            self.current_stash.append(self.current_run)
+            self.current_run = []
 
     def add_to_current(self, p, all_basic_units=False):
         if all_basic_units:
@@ -482,9 +482,7 @@ class CommencementsBeautifier(LocaleBasedMatcher):
             self.runs.append(self.stringify_run(self.current_run))
             self.current_run = []
         elif self.current_stash:
-            # TODO: comma-separate runs in stash: section 1, section 3–6
-            # self.runs.append(', '.join([self.stringify_run(r) for r in self.current_stash]))
-            self.runs.append(self.stringify_run(self.current_stash))
+            self.runs.append(', '.join([self.stringify_run(r) for r in self.current_stash]))
             self.current_stash = []
 
         self.previous_in_run = False
@@ -513,6 +511,7 @@ class CommencementsBeautifier(LocaleBasedMatcher):
         if p.children and not p.all_descendants_same:
             # don't continue run if we're giving subprovisions
             end_at_next_add = True
+            self.stash_next = True
             # e.g. section 1-5, section 6(1)
             if p.type in [r['type'] for r in self.current_run]:
                 self.stash_current()
@@ -524,6 +523,10 @@ class CommencementsBeautifier(LocaleBasedMatcher):
 
         if end_at_next_add:
             self.stash_current()
+        elif self.stash_next:
+            self.stash_current()
+            self.stash_next = False
+
 
     def process_provision(self, p):
         # start processing?
@@ -577,6 +580,7 @@ class CommencementsBeautifier(LocaleBasedMatcher):
         self.current_stash = []
         self.runs = []
         self.previous_in_run = False
+        self.stash_next = False
 
         self.decorate_provisions(provisions, assess_against)
 

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -514,15 +514,15 @@ class CommencementsBeautifier(LocaleBasedMatcher):
 
             # e.g. a Chapter that isn't fully un/commenced
             elif p.container:
-                # if the id was explicitly given: Chapter 1 (in part);
-                if p.commenced == self.commenced:
+                # if the id was explicitly given and none of the children will be given: Chapter 1 (in part);
+                if p.commenced == self.commenced and p.all_descendants_opposite:
                     old_num = p.num
                     p.num += ' (in part)'
                     self.add_to_current(p)
                     p.num = old_num
                     self.end_current()
-                # if we're going to keep going: Chapter 1 (in part); Chapter 1, …
-                if not p.all_descendants_opposite or p.commenced != self.commenced:
+                # if we're going to keep going: Chapter 1, Part …
+                else:
                     self.add_to_current(p)
 
             # e.g. section with subsections

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -451,11 +451,18 @@ class CommencementsBeautifier(LocaleBasedMatcher):
         """ Adds a description of all basic units in a container to the container's `num`.
         e.g. Part A's `num`: 'A' --> 'A (section 1–3)'
         """
-        # get all the basic units in the container
+        # get all the basic units in the container, but don't look lower than needed
         basics = []
-        for c in descend_toc_pre_order(p.children):
-            if c.basic_unit:
-                self.add_to_run(c, basics)
+        def look_for_basics(prov, basics):
+            if prov.basic_unit:
+                self.add_to_run(prov, basics)
+            elif prov.container:
+                for c in prov.children:
+                    look_for_basics(c, basics)
+
+        # we don't need to check if p itself is a basic unit because it must be a container
+        for c in p.children:
+            look_for_basics(c, basics)
 
         p.num += f' ({self.stringify_run(basics)})' if basics else ''
 

--- a/indigo/tests/test_beautiful_provisions.py
+++ b/indigo/tests/test_beautiful_provisions.py
@@ -62,19 +62,19 @@ class BeautifulProvisionsTestCase(TestCase):
 
         provision_ids = ['section-1', 'section-3', 'section-4', 'section-5', 'section-6']
         description = self.beautifier.make_beautiful(self.commenceable_provisions, provision_ids)
-        self.assertEqual(description, 'section 1; section 3–6')
+        self.assertEqual(description, 'section 1, section 3–6')
 
         provision_ids = ['section-1', 'section-2', 'section-3', 'section-4', 'section-5', 'section-7']
         description = self.beautifier.make_beautiful(self.commenceable_provisions, provision_ids)
-        self.assertEqual(description, 'section 1–5; section 7')
+        self.assertEqual(description, 'section 1–5, section 7')
 
         provision_ids = ['section-1', 'section-3', 'section-4', 'section-5', 'section-6', 'section-8']
         description = self.beautifier.make_beautiful(self.commenceable_provisions, provision_ids)
-        self.assertEqual(description, 'section 1; section 3–6; section 8')
+        self.assertEqual(description, 'section 1, section 3–6, section 8')
 
         provision_ids = ['section-1', 'section-4', 'section-5', 'section-6', 'section-7', 'section-8', 'section-9', 'section-10', 'section-11', 'section-12', 'section-14', 'section-16', 'section-20', 'section-21']
         description = self.beautifier.make_beautiful(self.commenceable_provisions, provision_ids)
-        self.assertEqual(description, 'section 1; section 4–12; section 14; section 16; section 20–21')
+        self.assertEqual(description, 'section 1, section 4–12, section 14, section 16, section 20–21')
 
     def test_one_item(self):
         provision_ids = ['section-23']
@@ -84,7 +84,7 @@ class BeautifulProvisionsTestCase(TestCase):
     def test_two_items(self):
         provision_ids = ['section-23', 'section-25']
         description = self.beautifier.make_beautiful(self.commenceable_provisions, provision_ids)
-        self.assertEqual(description, 'section 23; section 25')
+        self.assertEqual(description, 'section 23, section 25')
 
     def test_three_items(self):
         provision_ids = ['section-23', 'section-24', 'section-25']
@@ -377,9 +377,9 @@ class BeautifulProvisionsTestCase(TestCase):
             'sec_3'
         ]
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 3', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3), section 3', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 3', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3), section 3', self.run_nested(provision_ids))
 
         provision_ids = [
             'chp_1',
@@ -396,9 +396,9 @@ class BeautifulProvisionsTestCase(TestCase):
             'sec_2'
         ]
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 2', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3), section 2', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 2', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3), section 2', self.run_nested(provision_ids))
 
         provision_ids = ['sec_1__subsec_1__list_1__item_b', 'sec_4']
         self.beautifier.commenced = True
@@ -409,9 +409,9 @@ class BeautifulProvisionsTestCase(TestCase):
         # If a basic unit isn't fully commenced, don't end up with section 6–7(1)
         provision_ids = ['sec_6', 'sec_7__subsec_1']
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 2, section 6; section 7(1)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 2, section 6, section 7(1)', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 2, section 6; section 7(1)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 2, section 6, section 7(1)', self.run_nested(provision_ids))
 
     def run_lonely(self, provision_ids):
         lonely_item = self.make_toc_elements('item_', 'item', ['xxx'])[0]

--- a/indigo/tests/test_beautiful_provisions.py
+++ b/indigo/tests/test_beautiful_provisions.py
@@ -19,9 +19,11 @@ class BeautifulProvisionsTestCase(TestCase):
         items_1 = self.make_toc_elements('sec_1__subsec_1__list_1__item_', 'item', ['a', 'aA', 'b', 'c'])
         items_1[0].children = items_2
         subsections = self.make_toc_elements('sec_1__subsec_', 'subsection', range(1, 5))
+        sec7_subsections = self.make_toc_elements('sec_7__subsec_', 'subsection', range(1, 3))
         subsections[0].children = items_1
         sections = self.make_toc_elements('sec_', 'section', range(1, 8), basic_unit=True)
         sections[0].children = subsections
+        sections[6].children = sec7_subsections
         parts = self.make_toc_elements('chp_1__part_', 'part', ['A', 'B'], with_brackets=False)
         parts[0].children = sections[:3]
         parts[1].children = sections[3:5]
@@ -120,7 +122,7 @@ class BeautifulProvisionsTestCase(TestCase):
             'sec_1__subsec_2', 'sec_1__subsec_3', 'sec_1__subsec_4',
             'sec_2', 'sec_3',
             'chp_1__part_B', 'sec_4', 'sec_5',
-            'chp_2', 'sec_6', 'sec_7',
+            'chp_2', 'sec_6', 'sec_7', 'sec_7__subsec_1', 'sec_7__subsec_2',
         ]
         self.beautifier.commenced = True
         self.assertEqual('Chapter 1 (section 1–5); Chapter 2 (section 6–7)', self.run_nested(provision_ids))
@@ -151,7 +153,7 @@ class BeautifulProvisionsTestCase(TestCase):
         provision_ids = [
             'sec_2', 'sec_3',
             'chp_1__part_B', 'sec_4', 'sec_5',
-            'chp_2', 'sec_6', 'sec_7'
+            'chp_2', 'sec_6', 'sec_7', 'sec_7__subsec_1', 'sec_7__subsec_2'
         ]
         self.beautifier.commenced = True
         self.assertEqual('Chapter 1, Part A, section 2–3; Part B (section 4–5); Chapter 2 (section 6–7)', self.run_nested(provision_ids))
@@ -403,6 +405,13 @@ class BeautifulProvisionsTestCase(TestCase):
         self.assertEqual('Chapter 1, Part A, section 1(1)(b); Part B, section 4', self.run_nested(provision_ids))
         self.beautifier.commenced = False
         self.assertEqual('Chapter 1, Part A, section 1(1)(b); Part B, section 4', self.run_nested(provision_ids))
+
+        # If a basic unit isn't fully commenced, don't end up with section 6–7(1)
+        provision_ids = ['sec_6', 'sec_7__subsec_1']
+        self.beautifier.commenced = True
+        self.assertEqual('Chapter 2, section 6; section 7(1)', self.run_nested(provision_ids))
+        self.beautifier.commenced = False
+        self.assertEqual('Chapter 2, section 6; section 7(1)', self.run_nested(provision_ids))
 
     def run_lonely(self, provision_ids):
         lonely_item = self.make_toc_elements('item_', 'item', ['xxx'])[0]

--- a/indigo/tests/test_beautiful_provisions.py
+++ b/indigo/tests/test_beautiful_provisions.py
@@ -143,9 +143,9 @@ class BeautifulProvisionsTestCase(TestCase):
             'sec_2', 'sec_3',
         ]
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (section 1–3)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A (section 1–3)', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (section 1–3)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A (section 1–3)', self.run_nested(provision_ids))
 
         # don't repeat 'Chapter 1' before Part B
         provision_ids = [
@@ -168,14 +168,14 @@ class BeautifulProvisionsTestCase(TestCase):
         self.assertEqual('Chapter 1, Part A, section 1(1); Chapter 2, section 6', self.run_nested(provision_ids))
 
     def test_nested_partial_containers(self):
-        # Chapter 1 is mentioned regardless because it's given
+        # Chapter 1 is not mentioned separately because one of its descendants is given
         provision_ids = ['chp_1', 'sec_2']
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A, section 2', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A, section 2', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2', self.run_nested(provision_ids))
 
-        # Chapter 1, Part B are mentioned regardless because they're given
+        # Chapter 1, Part B are not mentioned separately because one of their descendants is given
         provision_ids = [
             'chp_1', 'chp_1__part_A',
             'sec_1', 'sec_1__subsec_1',
@@ -193,9 +193,9 @@ class BeautifulProvisionsTestCase(TestCase):
             'chp_1__part_B',
         ]
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (section 1–3); Part B (in part)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A (section 1–3); Part B (in part)', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (section 1–3); Part B (in part)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A (section 1–3); Part B (in part)', self.run_nested(provision_ids))
 
         provision_ids = [
             'chp_1', 'chp_1__part_A',
@@ -214,16 +214,16 @@ class BeautifulProvisionsTestCase(TestCase):
             'chp_1__part_B', 'sec_4',
         ]
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (section 1–3); Part B (in part); Part B, section 4', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A (section 1–3); Part B, section 4', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (section 1–3); Part B (in part); Part B, section 4', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A (section 1–3); Part B, section 4', self.run_nested(provision_ids))
 
         # Chapter 1, Part A is mentioned (even though it's not given) for context
         provision_ids = ['chp_1', 'sec_2', 'chp_1__part_B']
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A, section 2; Part B (in part)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2; Part B (in part)', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A, section 2; Part B (in part)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2; Part B (in part)', self.run_nested(provision_ids))
 
         provision_ids = ['sec_2', 'chp_1__part_B']
         self.beautifier.commenced = True
@@ -255,9 +255,9 @@ class BeautifulProvisionsTestCase(TestCase):
         # Both Part A and Part B are given for context 
         provision_ids = ['chp_1', 'sec_2', 'sec_4', 'sec_5']
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A, section 2; Part B, section 4–5', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2; Part B, section 4–5', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A, section 2; Part B, section 4–5', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2; Part B, section 4–5', self.run_nested(provision_ids))
 
         provision_ids = [
             'chp_1__part_A',
@@ -281,9 +281,9 @@ class BeautifulProvisionsTestCase(TestCase):
 
         provision_ids = ['chp_1', 'sec_2', 'chp_1__part_B', 'sec_4', 'sec_5']
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A, section 2; Part B (section 4–5)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2; Part B (section 4–5)', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A, section 2; Part B (section 4–5)', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2; Part B (section 4–5)', self.run_nested(provision_ids))
 
         provision_ids = ['chp_1__part_B']
         self.beautifier.commenced = True
@@ -298,9 +298,9 @@ class BeautifulProvisionsTestCase(TestCase):
             'chp_2', 'sec_7'
         ]
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1, Part A, section 2–3; Part B (in part); Part B, section 5; Chapter 2 (in part); Chapter 2, section 7', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2–3; Part B, section 5; Chapter 2, section 7', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1, Part A, section 2–3; Part B (in part); Part B, section 5; Chapter 2 (in part); Chapter 2, section 7', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 2–3; Part B, section 5; Chapter 2, section 7', self.run_nested(provision_ids))
 
         provision_ids = [
             'sec_2', 'sec_3',
@@ -314,9 +314,9 @@ class BeautifulProvisionsTestCase(TestCase):
 
         provision_ids = ['sec_4', 'chp_2', 'sec_6']
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1, Part B, section 4; Chapter 2 (in part); Chapter 2, section 6', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part B, section 4; Chapter 2, section 6', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1, Part B, section 4; Chapter 2 (in part); Chapter 2, section 6', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part B, section 4; Chapter 2, section 6', self.run_nested(provision_ids))
 
         provision_ids = ['sec_4', 'chp_2']
         self.beautifier.commenced = True
@@ -375,9 +375,9 @@ class BeautifulProvisionsTestCase(TestCase):
             'sec_3'
         ]
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (in part); Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 3', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 3', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (in part); Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 3', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 3', self.run_nested(provision_ids))
 
         provision_ids = [
             'chp_1',
@@ -394,9 +394,9 @@ class BeautifulProvisionsTestCase(TestCase):
             'sec_2'
         ]
         self.beautifier.commenced = True
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (in part); Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 2', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 2', self.run_nested(provision_ids))
         self.beautifier.commenced = False
-        self.assertEqual('Chapter 1 (in part); Chapter 1, Part A (in part); Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 2', self.run_nested(provision_ids))
+        self.assertEqual('Chapter 1, Part A, section 1(1)(a)(i), 1(1)(a)(ii), 1(1)(a)(iii), 1(1)(c), 1(2), 1(3); section 2', self.run_nested(provision_ids))
 
         provision_ids = ['sec_1__subsec_1__list_1__item_b', 'sec_4']
         self.beautifier.commenced = True


### PR DESCRIPTION
- Only give (in part) for containers that wouldn't be mentioned otherwise
- Don't elide e.g. section 2–15(1)(b) (https://edit.laws.africa/places/na/tasks/14206/)
- Comma-separate (runs of) basic provisions within a container
- Don't include space if there's no num following (https://edit.laws.africa/places/za/tasks/14114/)

![image](https://user-images.githubusercontent.com/32566441/126498127-7b0baacd-461f-4f6f-b8c7-f0c2069bb998.png)

![image](https://user-images.githubusercontent.com/32566441/126502148-66dcec2b-e12f-4d13-879b-a7de2d3b2b2f.png)
