### PR TITLE
log when failing to transform a fragment to text

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -141,7 +141,19 @@
     },
 
     editFragmentText: function(fragment) {
-      var self = this;
+      let text;
+
+      // text from node in the actual XML document
+      try {
+        text = this.grammarModel.xmlToText(fragment);
+      } catch (e) {
+        // log details and then re-raise the error so that it's reported and we can work out what went wrong
+        console.log("Error converting XML to text");
+        console.log(fragment);
+        console.log(e);
+        throw e;
+      }
+
       this.editActivityStarted('text');
 
       this.editing = true;
@@ -154,9 +166,6 @@
       this.$toolbar.find('.btn-toolbar').addClass('d-none');
       this.$toolbar.find('.text-editor-buttons').removeClass('d-none');
       this.$('.document-workspace-buttons').addClass('d-none');
-
-      // text from node in the actual XML document
-      const text = this.grammarModel.xmlToText(this.fragment);
 
       // show the text editor
       this.$('.document-content-view').addClass('show-text-editor');

--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -150,6 +150,7 @@
         // log details and then re-raise the error so that it's reported and we can work out what went wrong
         console.log("Error converting XML to text");
         console.log(fragment);
+        console.log(new XMLSerializer().serializeToString(fragment));
         console.log(e);
         throw e;
       }


### PR DESCRIPTION
see https://github.com/laws-africa/indigo/issues/2007

I want to see what the actual XML is, since this shouldn't be happening.