### PR TITLE
Django 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,12 @@ setup(
     # See https://pypi.org/classifiers/
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.2',
         'Intended Audience :: Legal Industry',
         'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ],
 
     packages=find_packages(exclude=['docs']),


### PR DESCRIPTION
Updated the classifiers for Framework and Programming Language, note that Python 3.6 and 3.7 won't allow the installation of django-cors-headers 3.11.0.
This created a bit of a headache for me last night during an update task.