### PR TITLE
Bulk Import Repeals Tweak

### DIFF
--- a/indigo/bulk_creator.py
+++ b/indigo/bulk_creator.py
@@ -537,7 +537,7 @@ class BaseBulkCreator(LocaleBasedMatcher):
 
         if not repealing_work:
             # a work with the given FRBR URI / title wasn't found
-            self.create_task(row.work, row, task_type='no-repeal-match')
+            self.create_task(row.work, row, task_type='no-repealed-by-match')
 
         elif row.work.repealed_by and row.work.repealed_by != repealing_work:
             # the work was already marked as repealed by a different work
@@ -571,7 +571,7 @@ class BaseBulkCreator(LocaleBasedMatcher):
 
         if not repealed_work:
             # a work with the given FRBR URI / title wasn't found
-            return self.create_task(row.work, row, task_type='no-repeal-match')
+            return self.create_task(row.work, row, task_type='no-repeals-match')
 
         elif isinstance(repealed_work, Work) and \
                 repealed_work.repealed_by and repealed_work.repealed_by != row.work:
@@ -842,8 +842,8 @@ The amendment has already been linked, so start at Step 3 of https://docs.laws.a
                 'date': amendment.date,
             }
 
-        elif task_type == 'no-repeal-match':
-            task.title = _('Link repeal')
+        elif task_type == 'no-repealed-by-match':
+            task.title = _('Link repealed by')
             task.description = _('''It looks like this work was repealed by "%(repealed_by)s" (see row %(row_num)s of the spreadsheet), but it couldn't be linked automatically.
 
 Possible reasons:
@@ -852,6 +852,19 @@ Possible reasons:
 
 Please link the repeal manually.''') % {
                 'repealed_by': row.repealed_by,
+                'row_num': row.row_number,
+            }
+
+        elif task_type == 'no-repeals-match':
+            task.title = _('Link repeal')
+            task.description = _('''It looks like this work repeals "%(repeals)s" (see row %(row_num)s of the spreadsheet), but it couldn't be linked automatically.
+
+Possible reasons:
+– a typo in the spreadsheet
+– the repealed work doesn't exist on the system.
+
+Please link the repeal manually.''') % {
+                'repeals': row.repeals,
                 'row_num': row.row_number,
             }
 

--- a/indigo/tests/bulk_creator/test_bulk_creator.py
+++ b/indigo/tests/bulk_creator/test_bulk_creator.py
@@ -882,7 +882,7 @@ class BaseBulkCreatorTest(testcases.TestCase):
 
         self.assertEqual([], main3.notes)
         self.assertEqual([], main3.relationships)
-        self.assertEqual(['link gazette', 'import content', 'no repeal match'], main3.tasks)
+        self.assertEqual(['link gazette', 'import content', 'no repealed by match'], main3.tasks)
 
         # live
         works = self.get_works(False, 'repeals_passive.csv')
@@ -945,7 +945,7 @@ class BaseBulkCreatorTest(testcases.TestCase):
 
         self.assertEqual(['Stub'], repeal3.notes)
         self.assertEqual([], repeal3.relationships)
-        self.assertEqual(['link gazette', 'no repeal match'], repeal3.tasks)
+        self.assertEqual(['link gazette', 'no repeals match'], repeal3.tasks)
 
         # live
         works = self.get_works(False, 'repeals_active.csv')

--- a/indigo/tests/bulk_creator/test_bulk_creator.py
+++ b/indigo/tests/bulk_creator/test_bulk_creator.py
@@ -900,7 +900,7 @@ class BaseBulkCreatorTest(testcases.TestCase):
         self.assertIsNone(main2.repealed_by)
         self.assertIn('Link repeal (pending commencement)', [t.title for t in repeal2.tasks.all()])
         self.assertIsNone(main3.repealed_by)
-        self.assertIn('Link repeal', [t.title for t in main3.tasks.all()])
+        self.assertIn('Link repealed by', [t.title for t in main3.tasks.all()])
         self.assertEqual(main4.repealed_by, repeal3)
         self.assertEqual(main4.repealed_date, datetime.date(2020, 6, 1))
 


### PR DESCRIPTION
This PR updates the bulk importer to distinguish `repeal_by` and `repeals` task descriptions for missing works.

closes #1558 