### PR TITLE
Force HTML parser to use utf-8

### DIFF
--- a/indigo/analysis/differ.py
+++ b/indigo/analysis/differ.py
@@ -126,8 +126,9 @@ class AKNHTMLDiffer:
             # it was deleted
             return '<div class="del">' + old_html + '</div>'
 
-        old_tree = lxml.html.fromstring(old_html)
-        new_tree = lxml.html.fromstring(new_html)
+        parser = lxml.html.HTMLParser(encoding='utf-8')
+        old_tree = lxml.html.fromstring(old_html.encode('utf-8'), parser=parser)
+        new_tree = lxml.html.fromstring(new_html.encode('utf-8'), parser=parser)
         diff = self.diff_html(old_tree, new_tree)
         return lxml.html.tostring(diff, encoding='unicode')
 

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -263,8 +263,10 @@ class RevisionViewSet(DocumentResourceView, viewsets.ReadOnlyModelViewSet):
         new_document.document_xml = differ.preprocess_xml_str(new_document.document_xml)
         new_html = new_document.to_html()
 
-        old_tree = lxml.html.fromstring(old_html.encode('utf-8')) if old_html else None
-        new_tree = lxml.html.fromstring(new_html.encode('utf-8'))
+        # we have to explicitly tell the HTML parser that we're dealing with utf-8
+        parser = lxml.html.HTMLParser(encoding='utf-8')
+        old_tree = lxml.html.fromstring(old_html.encode('utf-8'), parser=parser) if old_html else None
+        new_tree = lxml.html.fromstring(new_html.encode('utf-8'), parser=parser)
 
         diff = differ.diff_html(old_tree, new_tree)
         n_changes = differ.count_differences(diff)


### PR DESCRIPTION
Fixes https://github.com/laws-africa/indigo/issues/1829

The HTML parser looks for a `<meta encoding...` element in proper HTML. Since ours are fragments, we have to tell it what to expect.

![image](https://github.com/laws-africa/indigo/assets/4178542/ea65fc72-bb33-4f97-aae8-458c41cb0490)

