### PR TITLE
fix non-closing tag for styleguide

### DIFF
--- a/indigo_app/templates/indigo_api/document/_toolbar.html
+++ b/indigo_app/templates/indigo_api/document/_toolbar.html
@@ -106,6 +106,7 @@
         <a class="btn btn-outline-secondary ms-2" href="{{ place.settings.styleguide_url }}" target="_blank">
         <i class="fas fa-book-open fa-fw"></i>
         {% blocktrans trimmed with country=work.country.name %}{{ country }} Style Guide{% endblocktrans %}
+        </a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
![image](https://github.com/laws-africa/indigo/assets/4178542/2ea8e4cb-3b63-4f34-a5b3-7f33c5612042)
