### PR TITLE
Show badge perms to all users

### DIFF
--- a/indigo_social/templates/indigo_social/badge_detail.html
+++ b/indigo_social/templates/indigo_social/badge_detail.html
@@ -38,16 +38,23 @@
         </div>
       </div>
 
-      {% if request.user.is_superuser and badge.nature == 'permission' %}
-      <h4 class="mt-3">Permissions granted by this badge</h4>
+      {% if badge.nature == 'permission' %}
+        <h4 class="mt-3">Permissions granted by this badge</h4>
 
-      <p>Users awarded this badge are added to the <a href="{% url 'admin:auth_group_change' badge.group.pk %}">{{ badge.group_name }} group</a>.</p>
+        <ul>
+          {% for perm in badge.get_permissions %}
+            <li>
+              {{ perm.name }}
+              {% if request.user.is_staff %}
+                — <code>{{ perm.content_type.app_label }}.{{ perm.content_type }}.{{ perm.codename }}</code>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
 
-      <ul>
-        {% for perm in badge.permissions %}
-        <li>{{ perm }}</li>
-        {% endfor %}
-      </ul>
+        {% if request.user.is_staff %}
+          <p>Users awarded this badge are added to the <a href="{% url 'admin:auth_group_change' badge.group.pk %}">{{ badge.group_name }} group</a>.</p>
+        {% endif %}
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Previously only superusers could see this, but it's useful information.

Only staff are shown the permission codenames and the link to the security group in the admin area.

![image](https://user-images.githubusercontent.com/4178542/144980897-79b28446-aae3-443d-b186-55865046c9c1.png)
