### PR TITLE
Django 3 fixes

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -156,6 +156,10 @@ DATABASES = {
     'default': db_config,
 }
 
+# Auto-created primary keys
+# see: https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 SITE_ID = 1
 
 # Internationalization

--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -9,7 +9,7 @@ from django.db import models
 from django.db.models import signals
 from django.core.management import call_command
 from django.contrib.auth.models import User
-from django.contrib.postgres.fields import JSONField
+from django.db.models import JSONField
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils import timezone

--- a/indigo_api/models/tasks.py
+++ b/indigo_api/models/tasks.py
@@ -2,7 +2,7 @@ import datetime
 from itertools import groupby
 
 from actstream import action
-from django.contrib.postgres.fields import JSONField
+from django.db.models import JSONField
 from django.db import models
 from django.db.models import signals, Prefetch, Count
 from django.conf import settings

--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from actstream import action
-from django.contrib.postgres.fields import JSONField
+from django.db.models import JSONField
 from django.db import models
 from django.db.models import signals, Q
 from django.core.exceptions import ValidationError

--- a/indigo_resolver/views.py
+++ b/indigo_resolver/views.py
@@ -14,7 +14,7 @@ from .authorities import authorities as registry
 class ResolveView(TemplateView):
     template_name = 'resolve.html'
 
-    def get(self, request, frbr_uri, authorities, *args, **kwargs):
+    def get(self, request, frbr_uri, authorities=None, *args, **kwargs):
         try:
             FrbrUri.default_language = None
             self.frbr_uri = FrbrUri.parse(frbr_uri)


### PR DESCRIPTION
This PR fixes the following warnings on Django 3:

* [x] JSONField warning
  ```
  indigo_api.Work.properties: (fields.W904) django.contrib.postgres.fields.JSONField is deprecated. Support for it (except in historical migrations) will be removed in Django 4.0.
          HINT: Use django.db.models.JSONField instead.
  ```
* [x] DEFAULT_AUTO_FIELD warning
  ```
  indigo_api.ArbitraryExpressionDate: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
     HINT: Configure the DEFAULT_AUTO_FIELD setting or the IndigoApiConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
  ```

* [x] Fix for [TypeError LAWSAFRICA-EG](https://sentry.io/organizations/lawsafrica/issues/3016741091/events/948562bb329b48ee9d38858033a35bdf/?project=5229057&referrer=slack)
  Cause from [Django 3.2 changelog](https://docs.djangoproject.com/en/3.2/releases/3.0/#miscellaneous): 
  ```
   RegexPattern, used by [re_path()](https://docs.djangoproject.com/en/3.2/ref/urls/#django.urls.re_path), no longer returns keyword arguments with `None` values to be passed to the view for the optional named groups that are missing.
  ```
  In cases when `authorities` is missing, the parameter is not passed to the get function of [`indigo_resolver.ResolveView`](https://github.com/laws-africa/indigo/blob/628854eae70e0bdbf9f4ba978f6ef705d6bdbb31/indigo_resolver/views.py#L17)