### PR TITLE
Taxonomy topic work list

### DIFF
--- a/indigo_api/fixtures/work.json
+++ b/indigo_api/fixtures/work.json
@@ -20,6 +20,7 @@
         "cap": "52"
       },
       "principal": true,
+      "taxonomy_topics": [2],
       "work_in_progress": false
     }
   },

--- a/indigo_app/admin.py
+++ b/indigo_app/admin.py
@@ -28,8 +28,7 @@ class PublicationInline(admin.TabularInline):
 
 
 # Define a new User admin
-class UserAdmin(UserAdmin):
-    inlines = (EditorInline, )
+UserAdmin.inlines = UserAdmin.inlines + [EditorInline]
 
 
 @admin.register(Country)

--- a/indigo_content_api/tests/v3/test_taxonomies_api.py
+++ b/indigo_content_api/tests/v3/test_taxonomies_api.py
@@ -10,6 +10,7 @@ class TaxonomyTopicsAPIV3Test(TaxonomiesAPIV2Test):
         # /taxonomies isn't in v3
         self.assertEqual(404, response.status_code)
 
+    def test_taxonomy_topics_list(self):
         response = self.client.get(self.api_path + '/taxonomy-topics.json')
         self.assertEqual(200, response.status_code)
 
@@ -29,3 +30,38 @@ class TaxonomyTopicsAPIV3Test(TaxonomiesAPIV2Test):
                 ],
             },
         ], taxonomy_topics)
+
+    def test_taxonomy_topic_root_detail(self):
+        response = self.client.get(self.api_path + '/taxonomy-topics/lawsafrica-subject-areas.json')
+        self.assertEqual(200, response.status_code)
+
+        topic = response.json()
+        self.assertEqual({
+            "name": "Laws.Africa Subject Areas",
+            "slug": "lawsafrica-subject-areas",
+            "id": 1,
+            "children": [
+                {
+                    "name": "Money and Business",
+                    "slug": "lawsafrica-subject-areas-money-and-business",
+                    "id": 2,
+                    "children": [],
+                },
+            ],
+        }, topic)
+
+    def test_taxonomy_topic_child_detail(self):
+        response = self.client.get(self.api_path + '/taxonomy-topics/lawsafrica-subject-areas-money-and-business.json')
+        self.assertEqual(200, response.status_code)
+
+        topic = response.json()
+        self.assertEqual({
+            "name": "Money and Business",
+            "slug": "lawsafrica-subject-areas-money-and-business",
+            "id": 2,
+            "children": [],
+        }, topic)
+
+    def test_taxonomy_topic_detail_not_public(self):
+        self.assertEqual(404, self.client.get(self.api_path + '/taxonomy-topics/internal-topic.json').status_code)
+        self.assertEqual(404, self.client.get(self.api_path + '/taxonomy-topics/internal-topic-im-private.json').status_code)

--- a/indigo_content_api/tests/v3/test_taxonomies_api.py
+++ b/indigo_content_api/tests/v3/test_taxonomies_api.py
@@ -2,7 +2,8 @@ from indigo_content_api.tests.v2.test_taxonomies_api import TaxonomiesAPIV2Test
 
 
 class TaxonomyTopicsAPIV3Test(TaxonomiesAPIV2Test):
-    fixtures = ['languages_data', 'taxonomies', 'taxonomy_topics', 'user']
+    fixtures = ['languages_data', 'countries', 'user', 'editor', 'taxonomies', 'taxonomy_topics', 'work', 'published', 'colophon',
+                'attachments', 'commencements']
     api_path = '/api/v3'
 
     def test_taxonomies(self):
@@ -62,6 +63,17 @@ class TaxonomyTopicsAPIV3Test(TaxonomiesAPIV2Test):
             "children": [],
         }, topic)
 
+    def test_taxonomy_topic_work_expressions(self):
+        response = self.client.get(self.api_path + '/taxonomy-topics/lawsafrica-subject-areas-money-and-business/work-expressions.json')
+        self.assertEqual(200, response.status_code)
+
+        frbr_uris = [r["frbr_uri"] for r in response.json()['results']]
+        self.assertEqual(["/akn/za/act/2014/10", "/akn/za/act/1880/1"], frbr_uris)
+
     def test_taxonomy_topic_detail_not_public(self):
         self.assertEqual(404, self.client.get(self.api_path + '/taxonomy-topics/internal-topic.json').status_code)
         self.assertEqual(404, self.client.get(self.api_path + '/taxonomy-topics/internal-topic-im-private.json').status_code)
+
+    def test_taxonomy_topic_work_expressions_not_public(self):
+        self.assertEqual(404, self.client.get(self.api_path + '/taxonomy-topics/internal-topic/work-expressions.json').status_code)
+        self.assertEqual(404, self.client.get(self.api_path + '/taxonomy-topics/internal-topic-im-private/work-expressions.json').status_code)

--- a/indigo_content_api/v3/urls.py
+++ b/indigo_content_api/v3/urls.py
@@ -18,4 +18,6 @@ urlpatterns = urlpatterns_base + [
 
     # taxonomy topic work list
     path('taxonomy-topics/<slug:slug>/work-expressions', TaxonomyTopicPublishedDocumentsView.as_view({'get': 'list'}), name='taxonomy_topic-work-expressions'),
+    path('taxonomy-topics/<slug:slug>/work-expressions.<slug:format>', TaxonomyTopicPublishedDocumentsView.as_view({'get': 'list'}),
+         name='taxonomy_topic-work-expressions'),
 ]

--- a/indigo_content_api/v3/urls.py
+++ b/indigo_content_api/v3/urls.py
@@ -3,7 +3,7 @@ from rest_framework.routers import DefaultRouter
 
 from indigo_content_api.v2.urls import urlpatterns_base
 from indigo_content_api.v2.views import CountryViewSet, TaxonomyTopicView
-from indigo_content_api.v3.views import PublishedDocumentDetailViewV3
+from indigo_content_api.v3.views import PublishedDocumentDetailViewV3, TaxonomyTopicPublishedDocumentsView
 
 router = DefaultRouter(trailing_slash=False)
 router.register(r'countries', CountryViewSet, basename='country')
@@ -12,6 +12,10 @@ router.register(r'taxonomy-topics', TaxonomyTopicView, basename='taxonomy_topic'
 
 urlpatterns = urlpatterns_base + [
     path(r'', include(router.urls)),
+
     # eg. /akn/za/act/2007/98
     re_path(r'^(?P<frbr_uri>akn/[a-z]{2}[-/].*)$', PublishedDocumentDetailViewV3.as_view({'get': 'get'}), name='published-document-detail'),
+
+    # taxonomy topic work list
+    path('taxonomy-topics/<slug:slug>/work-expressions', TaxonomyTopicPublishedDocumentsView.as_view({'get': 'list'}), name='taxonomy_topic-work-expressions'),
 ]

--- a/indigo_content_api/v3/views.py
+++ b/indigo_content_api/v3/views.py
@@ -1,6 +1,38 @@
-from indigo_content_api.v2.views import PublishedDocumentDetailView as PublishedDocumentDetailViewV2
+from django.shortcuts import get_object_or_404
+from django.http import Http404
+from rest_framework.mixins import ListModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from indigo_api.models import TaxonomyTopic
+from indigo_content_api.v2.views import PublishedDocumentDetailView as PublishedDocumentDetailViewV2, ContentAPIBase, \
+    PublishedDocumentDetailView
+
 from .serializers import PublishedDocumentSerializerV3
 
 
 class PublishedDocumentDetailViewV3(PublishedDocumentDetailViewV2):
     serializer_class = PublishedDocumentSerializerV3
+
+
+class TaxonomyTopicPublishedDocumentsView(ContentAPIBase, ListModelMixin, GenericViewSet):
+    """ List of work expressions for a taxonomy topic."""
+    serializer_class = PublishedDocumentSerializerV3
+    queryset = PublishedDocumentDetailView.queryset
+    filter_backends = PublishedDocumentDetailViewV3.filter_backends
+    filterset_fields = PublishedDocumentDetailViewV3.filterset_fields
+
+    def list(self, request, *args, **kwargs):
+        self.taxonomy_topic = self.get_taxonomy_topic(kwargs['slug'])
+        return super().list(request, *args, **kwargs)
+
+    def get_taxonomy_topic(self, slug):
+        obj = get_object_or_404(TaxonomyTopic.objects, slug=slug)
+        if not TaxonomyTopic.get_public_root_nodes().filter(pk=obj.get_root().pk).exists():
+            # it's not public
+            raise Http404()
+        return obj
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        queryset = queryset.filter(work__taxonomy_topics__path__startswith=self.taxonomy_topic.path).distinct("pk")
+        return super().filter_queryset(queryset)

--- a/indigo_content_api/v3/views.py
+++ b/indigo_content_api/v3/views.py
@@ -4,8 +4,7 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.viewsets import GenericViewSet
 
 from indigo_api.models import TaxonomyTopic, Work
-from indigo_content_api.v2.views import PublishedDocumentDetailView as PublishedDocumentDetailViewV2, ContentAPIBase, \
-    PublishedDocumentDetailView
+from indigo_content_api.v2.views import PublishedDocumentDetailView as PublishedDocumentDetailViewV2, ContentAPIBase
 
 from .serializers import PublishedDocumentSerializerV3
 
@@ -16,10 +15,11 @@ class PublishedDocumentDetailViewV3(PublishedDocumentDetailViewV2):
 
 class TaxonomyTopicPublishedDocumentsView(ContentAPIBase, ListModelMixin, GenericViewSet):
     """ List of work expressions for a taxonomy topic."""
-    serializer_class = PublishedDocumentSerializerV3
-    queryset = PublishedDocumentDetailView.queryset
     filter_backends = PublishedDocumentDetailViewV3.filter_backends
     filterset_fields = PublishedDocumentDetailViewV3.filterset_fields
+
+    def get_serializer_class(self):
+        return PublishedDocumentDetailViewV3.serializer_class
 
     def list(self, request, *args, **kwargs):
         self.taxonomy_topic = self.get_taxonomy_topic(kwargs['slug'])
@@ -33,7 +33,7 @@ class TaxonomyTopicPublishedDocumentsView(ContentAPIBase, ListModelMixin, Generi
         return obj
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = PublishedDocumentDetailViewV3.queryset
         works = Work.objects.filter(taxonomy_topics__path__startswith=self.taxonomy_topic.path).distinct("pk")
         queryset = queryset.filter(work__in=works)
         return super().filter_queryset(queryset)

--- a/indigo_content_api/v3/views.py
+++ b/indigo_content_api/v3/views.py
@@ -3,7 +3,7 @@ from django.http import Http404
 from rest_framework.mixins import ListModelMixin
 from rest_framework.viewsets import GenericViewSet
 
-from indigo_api.models import TaxonomyTopic
+from indigo_api.models import TaxonomyTopic, Work
 from indigo_content_api.v2.views import PublishedDocumentDetailView as PublishedDocumentDetailViewV2, ContentAPIBase, \
     PublishedDocumentDetailView
 
@@ -34,5 +34,6 @@ class TaxonomyTopicPublishedDocumentsView(ContentAPIBase, ListModelMixin, Generi
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        queryset = queryset.filter(work__taxonomy_topics__path__startswith=self.taxonomy_topic.path).distinct("pk")
+        works = Work.objects.filter(taxonomy_topics__path__startswith=self.taxonomy_topic.path).distinct("pk")
+        queryset = queryset.filter(work__in=works)
         return super().filter_queryset(queryset)


### PR DESCRIPTION
Add a new URL endpoint to be able to list published documents under a particular taxonomy topic, eg:

```
/v3/taxonomy-topics/subject-areas-money/work-expressions
```