### PR TITLE
add work back into context for work_layout js preloads to not be empty

### DIFF
--- a/indigo_app/views/tasks.py
+++ b/indigo_app/views/tasks.py
@@ -24,6 +24,7 @@ from django_comments.models import Comment
 from django_fsm import has_transition_perm
 
 from indigo_api.models import Annotation, Task, TaskLabel, User, Work, Workflow, TaxonomyTopic
+from indigo_api.serializers import WorkSerializer
 from indigo_app.forms import TaskForm, TaskFilterForm, BulkTaskUpdateForm, TaskEditLabelsForm
 from indigo_app.views.base import AbstractAuthedIndigoView, PlaceViewBase
 from indigo_app.views.places import WorkChooserView
@@ -141,6 +142,12 @@ class TaskDetailView(SingleTaskViewBase, DetailView):
         # warn when submitting task on behalf of another user
         Task.decorate_submission_message([task], self)
         Task.decorate_permissions([task], self.request.user)
+
+        # add work to context
+        if task.work:
+            context['work'] = task.work
+            context['work_json'] = json.dumps(
+                WorkSerializer(instance=task.work, context={'request': self.request}).data)
 
         # include labels form
         context['labels_form'] = TaskEditLabelsForm(instance=task)


### PR DESCRIPTION
closes https://github.com/laws-africa/indigo-lawsafrica/issues/1158

I suspect / hope at some point we'll only need countries or something for the work chooser modal, but for now serializing the work and including it in the view makes everything behave

Current
<img width="1044" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/024c03c8-481e-4baf-bf2e-5b05cc701918">


With fix
<img width="1046" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/895f66f7-0128-4c45-a8ce-35193dfad311">
