### PR TITLE
disable the button if a consolidation exists at the default date

### DIFF
--- a/indigo_app/templates/indigo_api/timeline/_work_points_in_time.html
+++ b/indigo_app/templates/indigo_api/timeline/_work_points_in_time.html
@@ -16,11 +16,17 @@
             {% if perms.indigo_api.add_arbitraryexpressiondate %}
               <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
               <div class="dropdown-menu">
-                <form method="POST" action="{% url 'new_arbitrary_expression_date' frbr_uri=work.frbr_uri %}">
-                  {% csrf_token %}
-                  <button class="dropdown-item" type="submit" name="date"
-                          value="{{ consolidation_date|date:'Y-m-d' }}">{% trans 'Add consolidation date' %}: {{ consolidation_date|date:'Y-m-d' }}</button>
-                </form>
+                {% if existing_consolidation_at_default_date %}
+                  <button class="dropdown-item disabled">
+                    {% trans 'Consolidation already exists at' %} {{ consolidation_date|date:'Y-m-d' }}
+                  </button>
+                {% else %}
+                  <form method="POST" action="{% url 'new_arbitrary_expression_date' frbr_uri=work.frbr_uri %}">
+                    {% csrf_token %}
+                    <button class="dropdown-item" type="submit" name="date"
+                            value="{{ consolidation_date|date:'Y-m-d' }}">{% trans 'Add consolidation date' %}: {{ consolidation_date|date:'Y-m-d' }}</button>
+                  </form>
+                {% endif %}
               </div>
             {% endif %}
 

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -462,6 +462,7 @@ class WorkAmendmentsView(WorkViewBase, DetailView):
         context = super(WorkAmendmentsView, self).get_context_data(**kwargs)
         context['work_timeline'] = self.get_work_timeline(self.work)
         context['consolidation_date'] = self.work.as_at_date() or datetime.date.today()
+        context['existing_consolidation_at_default_date'] = ArbitraryExpressionDate.objects.filter(work=self.work, date=context['consolidation_date']).exists()
         return context
 
     def get_work_timeline(self, work):


### PR DESCRIPTION
resolves https://lawsafrica.sentry.io/issues/4792489400/

<img width="1153" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/5680e9fb-0c73-4379-aacd-44e053272e54">

This is easier than catching the exception and rendering a useful error message, given the form isn't straightforward and the date can't currently be changed.