### PR TITLE
Better commenceable provisions

### DIFF
--- a/indigo/tests/test_beautiful_provisions.py
+++ b/indigo/tests/test_beautiful_provisions.py
@@ -104,7 +104,7 @@ class BeautifulProvisionsTestCase(TestCase):
         self.assertEqual(description, 'section 2–3')
 
     def run_nested(self, provision_ids, nested_toc=None):
-        nested_toc = deepcopy(nested_toc) if nested_toc else deepcopy(self.chapters)
+        nested_toc = nested_toc if nested_toc else self.chapters
         return self.beautifier.make_beautiful(nested_toc, provision_ids)
 
     def test_nested_full_containers(self):
@@ -162,7 +162,7 @@ class BeautifulProvisionsTestCase(TestCase):
         self.assertEqual('Chapter 1, Part A, section 2–3; Part B (section 4–5); Chapter 2 (section 6–7)', self.run_nested(provision_ids))
 
     def test_subparts(self):
-        chapters = deepcopy(self.chapters)
+        chapters = self.chapters
         part_a = chapters[0].children[0]
         part_b = chapters[0].children[1]
         part_a_sections = part_a.children
@@ -203,8 +203,6 @@ class BeautifulProvisionsTestCase(TestCase):
         self.assertEqual('Chapter 1, Part A, subpart, section 1(1)(a)(ii)(A), 1(1)(a)(ii)(B), 1(1)(aA), section 3; Part B, section 5; Chapter 2, section 6', self.run_nested(provision_ids, chapters))
         self.beautifier.commenced = False
         self.assertEqual('Chapter 1, Part A, subpart, section 1(1)(a)(ii)(A), 1(1)(a)(ii)(B), 1(1)(aA), section 3; Part B, section 5; Chapter 2, section 6', self.run_nested(provision_ids, chapters))
-
-
 
     def test_nested_mix(self):
         provision_ids = [

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -310,8 +310,8 @@ class WorkCommencementsView(WorkViewBase, DetailView):
     beautifier = None
 
     def get_context_data(self, **kwargs):
-        context = super(WorkCommencementsView, self).get_context_data(**kwargs)
-        context['provisions'] = provisions = self.work.all_commenceable_provisions()
+        context = super().get_context_data(**kwargs)
+        provisions = self.work.all_commenceable_provisions()
         context['commencements'] = commencements = self.work.commencements.all().reverse()
         context['has_all_provisions'] = any(c.all_provisions for c in commencements)
         context['has_main_commencement'] = any(c.main for c in commencements)
@@ -326,24 +326,27 @@ class WorkCommencementsView(WorkViewBase, DetailView):
 
         # decorate all provisions on the work
         commenced_provision_ids = [p_id for c in commencements for p_id in c.provisions]
-        self.beautifier.decorate_provisions(provisions, commenced_provision_ids)
+        provisions = self.beautifier.decorate_provisions(provisions, commenced_provision_ids)
+        # TODO: update template to use p.toc_element, not p, where needed
+        context['provisions'] = provisions
 
         # decorate provisions on each commencement
         for commencement in commencements:
+            # TODO: update template to use p.toc_element, not p, where needed
             commencement.rich_provisions = self.decorate_commencement_provisions(commencement, commencements)
 
         return context
 
     def decorate_commencement_provisions(self, commencement, commencements):
         # provisions from all documents up to this commencement's date
-        rich_provisions = self.work.all_commenceable_provisions(commencement.date)
-        # provision ids commenced by everything else
+        provisions = self.work.all_commenceable_provisions(commencement.date)
+        # provision ids commenced by everything else; will affect visibility per commencement form
         commenced_provision_ids = set(p_id for comm in commencements
                                       if comm != commencement
                                       for p_id in comm.provisions)
 
         # commencement status for displaying provisions on commencement detail
-        self.beautifier.decorate_provisions(rich_provisions, commencement.provisions)
+        rich_provisions = self.beautifier.decorate_provisions(provisions, commencement.provisions)
 
         # visibility for what to show in commencement form
         for p in descend_toc_post_order(rich_provisions):


### PR DESCRIPTION
To do:

- [x] beautifier builds up a shadow tree that maps the actual TOCElement tree, and adds decorations there, rather than modifying TOCElement
- [ ] Update templates to take shadow tree into account
- [ ] all_commenceable_provisions incrementally builds and caches the combined TOCs for previous points in time, allowing them to be re-used
- [ ] all_commenceable_provisions strips .element from each TOCElement