### PR TITLE
decode "unicode_escape' if decoding 'utf-8' doesn't work

### DIFF
--- a/indigo_api/importers/pdfs.py
+++ b/indigo_api/importers/pdfs.py
@@ -9,7 +9,7 @@ def pdf_count_pages(fname):
     """ Counts the number of pages in a PDF.
     """
     result = subprocess.run(["pdfinfo", fname], stdout=subprocess.PIPE, check=True)
-    m = re.search(r'^Pages:\s*(\d+)', result.stdout.decode('utf-8', errors='ignore'), re.MULTILINE)
+    m = re.search(r'^Pages:\s*(\d+)', result.stdout.decode('utf-8', errors='replace'), re.MULTILINE)
     if m:
         return int(m.group(1))
     else:
@@ -20,7 +20,7 @@ def pdf_is_encrypted(fname):
     """ Is this pdf encrypted?
     """
     result = subprocess.run(["pdfinfo", fname], stdout=subprocess.PIPE, check=True)
-    m = re.search(r'^Encrypted:\s*(\w+)', result.stdout.decode('utf-8', errors='ignore'), re.MULTILINE)
+    m = re.search(r'^Encrypted:\s*(\w+)', result.stdout.decode('utf-8', errors='replace'), re.MULTILINE)
     if m:
         return m.group(1).lower() == 'yes'
     else:

--- a/indigo_api/importers/pdfs.py
+++ b/indigo_api/importers/pdfs.py
@@ -9,7 +9,10 @@ def pdf_count_pages(fname):
     """ Counts the number of pages in a PDF.
     """
     result = subprocess.run(["pdfinfo", fname], stdout=subprocess.PIPE, check=True)
-    m = re.search(r'^Pages:\s*(\d+)', result.stdout.decode('utf-8'), re.MULTILINE)
+    try:
+        m = re.search(r'^Pages:\s*(\d+)', result.stdout.decode('utf-8'), re.MULTILINE)
+    except UnicodeError:
+        m = re.search(r'^Pages:\s*(\d+)', result.stdout.decode('unicode_escape'), re.MULTILINE)
     if m:
         return int(m.group(1))
     else:
@@ -20,7 +23,10 @@ def pdf_is_encrypted(fname):
     """ Is this pdf encrypted?
     """
     result = subprocess.run(["pdfinfo", fname], stdout=subprocess.PIPE, check=True)
-    m = re.search(r'^Encrypted:\s*(\w+)', result.stdout.decode('utf-8'), re.MULTILINE)
+    try:
+        m = re.search(r'^Encrypted:\s*(\w+)', result.stdout.decode('utf-8'), re.MULTILINE)
+    except UnicodeError:
+        m = re.search(r'^Encrypted:\s*(\w+)', result.stdout.decode('unicode_escape'), re.MULTILINE)
     if m:
         return m.group(1).lower() == 'yes'
     else:

--- a/indigo_api/importers/pdfs.py
+++ b/indigo_api/importers/pdfs.py
@@ -9,10 +9,7 @@ def pdf_count_pages(fname):
     """ Counts the number of pages in a PDF.
     """
     result = subprocess.run(["pdfinfo", fname], stdout=subprocess.PIPE, check=True)
-    try:
-        m = re.search(r'^Pages:\s*(\d+)', result.stdout.decode('utf-8'), re.MULTILINE)
-    except UnicodeError:
-        m = re.search(r'^Pages:\s*(\d+)', result.stdout.decode('unicode_escape'), re.MULTILINE)
+    m = re.search(r'^Pages:\s*(\d+)', result.stdout.decode('utf-8', errors='ignore'), re.MULTILINE)
     if m:
         return int(m.group(1))
     else:
@@ -23,10 +20,7 @@ def pdf_is_encrypted(fname):
     """ Is this pdf encrypted?
     """
     result = subprocess.run(["pdfinfo", fname], stdout=subprocess.PIPE, check=True)
-    try:
-        m = re.search(r'^Encrypted:\s*(\w+)', result.stdout.decode('utf-8'), re.MULTILINE)
-    except UnicodeError:
-        m = re.search(r'^Encrypted:\s*(\w+)', result.stdout.decode('unicode_escape'), re.MULTILINE)
+    m = re.search(r'^Encrypted:\s*(\w+)', result.stdout.decode('utf-8', errors='ignore'), re.MULTILINE)
     if m:
         return m.group(1).lower() == 'yes'
     else:


### PR DESCRIPTION
The attached PDF currently fails on import because of a decoding error: `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfe in position 183: invalid start byte`.
The bytestring in question: `b'Title:          SI 108 2020 - Anti-Money Laundering and Countering Financing\nCreator:        CorelDRAW Version 12.0\nProducer:       Corel PDF Engine Version 1.0.0.458\nCreationDate:   \xfe\xff\nModDate:        \xfe\xff\nTagged:         no\nUserProperties: no\nSuspects:       no\nForm:           none\nJavaScript:     no\nPages:          44\nEncrypted:      no\nPage size:      419.528 x 595.276 pts\nPage rot:       0\nFile size:      182139 bytes\nOptimized:      yes\nPDF version:    1.3\n'`
The offending bytes are at `CreationDate:   \xfe\xff`

[sc-act-si-2020-108-publication-document (1).pdf](https://github.com/laws-africa/indigo/files/8222599/sc-act-si-2020-108-publication-document.1.pdf)
