### PR TITLE
ignore generated app css files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ venv
 attachments/
 indigo_app/static/lime/develop
 staticfiles/
+static/stylesheets/app.css
+static/stylesheets/app.css.map
 docs/_build
 node_modules/
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ venv
 attachments/
 indigo_app/static/lime/develop
 staticfiles/
-static/stylesheets/app.css
-static/stylesheets/app.css.map
+indigo_app/static/stylesheets/app.css
+indigo_app/static/stylesheets/app.css.map
 docs/_build
 node_modules/
 .coverage


### PR DESCRIPTION
These two files were auto generated and can be accidentally pushed in a commit, is it okay to ignore them? 

indigo_app/static/stylesheets/app.css
indigo_app/static/stylesheets/app.css.map