### PR TITLE
content api returns empty list when no results, rather than 404

### DIFF
--- a/indigo_api/renderers.py
+++ b/indigo_api/renderers.py
@@ -6,6 +6,7 @@ import logging
 
 from django.core.cache import caches
 from django.conf import settings
+from django.http import Http404
 from rest_framework.renderers import BaseRenderer, StaticHTMLRenderer
 from rest_framework_xml.renderers import XMLRenderer
 
@@ -133,6 +134,9 @@ class PDFRenderer(BaseRenderer):
     def render(self, data, media_type=None, renderer_context=None):
         self.renderer_context = renderer_context
 
+        if not data:
+            raise Http404()
+
         # we don't support rendering more than one PDF
         if not hasattr(data, 'frbr_uri') or isinstance(data, list):
             return ''
@@ -224,6 +228,9 @@ class EPUBRenderer(ExporterMixin, PDFRenderer):
 
         if isinstance(data, list):
             # render many
+            # we can't render an empty list
+            if not data:
+                raise Http404()
             epub = exporter.render_many(data)
         elif not hasattr(view, 'component') or (view.component == 'main' and not view.portion):
             # whole document

--- a/indigo_content_api/tests/v2/test_content_api.py
+++ b/indigo_content_api/tests/v2/test_content_api.py
@@ -203,8 +203,13 @@ class ContentAPIV2TestMixin:
         self.assertEqual(self.client.get(self.api_path + '/akn/za/act/2014/10/fre').status_code, 404)
         self.assertEqual(self.client.get(self.api_path + '/akn/za/act/2014/10/fre.html').status_code, 404)
 
+    def test_published_listing_no_results(self):
+        # valid countries with no results return empty lists, not 404
+        resp = self.client.get(self.api_path + '/akn/za/act/2999/')
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([], resp.json()['results'])
+
     def test_published_listing_missing(self):
-        self.assertEqual(self.client.get(self.api_path + '/akn/za/act/2999/').status_code, 404)
         self.assertEqual(self.client.get(self.api_path + '/akn/zm/').status_code, 404)
         self.assertEqual(self.client.get(self.api_path + '/akn/za-foo/').status_code, 404)
 

--- a/indigo_content_api/v2/views.py
+++ b/indigo_content_api/v2/views.py
@@ -51,7 +51,7 @@ class PlaceAPIBase(ContentAPIBase):
     def check_permissions(self, request):
         # ensure we have a country and locality before checking permissions
         self.determine_place()
-        super(PlaceAPIBase, self).check_permissions(request)
+        super().check_permissions(request)
 
 
 class FrbrUriViewMixin(PlaceAPIBase):
@@ -62,7 +62,7 @@ class FrbrUriViewMixin(PlaceAPIBase):
     def initial(self, request, **kwargs):
         # ensure the URI starts with a slash
         self.kwargs['frbr_uri'] = '/' + self.kwargs['frbr_uri']
-        super(FrbrUriViewMixin, self).initial(request, **kwargs)
+        super().initial(request, **kwargs)
         self.frbr_uri = self.parse_frbr_uri(self.kwargs['frbr_uri'])
 
     def parse_frbr_uri(self, frbr_uri):
@@ -87,7 +87,7 @@ class FrbrUriViewMixin(PlaceAPIBase):
         except (Country.DoesNotExist, Locality.DoesNotExist):
             raise Http404
 
-        super(FrbrUriViewMixin, self).determine_place()
+        super().determine_place()
 
     def get_document(self):
         """ Find and return one document based on the FRBR URI
@@ -223,7 +223,7 @@ class PublishedDocumentDetailView(DocumentViewMixin,
             self.request.accepted_renderer = renderers.JSONRenderer()
             self.request.accepted_media_type = self.request.accepted_renderer.media_type
 
-        response = super(PublishedDocumentDetailView, self).list(request)
+        response = super().list(request)
 
         # add alternate links for json
         if self.request.accepted_renderer.format == 'json':
@@ -256,13 +256,11 @@ class PublishedDocumentDetailView(DocumentViewMixin,
     def filter_queryset(self, queryset):
         """ Filter the queryset, used by list()
         """
-        queryset = super(PublishedDocumentDetailView, self).filter_queryset(queryset)
+        queryset = super().filter_queryset(queryset)
         queryset = queryset\
             .latest_expression()\
             .filter(frbr_uri__istartswith=self.kwargs['frbr_uri'])\
             .filter(language__language__iso_639_2T=self.country.primary_language.code)
-        if queryset.count() == 0:
-            raise Http404
         return queryset
 
     def get_format_suffix(self, **kwargs):
@@ -281,7 +279,7 @@ class PublishedDocumentDetailView(DocumentViewMixin,
             self.request.accepted_renderer = renderers.StaticHTMLRenderer()
             self.request.accepted_media_type = renderers.StaticHTMLRenderer.media_type
 
-        return super(PublishedDocumentDetailView, self).handle_exception(exc)
+        return super().handle_exception(exc)
 
 
 class PublishedDocumentCommencementsView(PublishedDocumentDetailView):


### PR DESCRIPTION
This is important when filtering results in the API, where it doesn't make sense to return a 404.