### PR TITLE
sentry profiling; bg task ops

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -505,4 +505,7 @@ if not DEBUG and SENTRY_DSN:
         integrations=[DjangoIntegration(), sentry_logging],
         send_default_pii=True,
         traces_sample_rate=SENTRY_SAMPLE_RATE,
+        _experiments={
+            "profiles_sample_rate": 1.0,
+        },
     )

--- a/indigo/signals.py
+++ b/indigo/signals.py
@@ -8,7 +8,8 @@ import sentry_sdk
 @receiver(task_started)
 def bg_task_started(sender, **kwargs):
     if not settings.DEBUG and settings.SENTRY_DSN:
-        transaction = sentry_sdk.start_transaction(op="task")
+        transaction = sentry_sdk.start_transaction(op="queue.task.bg")
+        transaction.set_tag("transaction_type", "task")
         # fake an entry into the context
         transaction.__enter__()
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'XlsxWriter>=1.2.6',
         # unreleased version of xmldiff that allows us to ignore attributes when diffing
         'xmldiff @ git+https://github.com/Shoobx/xmldiff@6980256b10ffa41b5ab80716e63a608f587126db#egg=xmldiff',
-        'sentry-sdk>=1.4,<=1.9.8',
+        'sentry-sdk>=1.16.0',
 
         # for indigo_social
         'pillow>=5.2.0',


### PR DESCRIPTION
Change bg task operation to match sentry naming: https://develop.sentry.dev/sdk/performance/span-operations/#messagesqueues

Turn on sentry profiling (experimental)

Tag background tasks so we can filter on them more easily