### PR TITLE
tests and fixes for newlines in provision citation extraction

### DIFF
--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -130,4 +130,4 @@ grammar ProvisionRefs
   comma       <- [,;]
   digit       <- [0-9]
   alpha_num_dot <- [a-zA-Z0-9.-]
-  WS          <- " " / "\t"
+  WS          <- " " / "\t" / "\n"

--- a/indigo/analysis/refs/provision_refs.py
+++ b/indigo/analysis/refs/provision_refs.py
@@ -2632,6 +2632,21 @@ class Grammar(object):
                     self._expected.append(('ProvisionRefs::WS', '"\\t"'))
             if address0 is FAILURE:
                 self._offset = index1
+                chunk2, max2 = None, self._offset + 1
+                if max2 <= self._input_size:
+                    chunk2 = self._input[self._offset:max2]
+                if chunk2 == '\n':
+                    address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
+                    self._offset = self._offset + 1
+                else:
+                    address0 = FAILURE
+                    if self._offset > self._failure:
+                        self._failure = self._offset
+                        self._expected = []
+                    if self._offset == self._failure:
+                        self._expected.append(('ProvisionRefs::WS', '"\\n"'))
+                if address0 is FAILURE:
+                    self._offset = index1
         self._cache['WS'][index0] = (address0, self._offset)
         return address0
 


### PR DESCRIPTION
fixes https://github.com/laws-africa/indigo/issues/2101

these are common when extracting citations from PDF text.