### PR TITLE
move hierarchicalize_stages out

### DIFF
--- a/indigo/pipelines/hier.py
+++ b/indigo/pipelines/hier.py
@@ -1056,7 +1056,7 @@ class IdentifyContainerHeadings(Stage):
                     block.remove(first)
 
 
-hierarchicalize = Pipeline([
+hierarchicalize_stages = [
     # these are unambiguous and can be identified up front
     IdentifyArticles(),
     IdentifyParts(),
@@ -1099,4 +1099,6 @@ hierarchicalize = Pipeline([
 
     # identify container headings that were missed previously once the structure is set
     IdentifyContainerHeadings(),
-], name="Hierarchicalize")
+]
+
+hierarchicalize = Pipeline(hierarchicalize_stages, name="Hierarchicalize")


### PR DESCRIPTION
This makes it a bit easier to manipulate the base stages, e.g. if we want to run an additional step before or after all the others