### PR TITLE
show block diffs as div, not inline

### DIFF
--- a/indigo/analysis/differ.py
+++ b/indigo/analysis/differ.py
@@ -120,11 +120,11 @@ class AKNHTMLDiffer:
 
         if not old_html:
             # it's newly added
-            return '<ins>' + new_html + '</ins>'
+            return '<div class="ins">' + new_html + '</div>'
 
         if not new_html:
             # it was deleted
-            return '<del>' + old_html + '</del>'
+            return '<div class="del">' + old_html + '</div>'
 
         old_tree = lxml.html.fromstring(old_html)
         new_tree = lxml.html.fromstring(new_html)


### PR DESCRIPTION
ins and del are inlines, not blocks; if a whole element is being added or removed, it must be as a block.

Before:

![image](https://user-images.githubusercontent.com/4178542/227533149-7ca80629-24f9-46f9-a617-cd7dc2011b3c.png)


After:

![image](https://user-images.githubusercontent.com/4178542/227533195-26c396ef-bfc0-4456-a0a6-0ca0cefc6c62.png)
