### PR TITLE
avoid tempfile error; better fop exceptions; quiten fop non-error output

### DIFF
--- a/indigo_api/exporters.py
+++ b/indigo_api/exporters.py
@@ -177,11 +177,11 @@ class PDFExporter(HTMLExporter, LocaleBasedMatcher):
             with open(xml_file, "wb") as f:
                 f.write(xml.encode('utf-8'))
 
-            outf = tempfile.NamedTemporaryFile('rb', dir=tmpdir, suffix='.pdf')
             xsl_fo = self.find_xsl_fo(document)
             self.update_base_xsl_fo_dir(xsl_fo)
-            run_fop(outf.name, tmpdir, xml_file, xsl_fo)
-            return outf.read()
+            outf_name = os.path.join(tmpdir, "out.pdf")
+            run_fop(outf_name, tmpdir, xml_file, xsl_fo)
+            return open(outf_name, 'rb').read()
 
     def insert_coverpage(self, document):
         """ Generates the coverpage and inserts it before the body in the XML.

--- a/indigo_api/pdf.py
+++ b/indigo_api/pdf.py
@@ -61,7 +61,11 @@ def run_fop(outf_name, cwd, xml=None, xsl_fo=None, xml_fo=None, output_fo=False)
     try:
         result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True, cwd=cwd,
                                 encoding='utf-8', errors='backslashreplace')
-        log.info(f"Output from fop: {result.stdout}")
+        log.debug(f"Output from fop: {result.stdout}")
     except subprocess.CalledProcessError as e:
         log.error(f"Error calling fop. Output: \n{e.output}", exc_info=e)
-        raise
+        # try to get a decent exception message from the FOP output
+        # find the first line that starts with SEVERE: and take the next line
+        match = re.search(r'^SEVERE: .*\n(.*)$', e.output, re.MULTILINE)
+        message = match.group(1) if match else "Error calling fop"
+        raise Exception(message) from e


### PR DESCRIPTION
* only log fop output at debug if there is no error; this makes our normal logs  much quieter
* avoid a spurious "file does not exist" error when the NamedTemporaryFile cleans itself up AFTER the tmpdir has done so
* try to get a better fop error message to make debugging simpler

eg:
```
Exception at /api/documents/1036.pdf
org.apache.fop.apps.FOPException: net.sf.saxon.s9api.SaxonApiException: Errors were reported during stylesheet compilation 
```