### PR TITLE
make it less work to include extra urls in the content api

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -151,7 +151,17 @@ INDIGO = {
     'EXTRA_DOCTYPES': {},
 
     # disable entire site except for superusers and the content API
-    'MAINTENANCE_MODE': bool(os.environ.get("INDIGO_MAINTENANCE_MODE"))
+    'MAINTENANCE_MODE': bool(os.environ.get("INDIGO_MAINTENANCE_MODE")),
+
+    'CONTENT_API': {
+        # URL prefix for where the API is mounted
+        'API_PREFIX': 'api/',
+        # django URL files to include for each API version
+        'URLCONF': {
+            'v2': 'indigo_content_api.v2.urls_api',
+            'v3': 'indigo_content_api.v3.urls_api',
+        }
+    }
 }
 
 # Database

--- a/indigo_content_api/v2/router.py
+++ b/indigo_content_api/v2/router.py
@@ -1,0 +1,24 @@
+from rest_framework.routers import DefaultRouter
+
+from . import views
+
+# declaring the patterns and providing a get_router method rather than just creating a router
+# directly in urls_api.py allows for the patterns to be reused in other routers and
+# adjusted
+
+
+router_patterns = [
+    (r'countries', views.CountryViewSet, 'country'),
+    (r'taxonomy-topics', views.TaxonomyTopicView, 'taxonomy_topic'),
+    (r'(?P<frbr_uri>akn/[a-z]{2}[-/].*)/toc', views.PublishedDocumentTOCView, 'published-document-toc'),
+    (r'(?P<frbr_uri>akn/[a-z]{2}[-/].*)/commencements', views.PublishedDocumentCommencementsView, 'published-document-commencements'),
+    (r'(?P<frbr_uri>akn/[a-z]{2}[-/].*)/timeline', views.PublishedDocumentTimelineView, 'published-document-timeline'),
+    (r'(?P<frbr_uri>akn/[a-z]{2}[-/]\S+?)/media', views.PublishedDocumentMediaView, 'published-document-media'),
+]
+
+
+def get_router():
+    router = DefaultRouter(trailing_slash=False)
+    for prefix, view, basename in router_patterns:
+        router.register(prefix, view, basename=basename)
+    return router

--- a/indigo_content_api/v2/urls.py
+++ b/indigo_content_api/v2/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path
+from django.conf import settings
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
@@ -6,18 +7,18 @@ from drf_spectacular.views import (
 )
 
 urlpatterns = [
-    path('', include('indigo_content_api.v2.urls_api')),
+    path('', include(settings.INDIGO['CONTENT_API']['URLCONF']['v2'])),
     path(
-        "schema",
+        'schema',
         SpectacularAPIView.as_view(
             api_version='v2',
-            urlconf='indigo_content_api.v2.urls_api',
+            urlconf=settings.INDIGO['CONTENT_API']['URLCONF']['v2'],
             custom_settings={
-                "SCHEMA_PATH_PREFIX_INSERT": "api/v2",
+                'SCHEMA_PATH_PREFIX_INSERT': settings.INDIGO['CONTENT_API']['API_PREFIX'] + 'v2',
             }
         ),
-        name="v2_schema",
+        name='v2_schema',
     ),
-    path("schema/swagger-ui", SpectacularSwaggerView.as_view(url_name="indigo_content_api:v2_schema")),
-    path("schema/redoc", SpectacularRedocView.as_view(url_name="indigo_content_api:v2_schema")),
+    path('schema/swagger-ui', SpectacularSwaggerView.as_view(url_name='indigo_content_api:v2_schema')),
+    path('schema/redoc', SpectacularRedocView.as_view(url_name='indigo_content_api:v2_schema')),
 ]

--- a/indigo_content_api/v2/urls_api.py
+++ b/indigo_content_api/v2/urls_api.py
@@ -1,15 +1,7 @@
 from django.urls import include, path, re_path
-from rest_framework.routers import DefaultRouter
 
 from . import views
-
-router = DefaultRouter(trailing_slash=False)
-router.register(r'countries', views.CountryViewSet, basename='country')
-router.register(r'taxonomy-topics', views.TaxonomyTopicView, basename='taxonomy_topic')
-router.register(r'(?P<frbr_uri>akn/[a-z]{2}[-/].*)/toc', views.PublishedDocumentTOCView, basename='published-document-toc'),
-router.register(r'(?P<frbr_uri>akn/[a-z]{2}[-/].*)/commencements', views.PublishedDocumentCommencementsView, basename='published-document-commencements'),
-router.register(r'(?P<frbr_uri>akn/[a-z]{2}[-/].*)/timeline', views.PublishedDocumentTimelineView, basename='published-document-timeline'),
-router.register(r'(?P<frbr_uri>akn/[a-z]{2}[-/]\S+?)/media', views.PublishedDocumentMediaView, basename='published-document-media'),
+from .router import get_router
 
 urlpatterns_base = [
     # Work publication document
@@ -18,8 +10,11 @@ urlpatterns_base = [
     re_path(r'^(?P<frbr_uri>akn/[a-z]{2}[-/]\S+?)/media/(?P<filename>.*)$', views.PublishedDocumentMediaView.as_view({'get': 'get_file'}), name='published-document-file'),
 ]
 
-urlpatterns = urlpatterns_base + [
-    path(r'', include(router.urls)),
+urlpatterns_extra = [
     # eg. /akn/za/act/2007/98
     re_path(r'^(?P<frbr_uri>akn/[a-z]{2}[-/].*)$', views.PublishedDocumentDetailView.as_view({'get': 'get'}), name='published-document-detail'),
+]
+
+urlpatterns = urlpatterns_base + urlpatterns_extra + [
+    path('', include(get_router().urls)),
 ]

--- a/indigo_content_api/v2/urls_api.py
+++ b/indigo_content_api/v2/urls_api.py
@@ -15,6 +15,6 @@ urlpatterns_extra = [
     re_path(r'^(?P<frbr_uri>akn/[a-z]{2}[-/].*)$', views.PublishedDocumentDetailView.as_view({'get': 'get'}), name='published-document-detail'),
 ]
 
-urlpatterns = urlpatterns_base + urlpatterns_extra + [
+urlpatterns = urlpatterns_base + [
     path('', include(get_router().urls)),
-]
+] + urlpatterns_extra

--- a/indigo_content_api/v3/router.py
+++ b/indigo_content_api/v3/router.py
@@ -1,0 +1,21 @@
+from rest_framework.routers import DefaultRouter
+
+from indigo_content_api.v2.router import router_patterns as router_patterns_v2
+from indigo_content_api.v3.views import TaxonomyTopicWorkExpressionsView, WorkExpressionsViewSet, PlaceViewSet, \
+    PlaceWorkExpressionsView
+
+
+router_patterns = router_patterns_v2 + [
+    # places will replace countries in the future
+    (r'places', PlaceViewSet, 'place'),
+    (r'places/(?P<frbr_uri_code>[^/.]+)/work-expressions', PlaceWorkExpressionsView, 'places-work-expressions'),
+    (r'taxonomy-topics/(?P<slug>[^/.]+)/work-expressions', TaxonomyTopicWorkExpressionsView, 'taxonomy_topic-work-expressions'),
+    ('work-expressions', WorkExpressionsViewSet, 'work_expression'),
+]
+
+
+def get_router():
+    router = DefaultRouter(trailing_slash=False)
+    for prefix, view, basename in router_patterns:
+        router.register(prefix, view, basename=basename)
+    return router

--- a/indigo_content_api/v3/urls.py
+++ b/indigo_content_api/v3/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path
+from django.conf import settings
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
@@ -6,18 +7,18 @@ from drf_spectacular.views import (
 )
 
 urlpatterns = [
-    path('', include('indigo_content_api.v3.urls_api')),
+    path('', include(settings.INDIGO['CONTENT_API']['URLCONF']['v3'])),
     path(
-        "schema",
+        'schema',
         SpectacularAPIView.as_view(
             api_version='v3',
-            urlconf='indigo_content_api.v3.urls_api',
+            urlconf=settings.INDIGO['CONTENT_API']['URLCONF']['v3'],
             custom_settings={
-                "SCHEMA_PATH_PREFIX_INSERT": "api/v3",
+                'SCHEMA_PATH_PREFIX_INSERT': settings.INDIGO['CONTENT_API']['API_PREFIX'] + 'v3',
             }
         ),
-        name="v3_schema",
+        name='v3_schema',
     ),
-    path("schema/swagger-ui", SpectacularSwaggerView.as_view(url_name="indigo_content_api:v3_schema")),
-    path("schema/redoc", SpectacularRedocView.as_view(url_name="indigo_content_api:v3_schema")),
+    path('schema/swagger-ui', SpectacularSwaggerView.as_view(url_name='indigo_content_api:v3_schema')),
+    path('schema/redoc', SpectacularRedocView.as_view(url_name='indigo_content_api:v3_schema')),
 ]

--- a/indigo_content_api/v3/urls_api.py
+++ b/indigo_content_api/v3/urls_api.py
@@ -9,6 +9,6 @@ urlpatterns_extra = [
     re_path(r'^(?P<frbr_uri>akn/[a-z]{2}[-/].*)$', PublishedDocumentDetailViewV3.as_view({'get': 'get'}), name='published-document-detail'),
 ]
 
-urlpatterns = urlpatterns_base + urlpatterns_extra + [
+urlpatterns = urlpatterns_base + [
     path('', include(get_router().urls)),
-]
+] + urlpatterns_extra

--- a/indigo_content_api/v3/urls_api.py
+++ b/indigo_content_api/v3/urls_api.py
@@ -1,17 +1,14 @@
 from django.urls import include, path, re_path
 
-from indigo_content_api.v2.urls_api import urlpatterns_base, router
-from indigo_content_api.v3.views import PublishedDocumentDetailViewV3, TaxonomyTopicWorkExpressionsView, \
-    WorkExpressionsViewSet, PlaceViewSet, PlaceWorkExpressionsView
+from indigo_content_api.v2.urls_api import urlpatterns_base
+from .router import get_router
+from .views import PublishedDocumentDetailViewV3
 
-# places will replace countries in the future
-router.register(r'places', PlaceViewSet, basename='place')
-router.register(r'places/(?P<frbr_uri_code>[^/.]+)/work-expressions', PlaceWorkExpressionsView, basename='places-work-expressions')
-router.register(r'taxonomy-topics/(?P<slug>[^/.]+)/work-expressions', TaxonomyTopicWorkExpressionsView, basename='taxonomy_topic-work-expressions')
-router.register('work-expressions', WorkExpressionsViewSet, basename='work_expression')
-
-urlpatterns = urlpatterns_base + [
-    path('', include(router.urls)),
+urlpatterns_extra = [
     # eg. /akn/za/act/2007/98
     re_path(r'^(?P<frbr_uri>akn/[a-z]{2}[-/].*)$', PublishedDocumentDetailViewV3.as_view({'get': 'get'}), name='published-document-detail'),
+]
+
+urlpatterns = urlpatterns_base + urlpatterns_extra + [
+    path('', include(get_router().urls)),
 ]


### PR DESCRIPTION
Previously it has been difficult to add new routes into the content API. This change makes it much simpler:

1. the content api patterns can be adjusted by other apps during `app_ready` by adjusting the content of the `router.router_patterns` variable
2. other apps don't need to re-implement the root content API views, and the new schema views, at all now
3. other apps have a mechanism to specify to the schema where the API lives and what URL patterns to use, if they need it, through `settings.py`