### PR TITLE
don't mark key-value props as translateable

### DIFF
--- a/indigo_api/models/places.py
+++ b/indigo_api/models/places.py
@@ -231,6 +231,6 @@ class PlaceSettings(models.Model):
 
         # optionally add / overwrite cap
         if self.uses_chapter:
-            props['cap'] = _("Chapter (Cap.)")
+            props['cap'] = "Chapter (Cap.)"
 
         return props


### PR DESCRIPTION
otherwise the content api behaves oddly