### PR TITLE
N+1 Fixes

### DIFF
--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -636,6 +636,11 @@ class Colophon(models.Model):
         return str(self.name)
 
 
+class AnnotationManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().select_related('created_by_user')
+
+
 class Annotation(models.Model):
     document = models.ForeignKey(Document, related_name='annotations', on_delete=models.CASCADE)
     created_by_user = models.ForeignKey(User, on_delete=models.CASCADE, null=False, related_name='+')
@@ -647,6 +652,8 @@ class Annotation(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     task = models.OneToOneField('task', on_delete=models.SET_NULL, null=True, related_name='annotation')
     selectors = JSONField(null=True)
+
+    objects = AnnotationManager()
 
     def resolve_anchor(self):
         if self.anchor_id and self.document:

--- a/indigo_api/models/tasks.py
+++ b/indigo_api/models/tasks.py
@@ -34,7 +34,9 @@ class TaskManager(models.Manager):
         from .documents import Document
 
         return super(TaskManager, self).get_queryset() \
-            .select_related('created_by_user', 'assigned_to', 'country', 'country__country', 'locality') \
+            .select_related('created_by_user', 'updated_by_user', 'assigned_to', \
+                            'submitted_by_user', 'reviewed_by_user', 'country', \
+                            'country__country', 'locality') \
             .prefetch_related(Prefetch('work', queryset=Work.objects.filter())) \
             .prefetch_related(Prefetch('document', queryset=Document.objects.no_xml())) \
             .prefetch_related('labels')


### PR DESCRIPTION
This PR fixes the following N+1 issues:
* [x] When fetching annotations, extra queries are made to fetch each annotation's creator - [see Indigo-LawsAfrica-Q2 on Sentry](https://sentry.io/share/issue/83bc81f08eea4d1f8a97cd85dfa8b022/)
* [x] When fetching tasks, extra queries are made to fetch each tasks creator, assignee, updator, submitter and reviewer - [see Indigo-LawsAfrica-QV on Sentry](https://sentry.io/share/issue/89b8491f1dad406aac636bae2c86a6bf/)