### PR TITLE
allow filtering on updated_at and created_at fields

### DIFF
--- a/indigo_content_api/tests/v2/test_content_api.py
+++ b/indigo_content_api/tests/v2/test_content_api.py
@@ -143,6 +143,17 @@ class ContentAPIV2TestMixin:
         self.assertEqual(response.accepted_media_type, 'application/json')
         self.assertEqual(len(response.data['results']), 1)
 
+    def test_published_listing_filters(self):
+        response = self.client.get(self.api_path + '/akn/za/', {'updated_at__lte': '2015-02-20T00:00:00Z'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.accepted_media_type, 'application/json')
+        self.assertEqual(len(response.data['results']), 3)
+
+        response = self.client.get(self.api_path + '/akn/za/', {'updated_at__gte': '2015-06-01T00:00:00Z'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.accepted_media_type, 'application/json')
+        self.assertEqual(len(response.data['results']), 5)
+
     @patch.object(PDFExporter, 'render', return_value='pdf-content')
     def test_published_listing_pdf(self, mock):
         response = self.client.get(self.api_path + '/akn/za/act.pdf')

--- a/indigo_content_api/v2/views.py
+++ b/indigo_content_api/v2/views.py
@@ -6,6 +6,7 @@ from rest_framework.authentication import SessionAuthentication, TokenAuthentica
 from rest_framework.permissions import IsAuthenticated, BasePermission
 from rest_framework.response import Response
 from rest_framework.versioning import NamespaceVersioning
+from django_filters.rest_framework import DjangoFilterBackend
 
 from cobalt import FrbrUri
 
@@ -152,6 +153,12 @@ class PublishedDocumentDetailView(DocumentViewMixin,
     serializer_class = PublishedDocumentSerializer
     # these determine what content negotiation takes place
     renderer_classes = (renderers.JSONRenderer, PDFRenderer, EPUBRenderer, AkomaNtosoRenderer, HTMLRenderer, ZIPRenderer)
+
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {
+        "updated_at": ["exact", "gte", "lte"],
+        "created_at": ["exact", "gte", "lte"],
+    }
 
     def perform_content_negotiation(self, request, force=False):
         # force content negotiation to succeed, because sometimes the suffix format


### PR DESCRIPTION
this allows callers to ask for data only updated/created since they lasted refreshed their content