### PR TITLE
Reduce dependency on local indigo-web

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Build
         run: npx webpack
 
+      - name: Import indigo-web
+        # Keep the local copy of indigo-web up to date; this is only used for PDF exports
+        run: cp -R node_modules/indigo-web/scss indigo_app/static/lib/indigo-web/
+
       - name: Push
         uses: EndBug/add-and-commit@v7
         with:
-          add: 'indigo_app/static/lib/external-imports.js indigo_app/static/javascript/indigo-app.js --force'
+          add: 'indigo_app/static/lib/external-imports.js indigo_app/static/javascript/indigo-app.js indigo_app/static/lib/indigo-web/ --force'
           message: 'Update compiled external-imports.js and indigo-app.js'

--- a/indigo_api/tests/test_work_api.py
+++ b/indigo_api/tests/test_work_api.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from nose.tools import assert_equal, assert_not_equal
 from rest_framework.test import APITestCase
 from django.test.utils import override_settings
@@ -31,6 +29,6 @@ class WorkAPITest(APITestCase):
         assert_equal(response.status_code, 200)
         assert_not_equal(len(response.data['results']), 0)
 
-        response = self.client.get('/api/works?country=xx')
+        response = self.client.get('/api/works?country=zz')
         assert_equal(response.status_code, 200)
         assert_equal(len(response.data['results']), 0)

--- a/indigo_api/tests/test_work_api.py
+++ b/indigo_api/tests/test_work_api.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from nose.tools import assert_equal, assert_not_equal
 from rest_framework.test import APITestCase
 from django.test.utils import override_settings
@@ -29,6 +31,6 @@ class WorkAPITest(APITestCase):
         assert_equal(response.status_code, 200)
         assert_not_equal(len(response.data['results']), 0)
 
-        response = self.client.get('/api/works?country=zz')
+        response = self.client.get('/api/works?country=xx')
         assert_equal(response.status_code, 200)
         assert_equal(len(response.data['results']), 0)

--- a/indigo_app/static/stylesheets/_akn.scss
+++ b/indigo_app/static/stylesheets/_akn.scss
@@ -1,6 +1,3 @@
-/* akoma ntoso styles */
-@import 'lib/indigo-web/scss/indigo-web';
-
 /* overrides for indigo inserts into akoma-ntoso trees */
 la-akoma-ntoso .ig {
   font-family: $font-family-base;

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'django-countries-plus<=2.0.0',
         'django-jsonfield>=1.4.1',
         'django-jsonfield-compat>=0.4.4',
-        'django-filter>=2.4.0',
+        'django-filter==2.4.0',
         'django-fsm>=2.6.0',
         'django-languages-plus>=1.1.1',
         'django-pipeline>=1.6.11',


### PR DESCRIPTION
* it's no longer needed as a CSS import, except for PDF exports
* keep it up to date automatically until we can remove it completely