### PR TITLE
Split out HTML differ logic from attribute differ logic

### DIFF
--- a/indigo/tests/test_differ.py
+++ b/indigo/tests/test_differ.py
@@ -1,16 +1,93 @@
 from django.test import TestCase
 
-import lxml.html
-
-from indigo.analysis.differ import AttributeDiffer
+from indigo.analysis.differ import AttributeDiffer, AKNHTMLDiffer
 
 
-def as_tree(html):
-    return lxml.html.fromstring(html)
+class AKNHTMLDifferTestCase(TestCase):
+    maxDiff = None
 
+    def setUp(self):
+        self.differ = AKNHTMLDiffer()
 
-def as_html(tree):
-    return lxml.html.tostring(tree, encoding='utf-8').decode('utf-8')
+    def test_text_changed(self):
+        diff = self.differ.diff_html_str(
+            '<p>abc 123</p>',
+            '<p>def 456</p>'
+        )
+
+        self.assertEqual(
+            '<p><span class="diff-pair"><del>abc 123</del><ins>def 456</ins></span></p>',
+            diff,
+        )
+
+    def test_text_partially_changed(self):
+        diff = self.differ.diff_html_str(
+            '<p>some old text</p>',
+            '<p>some new text</p>'
+        )
+
+        self.assertEqual(
+            '<p>some <span class="diff-pair"><del>old</del><ins>new</ins></span> text</p>',
+            diff,
+        )
+
+    def test_text_partially_changed_with_elements(self):
+        diff = self.differ.diff_html_str(
+            '<p>some old text <b>no change</b> text <i>no change</i></p>',
+            '<p>some new text <b>no change</b> text <i>no change</i></p>'
+        )
+
+        self.assertEqual(
+            '<p>some <span class="diff-pair"><del>old</del><ins>new</ins></span> text <b>no change</b> text <i>no change</i></p>',
+            diff,
+        )
+
+    def test_tail_changed(self):
+        diff = self.differ.diff_html_str(
+            '<p>something <b>bold</b> 123 xx <i>and</i> same </p>',
+            '<p>something <b>bold</b> 456 xx <i>and</i> same </p>'
+        )
+
+        self.assertEqual(
+            '<p>something <b>bold</b> <span class="diff-pair"><del>123</del><ins>456</ins></span> xx <i>and</i> same </p>',
+            diff,
+        )
+
+    def test_inline_tag_removed(self):
+        diff = self.differ.diff_html_str(
+            '<p>Some text <b>bold text</b> and a tail.</p>',
+            '<p>Some text bold text and a tail.</p>'
+        )
+
+        self.assertEqual(
+            '<p>Some text <ins>bold text and a tail.</ins><b class="del ">bold text</b> and a tail.</p>',
+            diff,
+        )
+
+    def test_inline_tag_added(self):
+        diff = self.differ.diff_html_str(
+            '<p>Some text bold text and a tail.</p>',
+            '<p>Some text <b>bold text</b> and a tail.</p>'
+        )
+
+        self.assertEqual(
+            '<p>Some text <span class="diff-pair"><del>bold text and a tail.</del><ins>&#xA0;</ins></span><b class="ins ">bold text</b><ins> and a tail.</ins></p>',
+            diff,
+        )
+
+    def test_more_refs_added(self):
+        """ When adding a new ref to a p tag, the other refs should not be considered different.
+        """
+        diff = self.differ.diff_html_str(
+            '<p class="akn-p">Some text <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_1" data-eid="ref_1">link</a>.</p>',
+            '<p class="akn-p">Some text <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_1" data-eid="ref_1">new</a> and'
+            ' <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_2" data-eid="ref_2">link</a>.</p>'
+        )
+
+        self.assertEqual(
+            '<p class="akn-p">Some text <a class="ins akn-ref" href="https://example.com">new</a><ins> and </ins><a class="akn-ref" href="https://example.com">link</a>.</p>',
+            diff,
+        )
 
 
 class AttributeDifferTestCase(TestCase):
@@ -18,79 +95,6 @@ class AttributeDifferTestCase(TestCase):
 
     def setUp(self):
         self.differ = AttributeDiffer()
-
-    def test_text_changed(self):
-        old = as_tree('<p>abc 123</p>')
-        new = as_tree('<p>def 456</p>')
-        n_changes, diff = self.differ.diff_document_html(old, new)
-
-        self.assertEqual(
-            '<p><span class="diff-pair"><del>abc 123</del><ins>def 456</ins></span></p>',
-            as_html(diff),
-        )
-
-    def test_text_partially_changed(self):
-        old = as_tree('<p>some old text</p>')
-        new = as_tree('<p>some new text</p>')
-        n_changes, diff = self.differ.diff_document_html(old, new)
-
-        self.assertEqual(
-            '<p>some <span class="diff-pair"><del>old</del><ins>new</ins></span> text</p>',
-            as_html(diff),
-        )
-
-    def test_text_partially_changed_with_elements(self):
-        old = as_tree('<p>some old text <b>no change</b> text <i>no change</i></p>')
-        new = as_tree('<p>some new text <b>no change</b> text <i>no change</i></p>')
-        n_changes, diff = self.differ.diff_document_html(old, new)
-
-        self.assertEqual(
-            '<p>some <span class="diff-pair"><del>old</del><ins>new</ins></span> text <b>no change</b> text <i>no change</i></p>',
-            as_html(diff),
-        )
-
-    def test_tail_changed(self):
-        old = as_tree('<p>something <b>bold</b> 123 xx <i>and</i> same </p>')
-        new = as_tree('<p>something <b>bold</b> 456 xx <i>and</i> same </p>')
-        n_changes, diff = self.differ.diff_document_html(old, new)
-
-        self.assertEqual(
-            '<p>something <b>bold</b> <span class="diff-pair"><del>123</del><ins>456</ins></span> xx <i>and</i> same </p>',
-            as_html(diff),
-        )
-
-    def test_inline_tag_removed(self):
-        old = as_tree('<p>Some text <b>bold text</b> and a tail.</p>')
-        new = as_tree('<p>Some text bold text and a tail.</p>')
-        n_changes, diff = self.differ.diff_document_html(old, new)
-
-        self.assertEqual(
-            '<p>Some text <ins>bold text and a tail.</ins><b class="del ">bold text</b> and a tail.</p>',
-            as_html(diff),
-        )
-
-    def test_inline_tag_added(self):
-        old = as_tree('<p>Some text bold text and a tail.</p>')
-        new = as_tree('<p>Some text <b>bold text</b> and a tail.</p>')
-        n_changes, diff = self.differ.diff_document_html(old, new)
-
-        self.assertEqual(
-            as_html(diff),
-            '<p>Some text <span class="diff-pair"><del>bold text and a tail.</del><ins>&#xA0;</ins></span><b class="ins ">bold text</b><ins> and a tail.</ins></p>',
-        )
-
-    def test_more_refs_added(self):
-        """ When adding a new ref to a p tag, the other refs should not be considered different.
-        """
-        old = as_tree('<p class="akn-p">Some text <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_1" data-eid="ref_1">link</a>.</p>')
-        new = as_tree('<p class="akn-p">Some text <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_1" data-eid="ref_1">new</a> and'
-                      ' <a class="akn-ref" href="https://example.com" data-href="https://example.com" id="ref_2" data-eid="ref_2">link</a>.</p>')
-        n_changes, diff = self.differ.diff_document_html(old, new)
-
-        self.assertEqual(
-            '<p class="akn-p">Some text <a class="ins akn-ref" href="https://example.com">new</a><ins> and </ins><a class="akn-ref" href="https://example.com">link</a>.</p>',
-            as_html(diff),
-        )
 
     def test_diff_lists_deleted(self):
         diffs = self.differ.diff_lists('test', 'Test', ['1', '2', '3'], ['1', '3'])

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -26,7 +26,7 @@ from cobalt import StructuredDocument
 import lxml.html.diff
 from lxml.etree import LxmlError
 
-from indigo.analysis.differ import AttributeDiffer
+from indigo.analysis.differ import AKNHTMLDiffer
 from indigo.plugins import plugins
 from ..models import Document, Annotation, DocumentActivity, Task
 from ..serializers import DocumentSerializer, RenderSerializer, ParseSerializer, DocumentAPISerializer, VersionSerializer, AnnotationSerializer, DocumentActivitySerializer, TaskSerializer, DocumentDiffSerializer
@@ -250,25 +250,25 @@ class RevisionViewSet(DocumentResourceView, viewsets.ReadOnlyModelViewSet):
         # most recent version just before this one
         old_version = self.get_queryset().filter(id__lt=version.id).first()
 
-        differ = AttributeDiffer()
+        differ = AKNHTMLDiffer()
 
         if old_version:
             old_document = old_version._object_version.object
-            old_document.document_xml = differ.preprocess_document_diff(old_document.document_xml)
+            old_document.document_xml = differ.preprocess_xml_str(old_document.document_xml)
             old_html = old_document.to_html()
         else:
             old_html = ""
 
         new_document = version._object_version.object
-        new_document.document_xml = differ.preprocess_document_diff(new_document.document_xml)
+        new_document.document_xml = differ.preprocess_xml_str(new_document.document_xml)
         new_html = new_document.to_html()
 
         old_tree = lxml.html.fromstring(old_html) if old_html else None
         new_tree = lxml.html.fromstring(new_html)
-        n_changes, diff = differ.diff_document_html(old_tree, new_tree)
 
-        if not isinstance(diff, str):
-            diff = lxml.html.tostring(diff, encoding='unicode')
+        diff = differ.diff_html(old_tree, new_tree)
+        n_changes = differ.count_differences(diff)
+        diff = lxml.html.tostring(diff, encoding='unicode')
 
         # TODO: include other diff'd attributes
 
@@ -466,7 +466,7 @@ class DocumentDiffView(DocumentResourceView, APIView):
         serializer = DocumentDiffSerializer(instance=self.document, data=self.request.data)
         serializer.is_valid(raise_exception=True)
 
-        differ = AttributeDiffer()
+        differ = AKNHTMLDiffer()
 
         local_doc = self.document
 
@@ -474,8 +474,8 @@ class DocumentDiffView(DocumentResourceView, APIView):
         remote_doc = Document.objects.get(pk=local_doc.pk)
         serializer.fields['document'].update_document(local_doc, serializer.validated_data['document'])
 
-        local_doc.content = differ.preprocess_document_diff(local_doc.document_xml).decode('utf-8')
-        remote_doc.content = differ.preprocess_document_diff(remote_doc.document_xml).decode('utf-8')
+        local_doc.content = differ.preprocess_xml_str(local_doc.document_xml).decode('utf-8')
+        remote_doc.content = differ.preprocess_xml_str(remote_doc.document_xml).decode('utf-8')
 
         element_id = serializer.validated_data.get('element_id')
         if element_id:
@@ -498,10 +498,10 @@ class DocumentDiffView(DocumentResourceView, APIView):
 
         local_tree = lxml.html.fromstring(local_html or "<div></div>")
         remote_tree = lxml.html.fromstring(remote_html) if remote_html else None
-        n_changes, diff = differ.diff_document_html(remote_tree, local_tree)
 
-        if not isinstance(diff, str):
-            diff = lxml.html.tostring(diff, encoding='utf-8')
+        diff = differ.diff_html(local_tree, remote_tree)
+        n_changes = differ.count_differences(diff)
+        diff = lxml.html.tostring(diff, encoding='unicode')
 
         # TODO: include other diff'd attributes
 


### PR DESCRIPTION
* move XML/HTML-specific logic out of the AttributeDiffer into into the HTML differ, which is a more logical home for it
* simplify the API so that most callers that don't need the number of diffs don't need to count them and then throw that away