### PR TITLE
Error report response.text() and editTimes

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -697,11 +697,13 @@
         },
         body: JSON.stringify(sourceEditor.editTimes)
       }).then(function(response) {
-
         if(response.ok) {
           sourceEditor.editTimes = [];
         } else {
-          throw new Error(response.statusText);
+          console.log('Edit times',JSON.stringify(sourceEditor.editTimes));
+          response.text().then(text => {
+            throw new Error(text);
+          });
         }
       });
     },


### PR DESCRIPTION
Refactor error of edit times in an attempt to get a better sense of what is happening with error could not be saved

The following changes were made:
- Report `editTimes` 
- We report `response.text()`

After testing locally this the error reporting looks like on sentry:
![image](https://user-images.githubusercontent.com/15995210/204229744-fda89f9a-af04-44ae-94f0-a500a1121e0c.png)