### PR TITLE
Provision refs

### DIFF
--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -278,6 +278,7 @@ class ProvisionRefsResolver:
         # prefix with namespace
         names = [f'{{{ns}}}{n}' for n in names]
         dead_ends = [f'{{{ns}}}{n}' for n in ['quotedStructure', 'embeddedStructure', 'content']]
+        not_outside_of = None if not_outside_of is None else [f'{{{ns}}}{n}' for n in not_outside_of]
 
         # do a breadth-first search, starting at root, and walk upwards, expanding until we find something or reach the top
         for elem in bfs_upward_search(root, names, dead_ends, not_outside_of):
@@ -673,7 +674,7 @@ def bfs_upward_search(root, names, dead_ends, not_outside_of=None):
         frontier.extend(child for child in node.iterchildren() if child not in visited and child.tag not in dead_ends)
 
         # If queue is empty (i.e., leaf node), move upwards
-        if not frontier and node.getparent() is not None and (
-                not_outside_of is None or node.getparent().tag in not_outside_of):
-            parent = node.getparent()
+        parent = node.getparent()
+        if not frontier and parent is not None and (
+                not_outside_of is None or node.tag not in not_outside_of):
             frontier.append(parent)

--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -227,7 +227,7 @@ class ProvisionRefsResolver:
         names = self.element_names[main_ref.name.lower()]
         if not isinstance(names, list):
             names = [names]
-        not_outside_of = self.major_hier_elements if any(x in self.minor_hier_elements for x in names) else None
+        not_outside_of = self.major_hier_elements if any(x in self.minor_hier_elements for x in names) else []
         ref.element = self.find_numbered_hier_element(local_root, names, ref.text, not_outside_of)
 
         if ref.element is not None:
@@ -264,7 +264,7 @@ class ProvisionRefsResolver:
             if ref.child:
                 self.resolve_ref(ref.child, [ref.element])
 
-    def find_numbered_hier_element(self, root: Element, names: Optional[List[str]], num: str, not_outside_of: Optional[List[str]] = None) -> Element:
+    def find_numbered_hier_element(self, root: Element, names: Optional[List[str]], num: str, not_outside_of: Optional[List[str]]=None) -> Element:
         """Find an heir element with the given number. Looks for elements with the given names, or any hier element
         if names is None. If not_outside_of is not None, then we'll look above the root element, but not go outside of
         the elements in not_outside_of (if any).
@@ -655,7 +655,7 @@ class ProvisionRefsFinderAFR(BaseProvisionRefsFinder):
     locale = (None, 'afr', None)
 
 
-def bfs_upward_search(root, names, dead_ends, not_outside_of=None):
+def bfs_upward_search(root, names, dead_ends, not_outside_of):
     """ Do a breadth-first search for tag_name elements, starting at root and not descending into elements named in
     dead_ends. If nothing matches, go up to the parent node (if not_outside_of is not None) and search from there. """
     # keep track of nodes we have seen, so we don't search back down into a node when we're going up a level
@@ -675,6 +675,5 @@ def bfs_upward_search(root, names, dead_ends, not_outside_of=None):
 
         # If queue is empty (i.e., leaf node), move upwards
         parent = node.getparent()
-        if not frontier and parent is not None and (
-                not_outside_of is None or node.tag not in not_outside_of):
+        if not frontier and parent is not None and not_outside_of is not None and node.tag not in not_outside_of:
             frontier.append(parent)

--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 from dataclasses import dataclass
-from typing import List, Union, Tuple
+from typing import List, Union, Tuple, Optional
 import logging
 from collections import deque
 
@@ -193,6 +193,22 @@ class ProvisionRefsResolver:
         "subafdelings": "subsection"
     }
 
+    # don't look outside of these elements when resolving references to minor_hier_elements
+    # that aren't otherwise scoped.
+    # ref: https://github.com/laws-africa/indigo-lawsafrica/issues/1067
+    major_hier_elements = [
+        "article",
+        "book",
+        "chapter",
+        "division",
+        "part",
+        "rule",
+        "section",
+        "title",
+        "tome",
+    ]
+    minor_hier_elements = list(set(AkomaNtoso30.hier_elements) - set(major_hier_elements))
+
     def resolve_references_str(self, text: str, root: Element):
         """Parse a string into reference objects, and the resolve them to eIds in the given root element."""
         refs = parse_provision_refs(text).references
@@ -211,7 +227,8 @@ class ProvisionRefsResolver:
         names = self.element_names[main_ref.name.lower()]
         if not isinstance(names, list):
             names = [names]
-        ref.element = self.find_numbered_hier_element(local_root, names, ref.text, True)
+        not_outside_of = self.major_hier_elements if any(x in self.minor_hier_elements for x in names) else None
+        ref.element = self.find_numbered_hier_element(local_root, names, ref.text, not_outside_of)
 
         if ref.element is not None:
             ref.eId = ref.element.get('eId')
@@ -247,9 +264,10 @@ class ProvisionRefsResolver:
             if ref.child:
                 self.resolve_ref(ref.child, [ref.element])
 
-    def find_numbered_hier_element(self, root: Element, names: Union[List[str], None], num: str, above_root: bool = False) -> Element:
+    def find_numbered_hier_element(self, root: Element, names: Optional[List[str]], num: str, not_outside_of: Optional[List[str]] = None) -> Element:
         """Find an heir element with the given number. Looks for elements with the given names, or any hier element
-        if names is None. If above_root is True, then we'll look above the root element if nothing inside matches.
+        if names is None. If not_outside_of is not None, then we'll look above the root element, but not go outside of
+        the elements in not_outside_of (if any).
         """
         names = names or AkomaNtoso30.hier_elements
         ns = root.nsmap.get(None)
@@ -262,7 +280,7 @@ class ProvisionRefsResolver:
         dead_ends = [f'{{{ns}}}{n}' for n in ['quotedStructure', 'embeddedStructure', 'content']]
 
         # do a breadth-first search, starting at root, and walk upwards, expanding until we find something or reach the top
-        for elem in bfs_upward_search(root, names, dead_ends, above_root):
+        for elem in bfs_upward_search(root, names, dead_ends, not_outside_of):
             # ignore matches to the root element, which avoids things like section (1)(a)(a) matching the same (a) twice
             if elem == root:
                 continue
@@ -636,9 +654,9 @@ class ProvisionRefsFinderAFR(BaseProvisionRefsFinder):
     locale = (None, 'afr', None)
 
 
-def bfs_upward_search(root, names, dead_ends, above_root):
+def bfs_upward_search(root, names, dead_ends, not_outside_of=None):
     """ Do a breadth-first search for tag_name elements, starting at root and not descending into elements named in
-    dead_ends. If nothing matches, go up to the parent node (if above_root is True) and search from there. """
+    dead_ends. If nothing matches, go up to the parent node (if not_outside_of is not None) and search from there. """
     # keep track of nodes we have seen, so we don't search back down into a node when we're going up a level
     visited = set()
     # the frontier is the set of nodes that we need to check
@@ -655,6 +673,7 @@ def bfs_upward_search(root, names, dead_ends, above_root):
         frontier.extend(child for child in node.iterchildren() if child not in visited and child.tag not in dead_ends)
 
         # If queue is empty (i.e., leaf node), move upwards
-        if not frontier and node.getparent() is not None and above_root:
+        if not frontier and node.getparent() is not None and (
+                not_outside_of is None or node.getparent().tag in not_outside_of):
             parent = node.getparent()
             frontier.append(parent)

--- a/indigo/tests/test_provision_refs.py
+++ b/indigo/tests/test_provision_refs.py
@@ -147,6 +147,38 @@ class ProvisionRefsResolverTestCase(TestCase):
             ),
         ], self.resolver.resolve_references_str("paragraph (a), subsection (1)", root))
 
+    def test_not_outside_of(self):
+        self.doc = AkomaNtosoDocument(document_fixture(xml="""
+        <article eId="art_44">
+          <num>44</num>
+          <heading>Termination of arbitral proceedings</heading>
+          <content>
+            <p eId="art_44__p_1">The arbitral proceedings are terminated by the pronouncement of the decisions in substance or by an order of the arbitral tribunal in accordance with paragraph <ref href="#chp_II__sec_5__subsec_2">2</ref> of this Article.</p>
+          </content>
+        </article>
+        <article eid="art_45">
+          <num>45</num>
+          <subsection eId="art_45__subsec_2">
+            <num>2</num>
+            <content>
+              <p>subsection 2 which can be mistaken for paragraph 2</p>
+            </content>
+          </subsection>
+          <paragraph eId="art_45__para_2">
+            <num>2</num>
+            <content>
+              <p>paragraph 2</p>
+            </content>
+          </paragraph>
+        </article>
+        """)).root
+        root = self.doc.xpath('.//*[@eId="art_44__p_1"]')[0]
+        self.assertEqual([
+            MainProvisionRef(
+                "Paragraph",
+                ProvisionRef("2", 10, 11, None))
+        ], self.resolver.resolve_references_str("Paragraph 2", root))
+
 
 class ProvisionRefsMatcherTestCase(TestCase):
     maxDiff = None


### PR DESCRIPTION
don't look outside of major hier container

for example, don't look outside of "section" when looking for a "paragraph 2" that doesn't have any other context.

fixes https://github.com/laws-africa/indigo-lawsafrica/issues/1067