### PR TITLE
keep <tocItem>s with next if they have children

### DIFF
--- a/indigo_api/static/xsl/fo/_toc.xsl
+++ b/indigo_api/static/xsl/fo/_toc.xsl
@@ -23,6 +23,9 @@
 
   <xsl:template match="akn:tocItem">
     <fo:block margin-top="{$para-spacing}" text-align-last="justify">
+      <xsl:if test="@class='keep-with-next'">
+        <xsl:attribute name="keep-with-next">always</xsl:attribute>
+      </xsl:if>
       <fo:inline>
         <fo:basic-link internal-destination="{@id}">
           <xsl:apply-templates/>

--- a/indigo_api/templates/indigo_api/akn/export/_pdf_toc_entry.xml
+++ b/indigo_api/templates/indigo_api/akn/export/_pdf_toc_entry.xml
@@ -1,6 +1,6 @@
 {% for entry in toc %}
   <div name="toc-level">
-    <tocItem id="{{ entry.id }}">{{ entry.title }}</tocItem>
+    <tocItem id="{{ entry.id }}" {% if entry.children %}class="keep-with-next"{% endif %}>{{ entry.title }}</tocItem>
     {% if entry.children %}
       {% include "indigo_api/akn/export/_pdf_toc_entry.xml" with toc=entry.children %}
     {% endif %}

--- a/indigo_api/templates/indigo_api/akn/export/pdf_frontmatter_akn.xml
+++ b/indigo_api/templates/indigo_api/akn/export/pdf_frontmatter_akn.xml
@@ -79,7 +79,7 @@
       <toc>
         {% for entry in toc %}
           <div name="toc-level">
-            <tocItem id="{{ entry.id }}">{{ entry.title }}</tocItem>
+            <tocItem id="{{ entry.id }}" {% if entry.children %}class="keep-with-next"{% endif %}>{{ entry.title }}</tocItem>
             {% if entry.children %}
               {% include "indigo_api/akn/export/_pdf_toc_entry.xml" with toc=entry.children %}
             {% endif %}


### PR DESCRIPTION
Before
<img width="823" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/a3baf101-e9c1-4abe-9558-2d77a636f553">


After (the Part heading goes to the next page) 
<img width="808" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/f187655b-a4e6-42b7-9ca5-c2d7804d2c1c">


With borders for clarity on where `class="keep with next"` has been set
<img width="827" alt="image" src="https://github.com/laws-africa/indigo/assets/32566441/f4f48d0e-c3cc-4459-8ebf-9e99fc334316">
