### PR TITLE
Add TLS/SSL Email Support

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -358,6 +358,8 @@ EMAIL_HOST = os.environ.get('DJANGO_EMAIL_HOST')
 EMAIL_HOST_USER = os.environ.get('DJANGO_EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.environ.get('DJANGO_EMAIL_HOST_PASSWORD')
 EMAIL_PORT = int(os.environ.get('DJANGO_EMAIL_PORT', 25))
+EMAIL_USE_TLS = os.environ.get('DJANGO_EMAIL_USE_TLS', 'false') == 'true'
+EMAIL_USE_SSL = os.environ.get('DJANGO_EMAIL_USE_SSL', 'false') == 'true'
 EMAIL_SUBJECT_PREFIX = '[%s] ' % INDIGO_ORGANISATION
 
 # Auth


### PR DESCRIPTION
Add support for enabling and disabling either SSL or TLS through os.environ.get and DJANGO_EMAIL_USE_SSL=true or DJANGO_EMAIL_USE_TLS env variables.