### PR TITLE
Speed improvements for document TOCs

### DIFF
--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -1,4 +1,6 @@
 import re
+from functools import lru_cache
+
 from lxml import etree
 
 from django.utils.translation import override, ugettext as _
@@ -18,6 +20,19 @@ _('Part')
 _('Section')
 _('Preface')
 _('Preamble')
+
+
+@lru_cache(maxsize=None)
+def type_title(typ, language):
+    """ Title for this type of TOC item, translated.
+
+    language is a django language code. It is only used for caching key purposes. It is assumed
+    that the django language has been set to this language already.
+
+    This can be called 10,000s of times when building a TOC, but there are only a handful
+    of possible item types, so they are cached for performance.
+    """
+    return _(typ.capitalize())
 
 
 def descend_toc_pre_order(items):
@@ -261,7 +276,7 @@ class TOCBuilderBase(LocaleBasedMatcher):
         if item.heading:
             title = item.heading
         else:
-            title = _(item.type.capitalize())
+            title = type_title(item.type, self.language)
             if item.num:
                 title += ' ' + item.num
 

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -300,8 +300,7 @@ class TOCBuilderBase(LocaleBasedMatcher):
 
         return items
 
-    def insert_commenceable_provisions(self, doc, provisions, id_set):
-        toc = self.table_of_contents_for_document(doc)
+    def insert_commenceable_provisions(self, toc, provisions, id_set):
         items = self.commenceable_items(toc)
         self.insert_provisions(provisions, id_set, items)
 

--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -163,10 +163,11 @@ class DocumentMixin(object):
 
         return search_toc(self.table_of_contents())
 
-    @lru_cache(maxsize=1)
     def table_of_contents(self):
-        builder = plugins.for_document('toc', self)
-        return builder.table_of_contents_for_document(self)
+        if not hasattr(self, '_toc'):
+            builder = plugins.for_document('toc', self)
+            self._toc = builder.table_of_contents_for_document(self)
+        return self._toc
 
     def all_provisions(self):
         ids = []

--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -3,6 +3,7 @@ import os
 import logging
 import re
 import datetime
+from functools import lru_cache
 
 from actstream import action
 from django.conf import settings
@@ -162,6 +163,7 @@ class DocumentMixin(object):
 
         return search_toc(self.table_of_contents())
 
+    @lru_cache(maxsize=1)
     def table_of_contents(self):
         builder = plugins.for_document('toc', self)
         return builder.table_of_contents_for_document(self)

--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -3,7 +3,6 @@ import os
 import logging
 import re
 import datetime
-from functools import lru_cache
 
 from actstream import action
 from django.conf import settings


### PR DESCRIPTION
1. Cache document TOCs
2. cache translation lookups for TOC entry titles
