### PR TITLE
Better diffs and defined terms in all hierarchical elements

### DIFF
--- a/indigo/analysis/terms/base.py
+++ b/indigo/analysis/terms/base.py
@@ -5,7 +5,7 @@ from itertools import chain
 from lxml import etree
 
 from indigo.plugins import LocaleBasedMatcher
-from schemas import AkomaNtoso30
+from cobalt.schemas import AkomaNtoso30
 
 log = logging.getLogger(__name__)
 

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -10,7 +10,7 @@ from indigo.plugins import plugins, LocaleBasedMatcher
 
 # Ensure that these translations are included by makemessages
 from indigo.xmlutils import closest
-from schemas import AkomaNtoso30
+from cobalt.schemas import AkomaNtoso30
 
 _('Act')
 _('Article')

--- a/indigo/analysis/toc/base.py
+++ b/indigo/analysis/toc/base.py
@@ -10,6 +10,7 @@ from indigo.plugins import plugins, LocaleBasedMatcher
 
 # Ensure that these translations are included by makemessages
 from indigo.xmlutils import closest
+from schemas import AkomaNtoso30
 
 _('Act')
 _('Article')
@@ -81,12 +82,7 @@ class TOCBuilderBase(LocaleBasedMatcher):
     toc_elements = [
         # top-level
         'coverpage', 'preface', 'preamble', 'conclusions', 'attachment', 'component',
-        # hierarchical elements
-        'alinea', 'article', 'book', 'chapter', 'clause', 'division', 'indent', 'level', 'list',
-        'paragraph', 'part', 'point', 'proviso', 'rule', 'section',
-        'subchapter', 'subclause', 'subdivision', 'sublist', 'subparagraph', 'subpart', 'subrule',
-        'subsection', 'subtitle', 'title', 'tome', 'transitional',
-    ]
+    ] + AkomaNtoso30.hier_elements
     """ Elements we include in the table of contents, without their XML namespace.
         Base includes the following from the from the AKN schema:
         - all `hierarchicalStructure` elements, except:

--- a/indigo/tests/test_differ.py
+++ b/indigo/tests/test_differ.py
@@ -76,6 +76,7 @@ class AttributeDifferTestCase(TestCase):
 
         self.assertEqual(
             as_html(diff),
+            '<p>Some text <span class="diff-pair"><del>bold text and a tail.</del><ins>&#xA0;</ins></span><b class="ins ">bold text</b><ins> and a tail.</ins></p>',
         )
 
     def test_more_refs_added(self):

--- a/indigo/tests/test_differ.py
+++ b/indigo/tests/test_differ.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-from unittest import TestCase
+from django.test import TestCase
 
 import lxml.html
 
@@ -15,6 +14,8 @@ def as_html(tree):
 
 
 class AttributeDifferTestCase(TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.differ = AttributeDiffer()
 
@@ -24,8 +25,8 @@ class AttributeDifferTestCase(TestCase):
         n_changes, diff = self.differ.diff_document_html(old, new)
 
         self.assertEqual(
-            as_html(diff),
             '<p><span class="diff-pair"><del>abc 123</del><ins>def 456</ins></span></p>',
+            as_html(diff),
         )
 
     def test_text_partially_changed(self):
@@ -34,8 +35,8 @@ class AttributeDifferTestCase(TestCase):
         n_changes, diff = self.differ.diff_document_html(old, new)
 
         self.assertEqual(
-            as_html(diff),
             '<p>some <span class="diff-pair"><del>old</del><ins>new</ins></span> text</p>',
+            as_html(diff),
         )
 
     def test_text_partially_changed_with_elements(self):
@@ -44,8 +45,8 @@ class AttributeDifferTestCase(TestCase):
         n_changes, diff = self.differ.diff_document_html(old, new)
 
         self.assertEqual(
-            as_html(diff),
             '<p>some <span class="diff-pair"><del>old</del><ins>new</ins></span> text <b>no change</b> text <i>no change</i></p>',
+            as_html(diff),
         )
 
     def test_tail_changed(self):
@@ -54,8 +55,8 @@ class AttributeDifferTestCase(TestCase):
         n_changes, diff = self.differ.diff_document_html(old, new)
 
         self.assertEqual(
-            as_html(diff),
             '<p>something <b>bold</b> <span class="diff-pair"><del>123</del><ins>456</ins></span> xx <i>and</i> same </p>',
+            as_html(diff),
         )
 
     def test_inline_tag_removed(self):
@@ -64,8 +65,8 @@ class AttributeDifferTestCase(TestCase):
         n_changes, diff = self.differ.diff_document_html(old, new)
 
         self.assertEqual(
-            as_html(diff),
             '<p>Some text <ins>bold text and a tail.</ins><b class="del ">bold text</b> and a tail.</p>',
+            as_html(diff),
         )
 
     def test_inline_tag_added(self):
@@ -75,7 +76,19 @@ class AttributeDifferTestCase(TestCase):
 
         self.assertEqual(
             as_html(diff),
-            '<p>Some text <span class="diff-pair"><del>bold text and a tail.</del><ins>&#xA0;</ins></span><b class="ins ">bold text</b><ins> and a tail.</ins></p>',
+        )
+
+    def test_more_refs_added(self):
+        """ When adding a new ref to a p tag, the other refs should not be considered different.
+        """
+        old = as_tree('<p class="akn-p">Some text <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_1" data-eid="ref_1">link</a>.</p>')
+        new = as_tree('<p class="akn-p">Some text <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_1" data-eid="ref_1">new</a> and'
+                      ' <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_2" data-eid="ref_2">link</a>.</p>')
+        n_changes, diff = self.differ.diff_document_html(old, new)
+
+        self.assertEqual(
+            '<p class="akn-p">Some text <a class="ins akn-ref" href="https://example.com">new</a><ins> and </ins><a class="akn-ref" href="https://example.com">link</a>.</p>',
+            as_html(diff),
         )
 
     def test_diff_lists_deleted(self):

--- a/indigo_za/tests/test_terms_eng.py
+++ b/indigo_za/tests/test_terms_eng.py
@@ -267,29 +267,29 @@ class TermsFinderENGTestCase(APITestCase):
 
     def test_mixed_quotes(self):
         doc = Document(work=self.work, content=document_fixture(xml="""
-<section eId="sec_1">
+<article eId="art_1">
   <num>1.</num>
   <heading>Definitions</heading>
-  <hcontainer eId="sec_1__hcontainer_1">
+  <hcontainer eId="art_1__hcontainer_1">
     <content>
       <p>"Women’s Police Network Sub-sub Committee" means the National Road Traffic Act, 1996 (<ref href="/akn/za/act/1996/93">Act No. 93 of 1996</ref>);</p>
     </content>
   </hcontainer>
-</section>"""))
+</article>"""))
 
         self.maxDiff = None
         self.finder.find_terms_in_document(doc)
         self.assertMultiLineEqual('''<body xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
       
-<section eId="sec_1">
+<article eId="art_1">
   <num>1.</num>
   <heading>Definitions</heading>
-  <hcontainer eId="sec_1__hcontainer_1">
+  <hcontainer eId="art_1__hcontainer_1">
     <content>
       <p refersTo="#term-Women_s_Police_Network_Sub_sub_Committee">"<def refersTo="#term-Women_s_Police_Network_Sub_sub_Committee">Women’s Police Network Sub-sub Committee</def>" means the National Road Traffic Act, 1996 (<ref href="/akn/za/act/1996/93">Act No. 93 of 1996</ref>);</p>
     </content>
   </hcontainer>
-</section>
+</article>
     </body>
   
 ''', etree.tostring(doc.doc.body, pretty_print=True, encoding='UTF-8').decode('utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         'django>=3.2,<4',
         'boto3>=1.7',
-        'cobalt>=6.0',
+        'cobalt>=6.1',
         'cssutils>=2.3.0',
         'django-ckeditor>=5.8',
         'dj-database-url>=0.3.0',
@@ -80,7 +80,8 @@ setup(
         'whitenoise>=5.3.0',
         'django-contrib-comments>=1.9.1',
         'XlsxWriter>=1.2.6',
-        'xmldiff>=2.4',
+        # unreleased version of xmldiff that allows us to ignore attributes when diffing
+        'xmldiff @ git+https://github.com/Shoobx/xmldiff@6980256b10ffa41b5ab80716e63a608f587126db#egg=xmldiff',
         'sentry-sdk>=1.4,<=1.9.8',
 
         # for indigo_social


### PR DESCRIPTION
## better diffs

The differ now doesn't differentiate inline elements based on attributes that don't matter, such as id.

before:

![image](https://user-images.githubusercontent.com/4178542/196973703-02347228-7ac4-4238-9ac9-02eec96e382f.png)

after:

![image](https://user-images.githubusercontent.com/4178542/196973778-eb403b82-48aa-4df5-9fa0-33a3bc687744.png)

## defined terms

Defined terms are now picked up in all hierarchical elements, not just sections.
