### PR TITLE
Django 3.2 Deploy Fixes

### DIFF
--- a/indigo_api/migrations/0001_squashed_0137.py
+++ b/indigo_api/migrations/0001_squashed_0137.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
         ('taggit', '0001_initial'),
         ('countries_plus', '0005_auto_20160224_1804'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('reversion', '0002_add_index_on_version_for_content_type_and_db'),
+        ('reversion', '0001_squashed_0004_auto_20160611_1202'),
         ('pinax_badges', '0001_initial'),
     ]
 


### PR DESCRIPTION
This PR fixes failed deploys by updated migration dependency

Failed deploy logs:
```
remote:        Traceback (most recent call last):        
[827](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:827)
remote:          File "manage.py", line 10, in <module>        
[803](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:803)
remote:            execute_from_command_line(sys.argv)        
[804](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:804)
remote:          File "/usr/local/lib/python3.8/dist-packages/django/core/management/__init__.py", line 419, in execute_from_command_line        
[805](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:805)
remote:            utility.execute()
[806](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:806)
remote:          File "/usr/local/lib/python3.8/dist-packages/django/core/management/__init__.py", line 413, in execute        
[807](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:807)
remote:            self.fetch_command(subcommand).run_from_argv(self.argv)        
[808](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:808)
remote:          File "/usr/local/lib/python3.8/dist-packages/django/core/management/base.py", line 354, in run_from_argv        
[809](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:809)
remote:            self.execute(*args, **cmd_options)        
[810](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:810)
remote:          File "/usr/local/lib/python3.8/dist-packages/django/core/management/base.py", line 398, in execute        
[811](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:811)
remote:            output = self.handle(*args, **options)        
[812](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:812)
remote:          File "/usr/local/lib/python3.8/dist-packages/django/core/management/base.py", line 89, in wrapped        
[813](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:813)
remote:            res = handle_func(*args, **kwargs)        
[814](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:814)
remote:          File "/usr/local/lib/python3.8/dist-packages/django/core/management/commands/migrate.py", line 95, in handle        
[815](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:815)
remote:            executor.loader.check_consistent_history(connection)        
[816](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:816)
remote:          File "/usr/local/lib/python3.8/dist-packages/django/db/migrations/loader.py", line 306, in check_consistent_history        
[817](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:817)
remote:            raise InconsistentMigrationHistory(        
[818](https://github.com/laws-africa/indigo-lawsafrica/runs/5201502718?check_suite_focus=true#step:4:818)
remote:        django.db.migrations.exceptions.InconsistentMigrationHistory: Migration indigo_api.0001_squashed_0137 is applied before its dependency reversion.0002_add_index_on_version_for_content_type_and_db on database 'default'.
```