### PR TITLE
Add deployment instructions for Debian 11 Host

### DIFF
--- a/docs/running/index.rst
+++ b/docs/running/index.rst
@@ -143,7 +143,12 @@ You can now easily change Django settings, add your own modules, change URLs, et
 Production Installation
 -----------------------
 
-Indigo requires some non-Python dependencies. This guide explains how to deploy
+Indigo requires some non-Python dependencies. This guide explains how to deploy on either Dokku (Simpler) or on a Debian 11 based VM, Container or Bare Metal:
+
+
+Dokku Deployment
+----------------
+
 Indigo and these dependencies on `Heroku <https://heroku.com/>`_ or `Dokku <http://progrium.viewdocs.io/dokku/>`_.
 Dokku uses Docker to emulate a Heroku-like environment on your own servers (or cloud).
 
@@ -212,6 +217,166 @@ We describe using Dokku below, and assume that you have already have `Dokku inst
    * Under **Indigo API** click Countries, then click Add Country in the top right corner
    * Choose a country and primary language from the dropdown lists
    * Click Save
+   
+Debian 11 VM, Container or Bare-metal
+-------------------------------------
+
+As this deployment is intended for an LXC Container running as root, you might need to create a sudo user and run the installation in that userspace if you are deploying this on bare-metal. The following instructions are run as root and tested on an updated Debian 11 LXC container.
+
+This deployment can run directly from the IP address, however has been set to reduced security as it is recommended you run it behind an NginX reverse Proxy. Read the Gunicorn documentation for more information on this.
+
+1. Install some required packages:
+
+    # apt update && apt install git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev xfonts-base xfonts-75dpi fontconfig xfonts-encodings xfonts-utils poppler-utils postgresql python3-pip libpq-dev libpoppler-dev sqlite3 libsqlite3-dev libbz2-dev wkhtmltopdf --no-install-recommends -y
+    
+2. Install Rbenv Ruby Version Manager so you can ensure that you run the correct Ruby version, this will also configure the necessary ENV variables for Ruby:
+
+    # curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
+    # echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
+    # echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+    # source ~/.bashrc
+    
+    You can test if Rbenv correctly installed with the following command:
+    
+    # rbenv -v
+    
+    Now install the appropriate ruby version (2.7.2 at time of writing):
+    
+    # rbenv install 2.7.2
+    
+    Set the global Ruby version to be used (Note, if you are deploying to bare-metal, this is not recommended as it might break other services)
+    
+    # rbenv global 2.7.2
+    
+    You can test if this worked as follows (Which should return version 2.7.2):
+    
+    # ruby -v
+
+3. Install Pyenv Python Version Manager so you can ensure that you run the correct Python version, this will also configure the necessary ENV variables for Python:
+
+    # curl https://pyenv.run | bash
+    # echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+    # echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+    # echo 'eval "$(pyenv init --path)"' >> ~/.bashrc
+    # source ~/.bashrc
+    
+    You can test if Pyenv correctly installed with the following command:
+    
+    # pyenv -v
+    
+    Now install the appropriate ruby version (3.8.12 at time of writing):
+    
+    # pyenv install 3.8.12
+
+    Set the global Python version to be used (Note, if you are deploying to bare-metal, this is not recommended as it might break other services)
+    
+    # pyenv global 3.8.12
+    
+    You can test if this worked as follows (Which should return version 3.8.12):
+    
+    # python --version
+    
+4. Install some PyPi packages that you will need for a production deployment:
+
+    # pip install --upgrade pip
+    # pip install wheel
+    # pip install -U pip setuptools
+    # pip install gevent==21.8.0
+    # pip install gunicorn==20.1.0
+    # pip install psycopg2==2.8.6
+    
+ 5. Clone into the current version of Indigo:
+ 
+    # git clone https://github.com/laws-africa/indigo
+    # cd indigo
+    
+    From here on, all commands will be run from this folder.
+    
+ 6. Setup the Indigo requirements:
+ 
+    # pip install -e .
+    
+ 7. Configure the Postgres Database:
+    
+    Note that if you want to use a more secure configuration, you will need to edit the settings.py file contained in ./indigo/settings.py, the relevant variable is: db_config = dj_database_url.config(default='postgres://indigo:indigo@localhost:5432/indigo'). You can edit this if you use a different Postgres host, username or password than those set below:
+    
+    # su - postgres -c 'createuser -d -P indigo'
+    
+    Set the password to indigo unless you have changed settings.py, in which case, use that password.
+    
+    su - postgres -c 'createdb indigo'
+    
+ 8. Install the Ruby gems required by Indigo:
+ 
+    # gem install bundler
+    # bundle install
+ 
+ 9. Set some ENV variables in Debian required for Indigo to work in production mode:
+ 
+    # nano ~/.bashrc
+    
+    Add the following lines to the bottom of the file, editing the portions in brackets (without brackets) as per your environment (i.e. DJANGO_SECRET_KEY=123456789, not DJANGO_SECRET_KEY={123456789}):
+    
+    Note, we set DJANGO_DEBUG=true for now, this is due to the way in which Django works and it cannot populate the database otherwise, as soon as we have run the first migration, we will change this.
+    
+    export DJANGO_DEBUG=true
+    export DJANGO_SECRET_KEY={Some random characters}
+    export AWS_ACCESS_KEY_ID={Your AWS Acces Key}
+    export AWS_SECRET_ACCESS_KEY={Your AWS Secret Key}
+    export AWS_S3_BUCKET={Your Amazon S3 Bucket Name, note, must be in eu-west-1}
+    export SUPPORT_EMAIL={you@yourdomain.com}
+    export DJANGO_DEFAULT_FROM_EMAIL={indigo@yourdomain.com}
+    export DJANGO_EMAIL_HOST={smtp.yourdomain.com}
+    export DJANGO_EMAIL_HOST_USER={indigo@yourdomain.com}
+    export DJANGO_EMAIL_HOST_PASSWORD={email password}
+    export DJANGO_EMAIL_PORT={Your SMTP Port number}
+    export INDIGO_ORGANISATION='{Name of Your Organization}'
+    export RECAPTCHA_PUBLIC_KEY={Your ReCaptcha Public Key}
+    export RECAPTCHA_PRIVATE_KEY={Your ReCaptcha Private Key}
+    export GOOGLE_ANALYTICS_ID={Your Google Analytics ID for the property}
+    
+    Now ensure that the ENV variables are in-use by refreshing the console session:
+    
+    # source ~/.bashrc
+
+10. Now let us run the initial Indigo Deployment:
+
+    # python manage.py migrate
+    # python manage.py update_countries_plus
+    # python manage.py loaddata countries.json
+    # python manage.py createsuperuser
+    # python manage.py compilescss
+    # python manage.py collectstatic --noinput -i docs -i \*scss 2>&1
+    
+    If everything worked out well, we should be able to test your installation in debug mode now:
+    
+    # python manage.py runserver 0.0.0.0:8000
+    
+    You should be able to connect to the host via your browser to http://ip-of-host:8000
+    
+    Ctrl+C to end the development server, we are now reasdy to deploy to production
+
+11. Change DJANGO_DEBUG to false so that we can run a production server:
+
+    Just like we did in step 9, we are just going to edit the ENV so that the debug flag is set to false:
+    
+    # nano ~/.bashrc
+    
+    Find the line you added earlier for export DJANGO_DEBUG=true and change it to read:
+    
+    export DJANGO_DEBUG=true
+    
+ 12. Create SSL Certificates:
+ 
+    In Production Mode, Indigo requires an SSL connection, lets generate a key-pair inside of the indigo folder:
+    
+    # openssl req -new -x509 -days 365 -nodes -out server.crt -keyout server.key
+    
+ 13. Run Gunicorn webserver for production use:
+ 
+    # gunicorn -k=gevent indigo.wsgi:application -t 600 --certfile=/root/indigo/server.crt --keyfile=/root/indigo/server.key -b=0.0.0.0:443 -w=4 --forwarded-allow-ips=* --proxy-allow-from=*
+    
+    You should now be able to connect to your Indigo instance at https://your-ip-address/
 
 Background Tasks
 ----------------


### PR DESCRIPTION
Added instructions on how to deploy Indigo on a Debian 11 LXC Container, VM or bare-metal host. Tested with similar functionality to the currently recommended dokku deployment.
I hope that this helps someone not familiar with Django to get a working instance without relying on dokku.