### PR TITLE
create fix for ResizeObserver loop limit exceeded on xml editor

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_xml_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_xml_editor.js
@@ -73,7 +73,14 @@
           wrappingIndent: 'same',
         });
 
-        new ResizeObserver(() => { this.editor.layout(); }).observe(this.editor.getContainerDomNode());
+        new ResizeObserver((entries) => {
+          window.requestAnimationFrame(() => {
+            if (!Array.isArray(entries) || !entries.length) {
+              return;
+            }
+            this.editor.layout();
+          });
+        }).observe(this.editor.getContainerDomNode());
         const onEditorChange = _.debounce(_.bind(this.editorChanged, this), 500);
         this.editor.onDidChangeModelContent(() => {
           if (!this.updating) onEditorChange();

--- a/indigo_app/static/javascript/indigo/views/document_xml_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_xml_editor.js
@@ -99,17 +99,8 @@
           }
 
         });
-
         resizeObserver.observe(this.editor.getContainerDomNode());
 
-        new ResizeObserver((entries) => {
-          window.requestAnimationFrame(() => {
-            if (!Array.isArray(entries) || !entries.length) {
-              return;
-            }
-            this.editor.layout();
-          });
-        }).observe(this.editor.getContainerDomNode());
         const onEditorChange = _.debounce(_.bind(this.editorChanged, this), 500);
         this.editor.onDidChangeModelContent(() => {
           if (!this.updating) onEditorChange();


### PR DESCRIPTION
Fix loop exceeded by suspending the observation and restart on the next animation frame, but only if the element resized while the handler was executing
resolves https://github.com/laws-africa/indigo/issues/1410#issue-1138366735