### PR TITLE
fix filterset with DRF API

### DIFF
--- a/indigo_api/views/works.py
+++ b/indigo_api/views/works.py
@@ -48,7 +48,7 @@ class WorkViewSet(viewsets.ReadOnlyModelViewSet):
                           'taxonomies', 'taxonomies__vocabulary')
     serializer_class = WorkSerializer
     filter_backends = (filters.DjangoFilterBackend, SearchFilter)
-    filter_class = WorkFilterSet
+    filterset_class = WorkFilterSet
     search_fields = ('title', 'frbr_uri')
 
 


### PR DESCRIPTION
Without this, the work chooser modal isn't having works filtered by country.

I think this would have been introduced during a version change for DRF.