### PR TITLE
Fix FOP

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -513,3 +513,4 @@ if not DEBUG and SENTRY_DSN:
 # where does the fop binary live?
 FOP_CMD = os.environ.get("FOP_CMD", "fop")
 FOP_CONFIG = os.environ.get("FOP_CONFIG")
+FONT_PATH = os.environ.get("FONT_PATH")

--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -512,4 +512,4 @@ if not DEBUG and SENTRY_DSN:
 
 # where does the fop binary live?
 FOP_CMD = os.environ.get("FOP_CMD", "fop")
-FOP_CONFIG = os.environ.get("FOP_CONFIG", "/app/indigo_api/fop.xconf")
+FOP_CONFIG = os.environ.get("FOP_CONFIG")

--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -513,4 +513,4 @@ if not DEBUG and SENTRY_DSN:
 # where does the fop binary live?
 FOP_CMD = os.environ.get("FOP_CMD", "fop")
 FOP_CONFIG = os.environ.get("FOP_CONFIG")
-FONT_PATH = os.environ.get("FONT_PATH")
+FOP_FONT_PATH = os.environ.get("FOP_FONT_PATH")

--- a/indigo_api/fop.xconf
+++ b/indigo_api/fop.xconf
@@ -85,8 +85,8 @@ the location of this file.
         <!-- <auto-detect/> -->
 
         <!-- register the fonts in the `fonts` directory -->
-        <!-- when running locally, replace `app` with the full path to indigo_api -->
-        <directory>/app/indigo_api/fonts</directory>
+        <!-- __FONT_PATH__ will be replaced with the full path to indigo_api/fonts -->
+        <directory>__FONT_PATH__</directory>
 
       </fonts>
 

--- a/indigo_api/pdf.py
+++ b/indigo_api/pdf.py
@@ -20,7 +20,6 @@ def default_fop_config():
     """
     fop_config = os.path.join(os.path.dirname(__file__), 'fop.xconf')
     font_path = FOP_FONT_PATH or os.path.join(os.path.dirname(__file__), 'fonts')
-    # TODO: is there a way to do this in place instead?
     with open(fop_config, 'r+') as f:
         out = re.sub('__FONT_PATH__', font_path, f.read())
         f.truncate()

--- a/indigo_api/pdf.py
+++ b/indigo_api/pdf.py
@@ -23,7 +23,7 @@ def default_fop_config():
     # TODO: is there a way to do this in place instead?
     with open(fop_config, 'r+') as f:
         out = re.sub('__FONT_PATH__', font_path, f.read())
-        f.seek(0)
+        f.truncate()
         f.write(out)
     return fop_config
 

--- a/indigo_api/pdf.py
+++ b/indigo_api/pdf.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 FOP_CMD = settings.FOP_CMD
 FOP_CONFIG = settings.FOP_CONFIG
-FONT_PATH = settings.FONT_PATH
+FOP_FONT_PATH = settings.FOP_FONT_PATH
 
 
 def default_fop_config():
@@ -19,7 +19,7 @@ def default_fop_config():
         :return the full path to the (edited) default fop config file.
     """
     fop_config = os.path.join(os.path.dirname(__file__), 'fop.xconf')
-    font_path = FONT_PATH or os.path.join(os.path.dirname(__file__), 'fonts')
+    font_path = FOP_FONT_PATH or os.path.join(os.path.dirname(__file__), 'fonts')
     # TODO: is there a way to do this in place instead?
     with open(fop_config, 'r+') as f:
         out = re.sub('__FONT_PATH__', font_path, f.read())


### PR DESCRIPTION
This PR:
- changes the settings to not have a default fop config file
- adds a FOP_FONT_PATH to settings (no default)
- gets the full path to the config file and the fop fonts directory in pdf.py
- edits the default fop config file to use the full path to the fonts directory

This should ensure that both vanilla indigo and others always use the right paths.
