### PR TITLE
Annotation, task and other serializer performance improvements

### DIFF
--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -517,7 +517,7 @@ def post_save_document(sender, instance, **kwargs):
 def attachment_filename(instance, filename):
     """ Make S3 attachment filenames relative to the document,
     this may be modified to ensure it's unique by the storage system. """
-    return 'attachments/%s/%s' % (instance.document.id, os.path.basename(filename))
+    return 'attachments/%s/%s' % (instance.document_id, os.path.basename(filename))
 
 
 class Attachment(models.Model):

--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -142,7 +142,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
         if not instance.pk:
             return None
         return reverse('document-attachments-detail', request=self.context['request'], kwargs={
-            'document_id': instance.document.pk,
+            'document_id': instance.document_id,
             'pk': instance.pk,
         })
 
@@ -150,7 +150,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
         if not instance.pk:
             return None
         return reverse('document-attachments-download', request=self.context['request'], kwargs={
-            'document_id': instance.document.pk,
+            'document_id': instance.document_id,
             'pk': instance.pk,
         })
 
@@ -158,7 +158,7 @@ class AttachmentSerializer(serializers.ModelSerializer):
         if not instance.pk:
             return None
         return reverse('document-attachments-view', request=self.context['request'], kwargs={
-            'document_id': instance.document.pk,
+            'document_id': instance.document_id,
             'pk': instance.pk,
         })
 
@@ -529,7 +529,7 @@ class AnnotationSerializer(serializers.ModelSerializer):
         if not instance.pk:
             return None
         return reverse('document-annotations-detail', request=self.context['request'], kwargs={
-            'document_id': instance.document.pk,
+            'document_id': instance.document_id,
             'pk': instance.pk,
         })
 

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -157,8 +157,8 @@ class DocumentResourceView:
 
 class AnnotationViewSet(DocumentResourceView, viewsets.ModelViewSet):
     queryset = Annotation.objects\
-        .select_related('updated_by_user', 'task', 'task__updated_by_user', 'task__created_by_user',
-                        'task_assigned_to', 'task__country', 'task__locality', 'task__work')
+        .select_related('created_by_user', 'task', 'task__updated_by_user', 'task__created_by_user',
+                        'task__assigned_to', 'task__country', 'task__locality', 'task__work')
     serializer_class = AnnotationSerializer
     permission_classes = DEFAULT_PERMS + (ModelPermissions, AnnotationPermissions)
 


### PR DESCRIPTION
Don't load document unnecessarily, preload certain fields. This has significant performance improvements for documents with large numbers of annotations.