### PR TITLE
Fix work_form js bug

### DIFF
--- a/indigo_app/js/components/work_form.js
+++ b/indigo_app/js/components/work_form.js
@@ -1,9 +1,12 @@
 export default class WorkForm {
   constructor (root) {
     this.root = root;
-    this.root.querySelector('#id_work-commenced').addEventListener('change', (e) => {
-      this.toggleCommenced(e.target.checked);
-    });
+
+    if (this.root.querySelector('#id_work-commenced')) {
+      this.root.querySelector('#id_work-commenced').addEventListener('change', (e) => {
+        this.toggleCommenced(e.target.checked);
+      });
+    }
   }
 
   toggleCommenced (commenced) {


### PR DESCRIPTION
- checks if the commencement input element is on the page before adding the event listener
- if a work has multiple commencements, the element is not shown

Fixes #1938