### PR TITLE
models.js: add if a is truthy for destroy function

### DIFF
--- a/indigo_app/static/javascript/indigo/models.js
+++ b/indigo_app/static/javascript/indigo/models.js
@@ -741,8 +741,11 @@
     destroyed: function() {
       // root was destroyed, delete everything else
       const root = this.root();
-      this.annotations.forEach(a => {
-        if (a !== root) a.destroy();
+      const annotations = this.annotations;
+      annotations.forEach(a => {
+        if (a !== root && a) {
+          a.destroy();
+        }
       });
       this.trigger('destroy');
     }


### PR DESCRIPTION
the problem is at a certain iteration of `this.annotations.forEach(a =>  { ... })`, `a` is undefined.
Example: If we had a thread of 4 annotations, we had to run through that loop, the last element is undefined, as result external controls.

Adding the `truthy` conditions does stop the error and the entire is deleted, it is reflected in the dom as correctly

resolves #1406 