### PR TITLE
move date first in all related-work tables

### DIFF
--- a/indigo_app/templates/indigo_api/_work_amendment_tables.html
+++ b/indigo_app/templates/indigo_api/_work_amendment_tables.html
@@ -7,19 +7,19 @@
     <table class="table table-sm">
       <thead>
       <tr>
-        <th>{% trans 'Work' %}</th>
         <th>{% trans 'Date' %}</th>
+        <th>{% trans 'Work' %}</th>
       </tr>
       </thead>
       {% for item in amendments %}
         <tr>
+          <td>{{ item.date|date:"Y-m-d" }}</td>
           <td>
             <a href="{% url 'work' frbr_uri=item.amending_work.frbr_uri %}"
                data-popup-url="{% url 'work_popup' frbr_uri=item.amending_work.frbr_uri %}"
             >{{ item.amending_work.title }}</a>
             <span class="text-muted">· {{ item.amending_work.frbr_uri }}</span>
           </td>
-          <td>{{ item.date|date:"Y-m-d" }}</td>
         </tr>
       {% endfor %}
     </table>
@@ -35,19 +35,19 @@
     <table class="table table-sm">
       <thead>
       <tr>
-        <th>{% trans 'Work' %}</th>
         <th>{% trans 'Date' %}</th>
+        <th>{% trans 'Work' %}</th>
       </tr>
       </thead>
       {% for item in amendments_made %}
         <tr>
+          <td>{{ item.date|date:"Y-m-d" }}</td>
           <td>
             <a href="{% url 'work' frbr_uri=item.amended_work.frbr_uri %}"
                data-popup-url="{% url 'work_popup' frbr_uri=item.amended_work.frbr_uri %}"
             >{{ item.amended_work.title }}</a>
             <span class="text-muted">· {{ item.amended_work.frbr_uri }}</span>
           </td>
-          <td>{{ item.date|date:"Y-m-d" }}</td>
         </tr>
       {% endfor %}
     </table>

--- a/indigo_app/templates/indigo_api/_work_commencement_tables.html
+++ b/indigo_app/templates/indigo_api/_work_commencement_tables.html
@@ -7,14 +7,15 @@
     <table class="table table-sm">
       <thead>
       <tr>
-        <th>{% trans 'Work' %}</th>
-        <th>{% trans 'In full' %}</th>
-        <th>{% trans 'Note' %}</th>
         <th>{% trans 'Date' %}</th>
+        <th>{% trans 'Work' %}</th>
+        <th>{% trans 'Note' %}</th>
+        <th>{% trans 'In full' %}</th>
       </tr>
       </thead>
       {% for item in commencements %}
         <tr>
+          <td>{{ item.date|date:"Y-m-d" }}</td>
           <td>
             {% if item.commencing_work %}
               <a href="{% url 'work' frbr_uri=item.commencing_work.frbr_uri %}"
@@ -25,9 +26,8 @@
               —
             {% endif %}
           </td>
-          <td>{% if item.all_provisions %}✔{% else %}✕{% endif %}</td>
           <td>{{ item.note|default:"" }}</td>
-          <td>{{ item.date|date:"Y-m-d" }}</td>
+          <td>{% if item.all_provisions %}✓{% else %}✕{% endif %}</td>
         </tr>
       {% endfor %}
     </table>
@@ -43,23 +43,23 @@
     <table class="table table-sm">
       <thead>
       <tr>
-        <th>{% trans 'Work' %}</th>
-        <th>{% trans 'In full' %}</th>
-        <th>{% trans 'Note' %}</th>
         <th>{% trans 'Date' %}</th>
+        <th>{% trans 'Work' %}</th>
+        <th>{% trans 'Note' %}</th>
+        <th>{% trans 'In full' %}</th>
       </tr>
       </thead>
       {% for item in commencements_made %}
         <tr>
+          <td>{{ item.date|date:"Y-m-d" }}</td>
           <td>
             <a href="{% url 'work' frbr_uri=item.commenced_work.frbr_uri %}"
                data-popup-url="{% url 'work_popup' frbr_uri=item.commenced_work.frbr_uri %}"
             >{{ item.commenced_work.title }}</a>
             <span class="text-muted">· {{ item.commenced_work.frbr_uri }}</span>
           </td>
-          <td>{% if item.all_provisions %}✔{% else %}✕{% endif %}</td>
           <td>{{ item.note|default:"" }}</td>
-          <td>{{ item.date|date:"Y-m-d" }}</td>
+          <td>{% if item.all_provisions %}✓{% else %}✕{% endif %}</td>
         </tr>
       {% endfor %}
     </table>

--- a/indigo_app/templates/indigo_api/_work_repeal_tables.html
+++ b/indigo_app/templates/indigo_api/_work_repeal_tables.html
@@ -6,18 +6,18 @@
   <table class="table table-sm">
     <thead>
     <tr>
-      <th>{% trans 'Work' %}</th>
       <th>{% trans 'Date' %}</th>
+      <th>{% trans 'Work' %}</th>
     </tr>
     </thead>
     <tr>
+      <td>{{ work.repealed_date|date:"Y-m-d" }}</td>
       <td>
         <a href="{% url 'work' frbr_uri=work.repealed_by.frbr_uri %}"
            data-popup-url="{% url 'work_popup' frbr_uri=work.repealed_by.frbr_uri %}"
         >{{ work.repealed_by.title }}</a>
         <span class="text-muted">· {{ work.repealed_by.frbr_uri }}</span>
       </td>
-      <td>{{ work.repealed_date|date:"Y-m-d" }}</td>
     </tr>
   </table>
 {% else %}
@@ -31,19 +31,19 @@
     <table class="table table-sm">
       <thead>
       <tr>
-        <th>{% trans 'Work' %}</th>
         <th>{% trans 'Date' %}</th>
+        <th>{% trans 'Work' %}</th>
       </tr>
       </thead>
       {% for repealed_work in repeals_made %}
         <tr>
+          <td>{{ repealed_work.repealed_date|date:"Y-m-d" }}</td>
           <td>
             <a href="{% url 'work' frbr_uri=repealed_work.frbr_uri %}"
                data-popup-url="{% url 'work_popup' frbr_uri=repealed_work.frbr_uri %}"
             >{{ repealed_work.title }}</a>
             <span class="text-muted">· {{ repealed_work.frbr_uri }}</span>
           </td>
-          <td>{{ repealed_work.repealed_date|date:"Y-m-d" }}</td>
         </tr>
       {% endfor %}
     </table>


### PR DESCRIPTION
also move 'in full' to the last column for commencements, and use a nicer checkmark: ✓ instead of ✔

Commencements
<img width="1040" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/8edf942e-0d0b-4be5-9b5a-3bdd694802a9">
<img width="1038" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/99a395f4-0501-4428-9544-942aa4f4d6a5">


Amendments
<img width="1040" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/fcecd9b4-0f87-4be1-a643-c41adf248386">

Repeals
<img width="1038" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/2867d266-76ea-4e22-b2d6-95281d68a7e1">
