### PR TITLE
Show consolidation note more

### DIFF
--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -336,6 +336,10 @@ class WorkMixin(object):
             commencements_count += 1
         return commencements_count
 
+    @property
+    def has_consolidation(self):
+        return self.arbitrary_expression_dates.exists()
+
     def consolidation_note(self):
         return self.consolidation_note_override or self.place.settings.consolidation_note
 

--- a/indigo_api/templates/indigo_api/akn/coverpage_act.html
+++ b/indigo_api/templates/indigo_api/akn/coverpage_act.html
@@ -211,7 +211,7 @@
 
       {% block consolidation_note %}
         {% with document.work.consolidation_note as consolidation_note %}
-          {% if document.is_consolidation and consolidation_note %}
+          {% if document.work.arbitrary_expression_dates.exists and consolidation_note %}
             <li class="verification-notice">
               [{% trans consolidation_note %}]
             </li>

--- a/indigo_api/templates/indigo_api/akn/coverpage_act.html
+++ b/indigo_api/templates/indigo_api/akn/coverpage_act.html
@@ -211,7 +211,7 @@
 
       {% block consolidation_note %}
         {% with document.work.consolidation_note as consolidation_note %}
-          {% if document.work.arbitrary_expression_dates.exists and consolidation_note %}
+          {% if document.work.has_consolidation and consolidation_note %}
             <li class="verification-notice">
               [{% trans consolidation_note %}]
             </li>


### PR DESCRIPTION
partially closes https://github.com/laws-africa/indigo-lawsafrica/issues/584 closes #1598 

The latter issue was reported incorrectly, I suspect. The consolidation note (if it exists) is currently only shown if the document itself _is_ a consolidation.

The changes closes the former issue: the note will now appear on all documents of a work that _has_ a consolidation.
