### PR TITLE
Don't consider a future commencement date as initial

### DIFF
--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -214,7 +214,8 @@ class DocumentMixin(object):
 
             Returns True or False.
 
-            Returns True if all dates after the current expression are arbitrary.
+            Returns True if all dates after the current expression are arbitrary. An arbitrary date is
+            one that isn't an initial date or an amendment date.
 
             Returns False if the document doesn't yet have an expression date
              or if the work doesn't yet have possible expression dates.

--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -196,7 +196,11 @@ class WorkMixin(object):
         consolidation_dates = [c.date for c in self.arbitrary_expression_dates.all()]
 
         # the initial date is the publication date, or the earliest of the consolidation and commencement dates
-        initial = self.publication_date or min(consolidation_dates + [x for x in [self.commencement_date] if x])
+        try:
+            initial = self.publication_date or min(consolidation_dates + [x for x in [self.commencement_date] if x])
+        except ValueError:
+            # list was empty
+            initial = None
 
         all_dates = set(amendment_dates + consolidation_dates)
         dates = [

--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -192,9 +192,12 @@ class WorkMixin(object):
         """ Return a list of dicts each describing a possible expression date on a work, in descending date order.
         Each has a date and specifies whether it is an amendment, consolidation, and/or initial expression.
         """
-        initial = self.publication_date or self.commencement_date
         amendment_dates = [a.date for a in self.amendments.all()]
         consolidation_dates = [c.date for c in self.arbitrary_expression_dates.all()]
+
+        # the initial date is the publication date, or the earliest of the consolidation and commencement dates
+        initial = self.publication_date or min(consolidation_dates + [x for x in [self.commencement_date] if x])
+
         all_dates = set(amendment_dates + consolidation_dates)
         dates = [
             {'date': date,

--- a/indigo_api/tests/test_work.py
+++ b/indigo_api/tests/test_work.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 
 from django.test import TestCase
@@ -154,4 +153,21 @@ class WorkTestCase(TestCase):
                 {'date': datetime.date(2017, 2, 23),
                  'initial': True},
             ]
+        )
+
+    def test_possible_expression_dates_future_commencement(self):
+        """ Use the consolidation date if the commencement date is in the future and the publication date is not known.
+        """
+        # the work commences on 2016-07-15
+        self.work.publication_date = None
+        consolidation = ArbitraryExpressionDate(work=self.work, date='2010-01-01', created_by_user_id=1)
+        consolidation.save()
+        self.assertEqual(
+            [
+                {'date': datetime.date(2010, 1, 1),
+                 'amendment': False,
+                 'consolidation': True,
+                 'initial': True},
+            ],
+            self.work.possible_expression_dates()
         )

--- a/indigo_api/tests/test_work.py
+++ b/indigo_api/tests/test_work.py
@@ -171,3 +171,10 @@ class WorkTestCase(TestCase):
             ],
             self.work.possible_expression_dates()
         )
+
+    def test_no_initial_date(self):
+        self.work.publication_date = None
+        self.work.commencements.all().delete()
+        self.assertEqual([],
+            self.work.possible_expression_dates()
+        )


### PR DESCRIPTION
If a work has no publication date, a consolidation date and a commencement date ahead of the consolidation date, use the consolidation date as the initial date, not the commencement.

Fixes #1600