### PR TITLE
Correctly handle diff case when an item is inserted mid-way in a list

### DIFF
--- a/indigo/analysis/differ.py
+++ b/indigo/analysis/differ.py
@@ -196,6 +196,8 @@ class AttributeDiffer:
             'html_new': html.escape(x),
         } for x in old]
 
+        # we're going to modify this
+        old = list(old)
         remove_offset = 0
 
         for patch in jsonpatch.make_patch(old, new):
@@ -210,6 +212,8 @@ class AttributeDiffer:
                     'html_old': '',
                     'html_new': "<ins>{}</ins>".format(html.escape(v)),
                 })
+                # add a fake entry to old, because subsequent references will assume it has happened
+                old.insert(index, None)
             elif patch['op'] == 'replace':
                 old_v = old[index]
                 new_v = patch['value']

--- a/indigo/tests/test_differ.py
+++ b/indigo/tests/test_differ.py
@@ -141,3 +141,47 @@ class AttributeDifferTestCase(TestCase):
                 'html_old': '3'
             }]},
             diffs)
+
+    def test_diff_list_item_inserted(self):
+        diffs = self.differ.diff_lists(
+            'test', 'Test',
+            ['2020-03-18: No commencing work: section 1, section 2, section 3, section 4, section 5, section 6, section 7, section 8, section 9, section 10, section 11, section 12, Chapter 1, section 1, section ...',
+             '2020-03-26: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 1, section 1A; Chapter 2, section 11A, section 11B, section 11C, section 11D, section 11E, section 11F, sec...',
+             '2020-04-02: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 3, section 11H, section 11I',
+             '2020-04-16: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 2, section 11CA; Chapter 4, section 11J, section 11K'],
+            ['2020-03-18: No commencing work: section 1–12, Chapter 1, section 1(a), 1(b), section 2, section 3–7, section 8(1), 8(2), 8(3), 8(4), 8(5), section 9, section 10(1), 10(2), 10(3), 10(4), 10(5), 10(6...',
+             '2020-03-25: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 1, section 1(a), 1(b), 1(c), section 1A; Chapter 2, section 11A, section 11B(1)(a)(i), 11B(1)(a)(ii), 11B(1...',
+             '2020-03-26: Disaster Management Act: Regulations relating to COVID-19: Amendment: no provisions',
+             '2020-04-02: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 3, section 11H, section 11I',
+             '2020-04-16: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 2, section 11CA; Chapter 4, section 11J–11K']
+        )
+
+        self.assertEqual({
+            'attr': 'test',
+            'title': 'Test',
+            'changes': [{
+                'old': '2020-03-18: No commencing work: section 1, section 2, section 3, section 4, section 5, section 6, section 7, section 8, section 9, section 10, section 11, section 12, Chapter 1, section 1, section ...',
+                'new': '2020-03-18: No commencing work: section 1–12, Chapter 1, section 1(a), 1(b), section 2, section 3–7, section 8(1), 8(2), 8(3), 8(4), 8(5), section 9, section 10(1), 10(2), 10(3), 10(4), 10(5), 10(6...',
+                'html_old': '2020-03-18: No commencing work: section 1<del>, section 2, section 3, section 4, section 5, section 6, section 7, section 8, section 9, section 10, section 11, section </del>12, Chapter 1, section 1<del>, section </del>...',
+                'html_new': '2020-03-18: No commencing work: section 1<ins>–</ins>12, Chapter 1, section 1<ins>(a), 1(b), section 2, section 3–7, section 8(1), 8(2), 8(3), 8(4), 8(5), section 9, section 10(1), 10(2), 10(3), 10(4), 10(5), 10(6</ins>...'
+            }, {
+                'old': '2020-03-26: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 1, section 1A; Chapter 2, section 11A, section 11B, section 11C, section 11D, section 11E, section 11F, sec...',
+                'new': '2020-03-25: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 1, section 1(a), 1(b), 1(c), section 1A; Chapter 2, section 11A, section 11B(1)(a)(i), 11B(1)(a)(ii), 11B(1...',
+                'html_old': '2020-03-2<del>6</del>: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 1, section 1A; Chapter 2, section 11A, section 11B<del>, section 11C, section 11D, section 11E, section 11F, sec</del>...',
+                'html_new': '2020-03-2<ins>5</ins>: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 1, section 1<ins>(a), 1(b), 1(c), section 1</ins>A; Chapter 2, section 11A, section 11B<ins>(1)(a)(i), 11B(1)(a)(ii), 11B(1</ins>...'
+            }, {
+                'old': None,
+                'new': '2020-03-26: Disaster Management Act: Regulations relating to COVID-19: Amendment: no provisions',
+                'html_old': '',
+                'html_new': '<ins>2020-03-26: Disaster Management Act: Regulations relating to COVID-19: Amendment: no provisions</ins>'
+            }, {
+                'html_old': '2020-04-02: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 3, section 11H, section 11I',
+                'html_new': '2020-04-02: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 3, section 11H, section 11I'
+            }, {
+                'old': '2020-04-16: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 2, section 11CA; Chapter 4, section 11J, section 11K',
+                'new': '2020-04-16: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 2, section 11CA; Chapter 4, section 11J–11K',
+                'html_old': '2020-04-16: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 2, section 11CA; Chapter 4, section 11J<del>, section </del>11K',
+                'html_new': '2020-04-16: Disaster Management Act: Regulations relating to COVID-19: Amendment: Chapter 2, section 11CA; Chapter 4, section 11J<ins>–</ins>11K'
+            }],
+            'type': 'list'
+        }, diffs)


### PR DESCRIPTION
Fixes LAWSAFRICA-9S in Sentry

The jsonpatch algorithm sometimes says to insert an item into a list mid-way. Because jsonpatch generates a patch that applies to a single object that is incrementally updated, subsequent patches take this new item into account. So we need to insert a fake item into the `old` list so that the index offsets still align.