### PR TITLE
Prevent pushing a timeslot if editStartedAt empty

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -64,6 +64,7 @@
     },
 
     editActivityEnded: function() {
+      if(!this.editStartedAt) return;
       this.editTimes.push({
         started_at: this.editStartedAt,
         ended_at: new Date().toISOString()


### PR DESCRIPTION
This is a patch to prevent the system from pushing a time slot with a `null` `this.editStartedAt`....sigh..

What I am unable to pinpoint is what is triggering `this.editStartedAt` to equal `null` at that point. 

The places where `this.editStartedAt` is set to `null` are the following:
- In the [intitializer](https://github.com/laws-africa/indigo/blob/a0b9d011195dddf80373992c7193520ad7c35655/indigo_app/static/javascript/indigo/views/document_editor.js#L31)
- in [`editActivityEnded`](https://github.com/laws-africa/indigo/blob/a0b9d011195dddf80373992c7193520ad7c35655/indigo_app/static/javascript/indigo/views/document_editor.js#L66) after the time slot as been added
- And in [`editActivityCancelled`](https://github.com/laws-africa/indigo/blob/a0b9d011195dddf80373992c7193520ad7c35655/indigo_app/static/javascript/indigo/views/document_editor.js#L74)