### PR TITLE
update crowdin to use github action

### DIFF
--- a/.github/workflows/fetch-l10n.yml
+++ b/.github/workflows/fetch-l10n.yml
@@ -1,0 +1,25 @@
+name: Fetch localisations
+
+on: workflow_dispatch
+
+jobs:
+  crowdin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Synchronize with Crowdin
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'New Crowdin pull request with translations'
+          pull_request_base_branch_name: 'main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,8 @@
+project_id: "2"
+api_token_env: "CROWDIN_API_TOKEN"
+preserve_hierarchy: true
+localization_branch_name: "l10n_master"
+
 files:
   - source: /indigo/locale/en/LC_MESSAGES/django.po
     translation: /indigo/locale/%two_letters_code%/LC_MESSAGES/%original_file_name%


### PR DESCRIPTION
this is apparently more flexible than the github oath, and requires less broad permissions; oath doesn't work on private repos, either.