### PR TITLE
Provision references citator handles French

### DIFF
--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -11,9 +11,7 @@ grammar ProvisionRefs
                  # section (a)
                  # section 32(a)(c)
                  # section 32.1a.2
-  references  <- unit WS+ main_ref (to_and_or main_ref)* %references
-
-  unit        <- unit_eng / unit_afr
+  references  <- unit__i18n WS+ main_ref (to_and_or main_ref)* %references
 
   main_ref    <- (main_num / num) (WS* sub_refs)? %main_ref
 
@@ -43,26 +41,28 @@ grammar ProvisionRefs
                  # (a), to (b)
   range       <- (WS* comma)? to %range
 
+  to          <- WS* dash WS* / WS+ to__i18n WS+
+
                  # (a) and (b)
                  # (a), or (b)
                  # (a), (b)
-  and_or      <- ((WS* comma)? WS* _and WS+) %and_or
-                 / ((WS* comma)? WS* _or WS+) %and_or
+  and_or      <- ((WS* comma)? WS* and__i18n WS+) %and_or
+                 / ((WS* comma)? WS* or__i18n WS+) %and_or
                  / (WS* comma WS*) %and_or
 
   target      <- of_this / of_the_act / thereof / of
 
                  # of this...
-  of_this     <- comma? WS* (of_this_eng / of_this_afr) WS+ %of_this
+  of_this     <- comma? WS* (of_this__i18n) WS+ %of_this
 
                  # of the Act
-  of_the_act  <- comma? WS* (of_the_act_eng) %of_the_act
+  of_the_act  <- comma? WS* (of_the_act__i18n) %of_the_act
 
                  # of...
-  of          <- comma? WS* (of_eng / of_afr) WS+ %of
+  of          <- comma? WS* (of__i18n) WS+ %of
 
                  # thereof
-  thereof     <- comma? WS* (thereof_eng / thereof_afr) %thereof
+  thereof     <- comma? WS* (thereof__i18n) %thereof
 
                  # this is simply all text after the reference, which could be none. This is required because
                  # the grammar expects to match the entire input, but we don't care about anything beyond the end
@@ -71,7 +71,22 @@ grammar ProvisionRefs
   tail        <- .*
 
   # --------
-  # terminals
+  # language-switching terminals
+  #
+  # the xxx__i18n rules will be patched in python to use the rule for the current language
+  # --------
+
+  and__i18n         <- ""
+  of__i18n          <- ""
+  of_the_act__i18n  <- ""
+  of_this__i18n     <- ""
+  or__i18n          <- ""
+  thereof__i18n     <- ""
+  to__i18n          <- ""
+  unit__i18n        <- ""
+
+  # --------
+  # translated terminals
   # --------
 
                  # english
@@ -100,19 +115,12 @@ grammar ProvisionRefs
                  `subafdelings` / `subafdeling` /
                  `subparagrawe` / `subparagraaf`
 
-  _and        <- and_eng / and_afr
   and_eng      <- `and`
   and_afr      <- `en`
 
-  _or         <- or_eng / or_afr
   or_eng       <- `or`
-  # HACK: Afrikaans 'of' for 'or' not supported because it clashes with English 'of'
-  or_afr       <- or_eng # `of`
+  or_afr       <- `of`
 
-                 # note that "tot" must come before "to" because the latter is a substring of the former
-                 # whitespace is required around 'to' word, optional around dashes
-  to          <- WS* dash WS* / WS+ to_afr WS+ / WS+ to_eng WS+
-  dash        <- `-` / `–` / `—`
   to_eng       <- `to`
   to_afr       <- `tot`
 
@@ -123,10 +131,16 @@ grammar ProvisionRefs
   of_this_afr  <- `van hierdie`
 
   of_the_act_eng <- `of the Act` / `of the act`
+  of_the_act_afr <- `van die Wet` / `van die wet`
 
   thereof_eng  <- `thereof`
   thereof_afr  <- `daarvan`
 
+  # --------
+  # terminals
+  # --------
+
+  dash        <- `-` / `–` / `—`
   comma       <- [,;]
   digit       <- [0-9]
   alpha_num_dot <- [a-zA-Z0-9.-]

--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -13,7 +13,7 @@ grammar ProvisionRefs
                  # section 32.1a.2
   references  <- unit WS+ main_ref (to_and_or main_ref)* %references
 
-  unit        <- unit_en / unit_af
+  unit        <- unit_eng / unit_afr
 
   main_ref    <- (main_num / num) (WS* sub_refs)? %main_ref
 
@@ -53,16 +53,16 @@ grammar ProvisionRefs
   target      <- of_this / of_the_act / thereof / of
 
                  # of this...
-  of_this     <- comma? WS* (of_this_en / of_this_af) WS+ %of_this
+  of_this     <- comma? WS* (of_this_eng / of_this_afr) WS+ %of_this
 
                  # of the Act
-  of_the_act  <- comma? WS* (of_the_act_en) %of_the_act
+  of_the_act  <- comma? WS* (of_the_act_eng) %of_the_act
 
                  # of...
-  of          <- comma? WS* (of_en / of_af) WS+ %of
+  of          <- comma? WS* (of_eng / of_afr) WS+ %of
 
                  # thereof
-  thereof     <- comma? WS* (thereof_en / thereof_af) %thereof
+  thereof     <- comma? WS* (thereof_eng / thereof_afr) %thereof
 
                  # this is simply all text after the reference, which could be none. This is required because
                  # the grammar expects to match the entire input, but we don't care about anything beyond the end
@@ -75,7 +75,7 @@ grammar ProvisionRefs
   # --------
 
                  # english
-  unit_en     <- `articles` / `article` /
+  unit_eng     <- `articles` / `article` /
                  `chapters` / `chapter` /
                  `items` / `item` /
                  `paragraphs` / `paragraph` /
@@ -91,7 +91,7 @@ grammar ProvisionRefs
                  `sub-sections` / `sub-section`
 
                  # afrikaans
-  unit_af     <- `afdelings` / `afdeling` /
+  unit_afr     <- `afdelings` / `afdeling` /
                  `artikels` / `artikel`
                  `dele` / `deel`
                  `hoofstukke` / `hoofstuk` /
@@ -100,32 +100,32 @@ grammar ProvisionRefs
                  `subafdelings` / `subafdeling` /
                  `subparagrawe` / `subparagraaf`
 
-  _and        <- and_en / and_af
-  and_en      <- `and`
-  and_af      <- `en`
+  _and        <- and_eng / and_afr
+  and_eng      <- `and`
+  and_afr      <- `en`
 
-  _or         <- or_en / or_af
-  or_en       <- `or`
+  _or         <- or_eng / or_afr
+  or_eng       <- `or`
   # HACK: Afrikaans 'of' for 'or' not supported because it clashes with English 'of'
-  or_af       <- or_en # `of`
+  or_afr       <- or_eng # `of`
 
                  # note that "tot" must come before "to" because the latter is a substring of the former
                  # whitespace is required around 'to' word, optional around dashes
-  to          <- WS* dash WS* / WS+ to_af WS+ / WS+ to_en WS+
+  to          <- WS* dash WS* / WS+ to_afr WS+ / WS+ to_eng WS+
   dash        <- `-` / `–` / `—`
-  to_en       <- `to`
-  to_af       <- `tot`
+  to_eng       <- `to`
+  to_afr       <- `tot`
 
-  of_en       <- `of`
-  of_af       <- `van`
+  of_eng       <- `of`
+  of_afr       <- `van`
 
-  of_this_en  <- `of this`
-  of_this_af  <- `van hierdie`
+  of_this_eng  <- `of this`
+  of_this_afr  <- `van hierdie`
 
-  of_the_act_en <- `of the Act` / `of the act`
+  of_the_act_eng <- `of the Act` / `of the act`
 
-  thereof_en  <- `thereof`
-  thereof_af  <- `daarvan`
+  thereof_eng  <- `thereof`
+  thereof_afr  <- `daarvan`
 
   comma       <- [,;]
   digit       <- [0-9]

--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -115,26 +115,47 @@ grammar ProvisionRefs
                  `subafdelings` / `subafdeling` /
                  `subparagrawe` / `subparagraaf`
 
+                 # french
+  unit_fra     <- `articles` / `article` /
+                  `chapitres` / `chapitre` /
+                  `paragraphes` / `paragraphe` /
+                  `parties` / `partie` /
+                  `points` / `point` /
+                  `règlements` / `règlement` /
+                  `reglements` / `reglement` /
+                  `sections` / `section` /
+                  `sous-paragraphes` / `sous-paragraphe` /
+                  `sous-règlements` / `sous-règlement` /
+                  `sous-reglements` / `sous-reglement` /
+                  `sous-sections` / `sous-section`
+
   and_eng      <- `and`
   and_afr      <- `en`
+  and_fra      <- `et`
 
   or_eng       <- `or`
   or_afr       <- `of`
+  or_fra       <- `ou`
 
   to_eng       <- `to`
   to_afr       <- `tot`
+  to_fra       <- `à` / `a`
 
   of_eng       <- `of`
   of_afr       <- `van`
+  of_fra       <- `de`
 
   of_this_eng  <- `of this`
   of_this_afr  <- `van hierdie`
+  of_this_fra  <- `de cette` / `de ce`
 
   of_the_act_eng <- `of the Act` / `of the act`
   of_the_act_afr <- `van die Wet` / `van die wet`
+  of_the_act_fra <- `de la loi` / `de la Loi`
 
   thereof_eng  <- `thereof`
   thereof_afr  <- `daarvan`
+  thereof_fra  <- `de cela`
 
   # --------
   # terminals

--- a/indigo/analysis/refs/provision_refs.py
+++ b/indigo/analysis/refs/provision_refs.py
@@ -2253,6 +2253,376 @@ class Grammar(object):
         self._cache['unit_afr'][index0] = (address0, self._offset)
         return address0
 
+    def _read_unit_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['unit_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 8
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'articles'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 8], self._offset, [])
+            self._offset = self._offset + 8
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::unit_fra', '`articles`'))
+        if address0 is FAILURE:
+            self._offset = index1
+            chunk1, max1 = None, self._offset + 7
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'article'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
+                self._offset = self._offset + 7
+            else:
+                address0 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::unit_fra', '`article`'))
+            if address0 is FAILURE:
+                self._offset = index1
+                chunk2, max2 = None, self._offset + 9
+                if max2 <= self._input_size:
+                    chunk2 = self._input[self._offset:max2]
+                if chunk2 is not None and chunk2.lower() == 'chapitres'.lower():
+                    address0 = TreeNode(self._input[self._offset:self._offset + 9], self._offset, [])
+                    self._offset = self._offset + 9
+                else:
+                    address0 = FAILURE
+                    if self._offset > self._failure:
+                        self._failure = self._offset
+                        self._expected = []
+                    if self._offset == self._failure:
+                        self._expected.append(('ProvisionRefs::unit_fra', '`chapitres`'))
+                if address0 is FAILURE:
+                    self._offset = index1
+                    chunk3, max3 = None, self._offset + 8
+                    if max3 <= self._input_size:
+                        chunk3 = self._input[self._offset:max3]
+                    if chunk3 is not None and chunk3.lower() == 'chapitre'.lower():
+                        address0 = TreeNode(self._input[self._offset:self._offset + 8], self._offset, [])
+                        self._offset = self._offset + 8
+                    else:
+                        address0 = FAILURE
+                        if self._offset > self._failure:
+                            self._failure = self._offset
+                            self._expected = []
+                        if self._offset == self._failure:
+                            self._expected.append(('ProvisionRefs::unit_fra', '`chapitre`'))
+                    if address0 is FAILURE:
+                        self._offset = index1
+                        chunk4, max4 = None, self._offset + 11
+                        if max4 <= self._input_size:
+                            chunk4 = self._input[self._offset:max4]
+                        if chunk4 is not None and chunk4.lower() == 'paragraphes'.lower():
+                            address0 = TreeNode(self._input[self._offset:self._offset + 11], self._offset, [])
+                            self._offset = self._offset + 11
+                        else:
+                            address0 = FAILURE
+                            if self._offset > self._failure:
+                                self._failure = self._offset
+                                self._expected = []
+                            if self._offset == self._failure:
+                                self._expected.append(('ProvisionRefs::unit_fra', '`paragraphes`'))
+                        if address0 is FAILURE:
+                            self._offset = index1
+                            chunk5, max5 = None, self._offset + 10
+                            if max5 <= self._input_size:
+                                chunk5 = self._input[self._offset:max5]
+                            if chunk5 is not None and chunk5.lower() == 'paragraphe'.lower():
+                                address0 = TreeNode(self._input[self._offset:self._offset + 10], self._offset, [])
+                                self._offset = self._offset + 10
+                            else:
+                                address0 = FAILURE
+                                if self._offset > self._failure:
+                                    self._failure = self._offset
+                                    self._expected = []
+                                if self._offset == self._failure:
+                                    self._expected.append(('ProvisionRefs::unit_fra', '`paragraphe`'))
+                            if address0 is FAILURE:
+                                self._offset = index1
+                                chunk6, max6 = None, self._offset + 7
+                                if max6 <= self._input_size:
+                                    chunk6 = self._input[self._offset:max6]
+                                if chunk6 is not None and chunk6.lower() == 'parties'.lower():
+                                    address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
+                                    self._offset = self._offset + 7
+                                else:
+                                    address0 = FAILURE
+                                    if self._offset > self._failure:
+                                        self._failure = self._offset
+                                        self._expected = []
+                                    if self._offset == self._failure:
+                                        self._expected.append(('ProvisionRefs::unit_fra', '`parties`'))
+                                if address0 is FAILURE:
+                                    self._offset = index1
+                                    chunk7, max7 = None, self._offset + 6
+                                    if max7 <= self._input_size:
+                                        chunk7 = self._input[self._offset:max7]
+                                    if chunk7 is not None and chunk7.lower() == 'partie'.lower():
+                                        address0 = TreeNode(self._input[self._offset:self._offset + 6], self._offset, [])
+                                        self._offset = self._offset + 6
+                                    else:
+                                        address0 = FAILURE
+                                        if self._offset > self._failure:
+                                            self._failure = self._offset
+                                            self._expected = []
+                                        if self._offset == self._failure:
+                                            self._expected.append(('ProvisionRefs::unit_fra', '`partie`'))
+                                    if address0 is FAILURE:
+                                        self._offset = index1
+                                        chunk8, max8 = None, self._offset + 6
+                                        if max8 <= self._input_size:
+                                            chunk8 = self._input[self._offset:max8]
+                                        if chunk8 is not None and chunk8.lower() == 'points'.lower():
+                                            address0 = TreeNode(self._input[self._offset:self._offset + 6], self._offset, [])
+                                            self._offset = self._offset + 6
+                                        else:
+                                            address0 = FAILURE
+                                            if self._offset > self._failure:
+                                                self._failure = self._offset
+                                                self._expected = []
+                                            if self._offset == self._failure:
+                                                self._expected.append(('ProvisionRefs::unit_fra', '`points`'))
+                                        if address0 is FAILURE:
+                                            self._offset = index1
+                                            chunk9, max9 = None, self._offset + 5
+                                            if max9 <= self._input_size:
+                                                chunk9 = self._input[self._offset:max9]
+                                            if chunk9 is not None and chunk9.lower() == 'point'.lower():
+                                                address0 = TreeNode(self._input[self._offset:self._offset + 5], self._offset, [])
+                                                self._offset = self._offset + 5
+                                            else:
+                                                address0 = FAILURE
+                                                if self._offset > self._failure:
+                                                    self._failure = self._offset
+                                                    self._expected = []
+                                                if self._offset == self._failure:
+                                                    self._expected.append(('ProvisionRefs::unit_fra', '`point`'))
+                                            if address0 is FAILURE:
+                                                self._offset = index1
+                                                chunk10, max10 = None, self._offset + 10
+                                                if max10 <= self._input_size:
+                                                    chunk10 = self._input[self._offset:max10]
+                                                if chunk10 is not None and chunk10.lower() == 'règlements'.lower():
+                                                    address0 = TreeNode(self._input[self._offset:self._offset + 10], self._offset, [])
+                                                    self._offset = self._offset + 10
+                                                else:
+                                                    address0 = FAILURE
+                                                    if self._offset > self._failure:
+                                                        self._failure = self._offset
+                                                        self._expected = []
+                                                    if self._offset == self._failure:
+                                                        self._expected.append(('ProvisionRefs::unit_fra', '`règlements`'))
+                                                if address0 is FAILURE:
+                                                    self._offset = index1
+                                                    chunk11, max11 = None, self._offset + 9
+                                                    if max11 <= self._input_size:
+                                                        chunk11 = self._input[self._offset:max11]
+                                                    if chunk11 is not None and chunk11.lower() == 'règlement'.lower():
+                                                        address0 = TreeNode(self._input[self._offset:self._offset + 9], self._offset, [])
+                                                        self._offset = self._offset + 9
+                                                    else:
+                                                        address0 = FAILURE
+                                                        if self._offset > self._failure:
+                                                            self._failure = self._offset
+                                                            self._expected = []
+                                                        if self._offset == self._failure:
+                                                            self._expected.append(('ProvisionRefs::unit_fra', '`règlement`'))
+                                                    if address0 is FAILURE:
+                                                        self._offset = index1
+                                                        chunk12, max12 = None, self._offset + 10
+                                                        if max12 <= self._input_size:
+                                                            chunk12 = self._input[self._offset:max12]
+                                                        if chunk12 is not None and chunk12.lower() == 'reglements'.lower():
+                                                            address0 = TreeNode(self._input[self._offset:self._offset + 10], self._offset, [])
+                                                            self._offset = self._offset + 10
+                                                        else:
+                                                            address0 = FAILURE
+                                                            if self._offset > self._failure:
+                                                                self._failure = self._offset
+                                                                self._expected = []
+                                                            if self._offset == self._failure:
+                                                                self._expected.append(('ProvisionRefs::unit_fra', '`reglements`'))
+                                                        if address0 is FAILURE:
+                                                            self._offset = index1
+                                                            chunk13, max13 = None, self._offset + 9
+                                                            if max13 <= self._input_size:
+                                                                chunk13 = self._input[self._offset:max13]
+                                                            if chunk13 is not None and chunk13.lower() == 'reglement'.lower():
+                                                                address0 = TreeNode(self._input[self._offset:self._offset + 9], self._offset, [])
+                                                                self._offset = self._offset + 9
+                                                            else:
+                                                                address0 = FAILURE
+                                                                if self._offset > self._failure:
+                                                                    self._failure = self._offset
+                                                                    self._expected = []
+                                                                if self._offset == self._failure:
+                                                                    self._expected.append(('ProvisionRefs::unit_fra', '`reglement`'))
+                                                            if address0 is FAILURE:
+                                                                self._offset = index1
+                                                                chunk14, max14 = None, self._offset + 8
+                                                                if max14 <= self._input_size:
+                                                                    chunk14 = self._input[self._offset:max14]
+                                                                if chunk14 is not None and chunk14.lower() == 'sections'.lower():
+                                                                    address0 = TreeNode(self._input[self._offset:self._offset + 8], self._offset, [])
+                                                                    self._offset = self._offset + 8
+                                                                else:
+                                                                    address0 = FAILURE
+                                                                    if self._offset > self._failure:
+                                                                        self._failure = self._offset
+                                                                        self._expected = []
+                                                                    if self._offset == self._failure:
+                                                                        self._expected.append(('ProvisionRefs::unit_fra', '`sections`'))
+                                                                if address0 is FAILURE:
+                                                                    self._offset = index1
+                                                                    chunk15, max15 = None, self._offset + 7
+                                                                    if max15 <= self._input_size:
+                                                                        chunk15 = self._input[self._offset:max15]
+                                                                    if chunk15 is not None and chunk15.lower() == 'section'.lower():
+                                                                        address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
+                                                                        self._offset = self._offset + 7
+                                                                    else:
+                                                                        address0 = FAILURE
+                                                                        if self._offset > self._failure:
+                                                                            self._failure = self._offset
+                                                                            self._expected = []
+                                                                        if self._offset == self._failure:
+                                                                            self._expected.append(('ProvisionRefs::unit_fra', '`section`'))
+                                                                    if address0 is FAILURE:
+                                                                        self._offset = index1
+                                                                        chunk16, max16 = None, self._offset + 16
+                                                                        if max16 <= self._input_size:
+                                                                            chunk16 = self._input[self._offset:max16]
+                                                                        if chunk16 is not None and chunk16.lower() == 'sous-paragraphes'.lower():
+                                                                            address0 = TreeNode(self._input[self._offset:self._offset + 16], self._offset, [])
+                                                                            self._offset = self._offset + 16
+                                                                        else:
+                                                                            address0 = FAILURE
+                                                                            if self._offset > self._failure:
+                                                                                self._failure = self._offset
+                                                                                self._expected = []
+                                                                            if self._offset == self._failure:
+                                                                                self._expected.append(('ProvisionRefs::unit_fra', '`sous-paragraphes`'))
+                                                                        if address0 is FAILURE:
+                                                                            self._offset = index1
+                                                                            chunk17, max17 = None, self._offset + 15
+                                                                            if max17 <= self._input_size:
+                                                                                chunk17 = self._input[self._offset:max17]
+                                                                            if chunk17 is not None and chunk17.lower() == 'sous-paragraphe'.lower():
+                                                                                address0 = TreeNode(self._input[self._offset:self._offset + 15], self._offset, [])
+                                                                                self._offset = self._offset + 15
+                                                                            else:
+                                                                                address0 = FAILURE
+                                                                                if self._offset > self._failure:
+                                                                                    self._failure = self._offset
+                                                                                    self._expected = []
+                                                                                if self._offset == self._failure:
+                                                                                    self._expected.append(('ProvisionRefs::unit_fra', '`sous-paragraphe`'))
+                                                                            if address0 is FAILURE:
+                                                                                self._offset = index1
+                                                                                chunk18, max18 = None, self._offset + 15
+                                                                                if max18 <= self._input_size:
+                                                                                    chunk18 = self._input[self._offset:max18]
+                                                                                if chunk18 is not None and chunk18.lower() == 'sous-règlements'.lower():
+                                                                                    address0 = TreeNode(self._input[self._offset:self._offset + 15], self._offset, [])
+                                                                                    self._offset = self._offset + 15
+                                                                                else:
+                                                                                    address0 = FAILURE
+                                                                                    if self._offset > self._failure:
+                                                                                        self._failure = self._offset
+                                                                                        self._expected = []
+                                                                                    if self._offset == self._failure:
+                                                                                        self._expected.append(('ProvisionRefs::unit_fra', '`sous-règlements`'))
+                                                                                if address0 is FAILURE:
+                                                                                    self._offset = index1
+                                                                                    chunk19, max19 = None, self._offset + 14
+                                                                                    if max19 <= self._input_size:
+                                                                                        chunk19 = self._input[self._offset:max19]
+                                                                                    if chunk19 is not None and chunk19.lower() == 'sous-règlement'.lower():
+                                                                                        address0 = TreeNode(self._input[self._offset:self._offset + 14], self._offset, [])
+                                                                                        self._offset = self._offset + 14
+                                                                                    else:
+                                                                                        address0 = FAILURE
+                                                                                        if self._offset > self._failure:
+                                                                                            self._failure = self._offset
+                                                                                            self._expected = []
+                                                                                        if self._offset == self._failure:
+                                                                                            self._expected.append(('ProvisionRefs::unit_fra', '`sous-règlement`'))
+                                                                                    if address0 is FAILURE:
+                                                                                        self._offset = index1
+                                                                                        chunk20, max20 = None, self._offset + 15
+                                                                                        if max20 <= self._input_size:
+                                                                                            chunk20 = self._input[self._offset:max20]
+                                                                                        if chunk20 is not None and chunk20.lower() == 'sous-reglements'.lower():
+                                                                                            address0 = TreeNode(self._input[self._offset:self._offset + 15], self._offset, [])
+                                                                                            self._offset = self._offset + 15
+                                                                                        else:
+                                                                                            address0 = FAILURE
+                                                                                            if self._offset > self._failure:
+                                                                                                self._failure = self._offset
+                                                                                                self._expected = []
+                                                                                            if self._offset == self._failure:
+                                                                                                self._expected.append(('ProvisionRefs::unit_fra', '`sous-reglements`'))
+                                                                                        if address0 is FAILURE:
+                                                                                            self._offset = index1
+                                                                                            chunk21, max21 = None, self._offset + 14
+                                                                                            if max21 <= self._input_size:
+                                                                                                chunk21 = self._input[self._offset:max21]
+                                                                                            if chunk21 is not None and chunk21.lower() == 'sous-reglement'.lower():
+                                                                                                address0 = TreeNode(self._input[self._offset:self._offset + 14], self._offset, [])
+                                                                                                self._offset = self._offset + 14
+                                                                                            else:
+                                                                                                address0 = FAILURE
+                                                                                                if self._offset > self._failure:
+                                                                                                    self._failure = self._offset
+                                                                                                    self._expected = []
+                                                                                                if self._offset == self._failure:
+                                                                                                    self._expected.append(('ProvisionRefs::unit_fra', '`sous-reglement`'))
+                                                                                            if address0 is FAILURE:
+                                                                                                self._offset = index1
+                                                                                                chunk22, max22 = None, self._offset + 13
+                                                                                                if max22 <= self._input_size:
+                                                                                                    chunk22 = self._input[self._offset:max22]
+                                                                                                if chunk22 is not None and chunk22.lower() == 'sous-sections'.lower():
+                                                                                                    address0 = TreeNode(self._input[self._offset:self._offset + 13], self._offset, [])
+                                                                                                    self._offset = self._offset + 13
+                                                                                                else:
+                                                                                                    address0 = FAILURE
+                                                                                                    if self._offset > self._failure:
+                                                                                                        self._failure = self._offset
+                                                                                                        self._expected = []
+                                                                                                    if self._offset == self._failure:
+                                                                                                        self._expected.append(('ProvisionRefs::unit_fra', '`sous-sections`'))
+                                                                                                if address0 is FAILURE:
+                                                                                                    self._offset = index1
+                                                                                                    chunk23, max23 = None, self._offset + 12
+                                                                                                    if max23 <= self._input_size:
+                                                                                                        chunk23 = self._input[self._offset:max23]
+                                                                                                    if chunk23 is not None and chunk23.lower() == 'sous-section'.lower():
+                                                                                                        address0 = TreeNode(self._input[self._offset:self._offset + 12], self._offset, [])
+                                                                                                        self._offset = self._offset + 12
+                                                                                                    else:
+                                                                                                        address0 = FAILURE
+                                                                                                        if self._offset > self._failure:
+                                                                                                            self._failure = self._offset
+                                                                                                            self._expected = []
+                                                                                                        if self._offset == self._failure:
+                                                                                                            self._expected.append(('ProvisionRefs::unit_fra', '`sous-section`'))
+                                                                                                    if address0 is FAILURE:
+                                                                                                        self._offset = index1
+        self._cache['unit_fra'][index0] = (address0, self._offset)
+        return address0
+
     def _read_and_eng(self):
         address0, index0 = FAILURE, self._offset
         cached = self._cache['and_eng'].get(index0)
@@ -2295,6 +2665,28 @@ class Grammar(object):
             if self._offset == self._failure:
                 self._expected.append(('ProvisionRefs::and_afr', '`en`'))
         self._cache['and_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_and_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['and_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 2
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'et'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
+            self._offset = self._offset + 2
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::and_fra', '`et`'))
+        self._cache['and_fra'][index0] = (address0, self._offset)
         return address0
 
     def _read_or_eng(self):
@@ -2341,6 +2733,28 @@ class Grammar(object):
         self._cache['or_afr'][index0] = (address0, self._offset)
         return address0
 
+    def _read_or_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['or_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 2
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'ou'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
+            self._offset = self._offset + 2
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::or_fra', '`ou`'))
+        self._cache['or_fra'][index0] = (address0, self._offset)
+        return address0
+
     def _read_to_eng(self):
         address0, index0 = FAILURE, self._offset
         cached = self._cache['to_eng'].get(index0)
@@ -2383,6 +2797,46 @@ class Grammar(object):
             if self._offset == self._failure:
                 self._expected.append(('ProvisionRefs::to_afr', '`tot`'))
         self._cache['to_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_to_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['to_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 1
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'à'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
+            self._offset = self._offset + 1
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::to_fra', '`à`'))
+        if address0 is FAILURE:
+            self._offset = index1
+            chunk1, max1 = None, self._offset + 1
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'a'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
+                self._offset = self._offset + 1
+            else:
+                address0 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::to_fra', '`a`'))
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['to_fra'][index0] = (address0, self._offset)
         return address0
 
     def _read_of_eng(self):
@@ -2429,6 +2883,28 @@ class Grammar(object):
         self._cache['of_afr'][index0] = (address0, self._offset)
         return address0
 
+    def _read_of_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 2
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'de'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
+            self._offset = self._offset + 2
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_fra', '`de`'))
+        self._cache['of_fra'][index0] = (address0, self._offset)
+        return address0
+
     def _read_of_this_eng(self):
         address0, index0 = FAILURE, self._offset
         cached = self._cache['of_this_eng'].get(index0)
@@ -2471,6 +2947,46 @@ class Grammar(object):
             if self._offset == self._failure:
                 self._expected.append(('ProvisionRefs::of_this_afr', '`van hierdie`'))
         self._cache['of_this_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_this_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_this_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 8
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'de cette'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 8], self._offset, [])
+            self._offset = self._offset + 8
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_this_fra', '`de cette`'))
+        if address0 is FAILURE:
+            self._offset = index1
+            chunk1, max1 = None, self._offset + 5
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'de ce'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 5], self._offset, [])
+                self._offset = self._offset + 5
+            else:
+                address0 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::of_this_fra', '`de ce`'))
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['of_this_fra'][index0] = (address0, self._offset)
         return address0
 
     def _read_of_the_act_eng(self):
@@ -2553,6 +3069,46 @@ class Grammar(object):
         self._cache['of_the_act_afr'][index0] = (address0, self._offset)
         return address0
 
+    def _read_of_the_act_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_the_act_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 9
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'de la loi'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 9], self._offset, [])
+            self._offset = self._offset + 9
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_the_act_fra', '`de la loi`'))
+        if address0 is FAILURE:
+            self._offset = index1
+            chunk1, max1 = None, self._offset + 9
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'de la Loi'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 9], self._offset, [])
+                self._offset = self._offset + 9
+            else:
+                address0 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::of_the_act_fra', '`de la Loi`'))
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['of_the_act_fra'][index0] = (address0, self._offset)
+        return address0
+
     def _read_thereof_eng(self):
         address0, index0 = FAILURE, self._offset
         cached = self._cache['thereof_eng'].get(index0)
@@ -2595,6 +3151,28 @@ class Grammar(object):
             if self._offset == self._failure:
                 self._expected.append(('ProvisionRefs::thereof_afr', '`daarvan`'))
         self._cache['thereof_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_thereof_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['thereof_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 7
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'de cela'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
+            self._offset = self._offset + 7
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::thereof_fra', '`de cela`'))
+        self._cache['thereof_fra'][index0] = (address0, self._offset)
         return address0
 
     def _read_dash(self):

--- a/indigo/analysis/refs/provision_refs.py
+++ b/indigo/analysis/refs/provision_refs.py
@@ -33,7 +33,7 @@ class TreeNode2(TreeNode):
 class TreeNode3(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode3, self).__init__(text, offset, elements)
-        self.unit = elements[0]
+        self.unit__i18n = elements[0]
         self.main_ref = elements[2]
 
 
@@ -96,19 +96,19 @@ class TreeNode12(TreeNode):
 class TreeNode13(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode13, self).__init__(text, offset, elements)
-        self._and = elements[2]
+        self.dash = elements[1]
 
 
 class TreeNode14(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode14, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.to__i18n = elements[1]
 
 
 class TreeNode15(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode15, self).__init__(text, offset, elements)
-        self._or = elements[2]
+        self.and__i18n = elements[2]
 
 
 class TreeNode16(TreeNode):
@@ -120,31 +120,43 @@ class TreeNode16(TreeNode):
 class TreeNode17(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode17, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.or__i18n = elements[2]
 
 
 class TreeNode18(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode18, self).__init__(text, offset, elements)
-        self.of_the_act_en = elements[2]
+        self.comma = elements[1]
 
 
 class TreeNode19(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode19, self).__init__(text, offset, elements)
-        self.dash = elements[1]
+        self.comma = elements[1]
 
 
 class TreeNode20(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode20, self).__init__(text, offset, elements)
-        self.to_af = elements[1]
+        self.of_this__i18n = elements[2]
 
 
 class TreeNode21(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode21, self).__init__(text, offset, elements)
-        self.to_en = elements[1]
+        self.of_the_act__i18n = elements[2]
+
+
+class TreeNode22(TreeNode):
+    def __init__(self, text, offset, elements):
+        super(TreeNode22, self).__init__(text, offset, elements)
+        self.of__i18n = elements[2]
+
+
+class TreeNode23(TreeNode):
+    def __init__(self, text, offset, elements):
+        super(TreeNode23, self).__init__(text, offset, elements)
+        self.thereof__i18n = elements[2]
 
 
 FAILURE = object()
@@ -240,7 +252,7 @@ class Grammar(object):
             return cached[0]
         index1, elements0 = self._offset, []
         address1 = FAILURE
-        address1 = self._read_unit()
+        address1 = self._read_unit__i18n()
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
@@ -314,22 +326,6 @@ class Grammar(object):
             address0 = self._actions.references(self._input, index1, self._offset, elements0)
             self._offset = self._offset
         self._cache['references'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_unit(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['unit'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        index1 = self._offset
-        address0 = self._read_unit_en()
-        if address0 is FAILURE:
-            self._offset = index1
-            address0 = self._read_unit_af()
-            if address0 is FAILURE:
-                self._offset = index1
-        self._cache['unit'][index0] = (address0, self._offset)
         return address0
 
     def _read_main_ref(self):
@@ -720,6 +716,118 @@ class Grammar(object):
         self._cache['range'][index0] = (address0, self._offset)
         return address0
 
+    def _read_to(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['to'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        index2, elements0 = self._offset, []
+        address1 = FAILURE
+        index3, elements1, address2 = self._offset, [], None
+        while True:
+            address2 = self._read_WS()
+            if address2 is not FAILURE:
+                elements1.append(address2)
+            else:
+                break
+        if len(elements1) >= 0:
+            address1 = TreeNode(self._input[index3:self._offset], index3, elements1)
+            self._offset = self._offset
+        else:
+            address1 = FAILURE
+        if address1 is not FAILURE:
+            elements0.append(address1)
+            address3 = FAILURE
+            address3 = self._read_dash()
+            if address3 is not FAILURE:
+                elements0.append(address3)
+                address4 = FAILURE
+                index4, elements2, address5 = self._offset, [], None
+                while True:
+                    address5 = self._read_WS()
+                    if address5 is not FAILURE:
+                        elements2.append(address5)
+                    else:
+                        break
+                if len(elements2) >= 0:
+                    address4 = TreeNode(self._input[index4:self._offset], index4, elements2)
+                    self._offset = self._offset
+                else:
+                    address4 = FAILURE
+                if address4 is not FAILURE:
+                    elements0.append(address4)
+                else:
+                    elements0 = None
+                    self._offset = index2
+            else:
+                elements0 = None
+                self._offset = index2
+        else:
+            elements0 = None
+            self._offset = index2
+        if elements0 is None:
+            address0 = FAILURE
+        else:
+            address0 = TreeNode13(self._input[index2:self._offset], index2, elements0)
+            self._offset = self._offset
+        if address0 is FAILURE:
+            self._offset = index1
+            index5, elements3 = self._offset, []
+            address6 = FAILURE
+            index6, elements4, address7 = self._offset, [], None
+            while True:
+                address7 = self._read_WS()
+                if address7 is not FAILURE:
+                    elements4.append(address7)
+                else:
+                    break
+            if len(elements4) >= 1:
+                address6 = TreeNode(self._input[index6:self._offset], index6, elements4)
+                self._offset = self._offset
+            else:
+                address6 = FAILURE
+            if address6 is not FAILURE:
+                elements3.append(address6)
+                address8 = FAILURE
+                address8 = self._read_to__i18n()
+                if address8 is not FAILURE:
+                    elements3.append(address8)
+                    address9 = FAILURE
+                    index7, elements5, address10 = self._offset, [], None
+                    while True:
+                        address10 = self._read_WS()
+                        if address10 is not FAILURE:
+                            elements5.append(address10)
+                        else:
+                            break
+                    if len(elements5) >= 1:
+                        address9 = TreeNode(self._input[index7:self._offset], index7, elements5)
+                        self._offset = self._offset
+                    else:
+                        address9 = FAILURE
+                    if address9 is not FAILURE:
+                        elements3.append(address9)
+                    else:
+                        elements3 = None
+                        self._offset = index5
+                else:
+                    elements3 = None
+                    self._offset = index5
+            else:
+                elements3 = None
+                self._offset = index5
+            if elements3 is None:
+                address0 = FAILURE
+            else:
+                address0 = TreeNode14(self._input[index5:self._offset], index5, elements3)
+                self._offset = self._offset
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['to'][index0] = (address0, self._offset)
+        return address0
+
     def _read_and_or(self):
         address0, index0 = FAILURE, self._offset
         cached = self._cache['and_or'].get(index0)
@@ -759,7 +867,7 @@ class Grammar(object):
         if elements1 is None:
             address1 = FAILURE
         else:
-            address1 = TreeNode14(self._input[index4:self._offset], index4, elements1)
+            address1 = TreeNode16(self._input[index4:self._offset], index4, elements1)
             self._offset = self._offset
         if address1 is FAILURE:
             address1 = TreeNode(self._input[index3:index3], index3, [])
@@ -782,7 +890,7 @@ class Grammar(object):
             if address5 is not FAILURE:
                 elements0.append(address5)
                 address7 = FAILURE
-                address7 = self._read__and()
+                address7 = self._read_and__i18n()
                 if address7 is not FAILURE:
                     elements0.append(address7)
                     address8 = FAILURE
@@ -851,7 +959,7 @@ class Grammar(object):
             if elements6 is None:
                 address10 = FAILURE
             else:
-                address10 = TreeNode16(self._input[index10:self._offset], index10, elements6)
+                address10 = TreeNode18(self._input[index10:self._offset], index10, elements6)
                 self._offset = self._offset
             if address10 is FAILURE:
                 address10 = TreeNode(self._input[index9:index9], index9, [])
@@ -874,7 +982,7 @@ class Grammar(object):
                 if address14 is not FAILURE:
                     elements5.append(address14)
                     address16 = FAILURE
-                    address16 = self._read__or()
+                    address16 = self._read_or__i18n()
                     if address16 is not FAILURE:
                         elements5.append(address16)
                         address17 = FAILURE
@@ -1018,17 +1126,11 @@ class Grammar(object):
             if address2 is not FAILURE:
                 elements0.append(address2)
                 address4 = FAILURE
-                index4 = self._offset
-                address4 = self._read_of_this_en()
-                if address4 is FAILURE:
-                    self._offset = index4
-                    address4 = self._read_of_this_af()
-                    if address4 is FAILURE:
-                        self._offset = index4
+                address4 = self._read_of_this__i18n()
                 if address4 is not FAILURE:
                     elements0.append(address4)
                     address5 = FAILURE
-                    index5, elements2, address6 = self._offset, [], None
+                    index4, elements2, address6 = self._offset, [], None
                     while True:
                         address6 = self._read_WS()
                         if address6 is not FAILURE:
@@ -1036,7 +1138,7 @@ class Grammar(object):
                         else:
                             break
                     if len(elements2) >= 1:
-                        address5 = TreeNode(self._input[index5:self._offset], index5, elements2)
+                        address5 = TreeNode(self._input[index4:self._offset], index4, elements2)
                         self._offset = self._offset
                     else:
                         address5 = FAILURE
@@ -1093,7 +1195,7 @@ class Grammar(object):
             if address2 is not FAILURE:
                 elements0.append(address2)
                 address4 = FAILURE
-                address4 = self._read_of_the_act_en()
+                address4 = self._read_of_the_act__i18n()
                 if address4 is not FAILURE:
                     elements0.append(address4)
                 else:
@@ -1144,17 +1246,11 @@ class Grammar(object):
             if address2 is not FAILURE:
                 elements0.append(address2)
                 address4 = FAILURE
-                index4 = self._offset
-                address4 = self._read_of_en()
-                if address4 is FAILURE:
-                    self._offset = index4
-                    address4 = self._read_of_af()
-                    if address4 is FAILURE:
-                        self._offset = index4
+                address4 = self._read_of__i18n()
                 if address4 is not FAILURE:
                     elements0.append(address4)
                     address5 = FAILURE
-                    index5, elements2, address6 = self._offset, [], None
+                    index4, elements2, address6 = self._offset, [], None
                     while True:
                         address6 = self._read_WS()
                         if address6 is not FAILURE:
@@ -1162,7 +1258,7 @@ class Grammar(object):
                         else:
                             break
                     if len(elements2) >= 1:
-                        address5 = TreeNode(self._input[index5:self._offset], index5, elements2)
+                        address5 = TreeNode(self._input[index4:self._offset], index4, elements2)
                         self._offset = self._offset
                     else:
                         address5 = FAILURE
@@ -1219,13 +1315,7 @@ class Grammar(object):
             if address2 is not FAILURE:
                 elements0.append(address2)
                 address4 = FAILURE
-                index4 = self._offset
-                address4 = self._read_thereof_en()
-                if address4 is FAILURE:
-                    self._offset = index4
-                    address4 = self._read_thereof_af()
-                    if address4 is FAILURE:
-                        self._offset = index4
+                address4 = self._read_thereof__i18n()
                 if address4 is not FAILURE:
                     elements0.append(address4)
                 else:
@@ -1275,9 +1365,185 @@ class Grammar(object):
         self._cache['tail'][index0] = (address0, self._offset)
         return address0
 
-    def _read_unit_en(self):
+    def _read_and__i18n(self):
         address0, index0 = FAILURE, self._offset
-        cached = self._cache['unit_en'].get(index0)
+        cached = self._cache['and__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::and__i18n', '""'))
+        self._cache['and__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of__i18n', '""'))
+        self._cache['of__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_the_act__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_the_act__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_the_act__i18n', '""'))
+        self._cache['of_the_act__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_this__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_this__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_this__i18n', '""'))
+        self._cache['of_this__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_or__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['or__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::or__i18n', '""'))
+        self._cache['or__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_thereof__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['thereof__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::thereof__i18n', '""'))
+        self._cache['thereof__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_to__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['to__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::to__i18n', '""'))
+        self._cache['to__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_unit__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['unit__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::unit__i18n', '""'))
+        self._cache['unit__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_unit_eng(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['unit_eng'].get(index0)
         if cached:
             self._offset = cached[1]
             return cached[0]
@@ -1294,7 +1560,7 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::unit_en', '`articles`'))
+                self._expected.append(('ProvisionRefs::unit_eng', '`articles`'))
         if address0 is FAILURE:
             self._offset = index1
             chunk1, max1 = None, self._offset + 7
@@ -1309,7 +1575,7 @@ class Grammar(object):
                     self._failure = self._offset
                     self._expected = []
                 if self._offset == self._failure:
-                    self._expected.append(('ProvisionRefs::unit_en', '`article`'))
+                    self._expected.append(('ProvisionRefs::unit_eng', '`article`'))
             if address0 is FAILURE:
                 self._offset = index1
                 chunk2, max2 = None, self._offset + 8
@@ -1324,7 +1590,7 @@ class Grammar(object):
                         self._failure = self._offset
                         self._expected = []
                     if self._offset == self._failure:
-                        self._expected.append(('ProvisionRefs::unit_en', '`chapters`'))
+                        self._expected.append(('ProvisionRefs::unit_eng', '`chapters`'))
                 if address0 is FAILURE:
                     self._offset = index1
                     chunk3, max3 = None, self._offset + 7
@@ -1339,7 +1605,7 @@ class Grammar(object):
                             self._failure = self._offset
                             self._expected = []
                         if self._offset == self._failure:
-                            self._expected.append(('ProvisionRefs::unit_en', '`chapter`'))
+                            self._expected.append(('ProvisionRefs::unit_eng', '`chapter`'))
                     if address0 is FAILURE:
                         self._offset = index1
                         chunk4, max4 = None, self._offset + 5
@@ -1354,7 +1620,7 @@ class Grammar(object):
                                 self._failure = self._offset
                                 self._expected = []
                             if self._offset == self._failure:
-                                self._expected.append(('ProvisionRefs::unit_en', '`items`'))
+                                self._expected.append(('ProvisionRefs::unit_eng', '`items`'))
                         if address0 is FAILURE:
                             self._offset = index1
                             chunk5, max5 = None, self._offset + 4
@@ -1369,7 +1635,7 @@ class Grammar(object):
                                     self._failure = self._offset
                                     self._expected = []
                                 if self._offset == self._failure:
-                                    self._expected.append(('ProvisionRefs::unit_en', '`item`'))
+                                    self._expected.append(('ProvisionRefs::unit_eng', '`item`'))
                             if address0 is FAILURE:
                                 self._offset = index1
                                 chunk6, max6 = None, self._offset + 10
@@ -1384,7 +1650,7 @@ class Grammar(object):
                                         self._failure = self._offset
                                         self._expected = []
                                     if self._offset == self._failure:
-                                        self._expected.append(('ProvisionRefs::unit_en', '`paragraphs`'))
+                                        self._expected.append(('ProvisionRefs::unit_eng', '`paragraphs`'))
                                 if address0 is FAILURE:
                                     self._offset = index1
                                     chunk7, max7 = None, self._offset + 9
@@ -1399,7 +1665,7 @@ class Grammar(object):
                                             self._failure = self._offset
                                             self._expected = []
                                         if self._offset == self._failure:
-                                            self._expected.append(('ProvisionRefs::unit_en', '`paragraph`'))
+                                            self._expected.append(('ProvisionRefs::unit_eng', '`paragraph`'))
                                     if address0 is FAILURE:
                                         self._offset = index1
                                         chunk8, max8 = None, self._offset + 5
@@ -1414,7 +1680,7 @@ class Grammar(object):
                                                 self._failure = self._offset
                                                 self._expected = []
                                             if self._offset == self._failure:
-                                                self._expected.append(('ProvisionRefs::unit_en', '`parts`'))
+                                                self._expected.append(('ProvisionRefs::unit_eng', '`parts`'))
                                         if address0 is FAILURE:
                                             self._offset = index1
                                             chunk9, max9 = None, self._offset + 4
@@ -1429,7 +1695,7 @@ class Grammar(object):
                                                     self._failure = self._offset
                                                     self._expected = []
                                                 if self._offset == self._failure:
-                                                    self._expected.append(('ProvisionRefs::unit_en', '`part`'))
+                                                    self._expected.append(('ProvisionRefs::unit_eng', '`part`'))
                                             if address0 is FAILURE:
                                                 self._offset = index1
                                                 chunk10, max10 = None, self._offset + 6
@@ -1444,7 +1710,7 @@ class Grammar(object):
                                                         self._failure = self._offset
                                                         self._expected = []
                                                     if self._offset == self._failure:
-                                                        self._expected.append(('ProvisionRefs::unit_en', '`points`'))
+                                                        self._expected.append(('ProvisionRefs::unit_eng', '`points`'))
                                                 if address0 is FAILURE:
                                                     self._offset = index1
                                                     chunk11, max11 = None, self._offset + 5
@@ -1459,7 +1725,7 @@ class Grammar(object):
                                                             self._failure = self._offset
                                                             self._expected = []
                                                         if self._offset == self._failure:
-                                                            self._expected.append(('ProvisionRefs::unit_en', '`point`'))
+                                                            self._expected.append(('ProvisionRefs::unit_eng', '`point`'))
                                                     if address0 is FAILURE:
                                                         self._offset = index1
                                                         chunk12, max12 = None, self._offset + 11
@@ -1474,7 +1740,7 @@ class Grammar(object):
                                                                 self._failure = self._offset
                                                                 self._expected = []
                                                             if self._offset == self._failure:
-                                                                self._expected.append(('ProvisionRefs::unit_en', '`regulations`'))
+                                                                self._expected.append(('ProvisionRefs::unit_eng', '`regulations`'))
                                                         if address0 is FAILURE:
                                                             self._offset = index1
                                                             chunk13, max13 = None, self._offset + 10
@@ -1489,7 +1755,7 @@ class Grammar(object):
                                                                     self._failure = self._offset
                                                                     self._expected = []
                                                                 if self._offset == self._failure:
-                                                                    self._expected.append(('ProvisionRefs::unit_en', '`regulation`'))
+                                                                    self._expected.append(('ProvisionRefs::unit_eng', '`regulation`'))
                                                             if address0 is FAILURE:
                                                                 self._offset = index1
                                                                 chunk14, max14 = None, self._offset + 8
@@ -1504,7 +1770,7 @@ class Grammar(object):
                                                                         self._failure = self._offset
                                                                         self._expected = []
                                                                     if self._offset == self._failure:
-                                                                        self._expected.append(('ProvisionRefs::unit_en', '`sections`'))
+                                                                        self._expected.append(('ProvisionRefs::unit_eng', '`sections`'))
                                                                 if address0 is FAILURE:
                                                                     self._offset = index1
                                                                     chunk15, max15 = None, self._offset + 7
@@ -1519,7 +1785,7 @@ class Grammar(object):
                                                                             self._failure = self._offset
                                                                             self._expected = []
                                                                         if self._offset == self._failure:
-                                                                            self._expected.append(('ProvisionRefs::unit_en', '`section`'))
+                                                                            self._expected.append(('ProvisionRefs::unit_eng', '`section`'))
                                                                     if address0 is FAILURE:
                                                                         self._offset = index1
                                                                         chunk16, max16 = None, self._offset + 13
@@ -1534,7 +1800,7 @@ class Grammar(object):
                                                                                 self._failure = self._offset
                                                                                 self._expected = []
                                                                             if self._offset == self._failure:
-                                                                                self._expected.append(('ProvisionRefs::unit_en', '`subparagraphs`'))
+                                                                                self._expected.append(('ProvisionRefs::unit_eng', '`subparagraphs`'))
                                                                         if address0 is FAILURE:
                                                                             self._offset = index1
                                                                             chunk17, max17 = None, self._offset + 12
@@ -1549,7 +1815,7 @@ class Grammar(object):
                                                                                     self._failure = self._offset
                                                                                     self._expected = []
                                                                                 if self._offset == self._failure:
-                                                                                    self._expected.append(('ProvisionRefs::unit_en', '`subparagraph`'))
+                                                                                    self._expected.append(('ProvisionRefs::unit_eng', '`subparagraph`'))
                                                                             if address0 is FAILURE:
                                                                                 self._offset = index1
                                                                                 chunk18, max18 = None, self._offset + 14
@@ -1564,7 +1830,7 @@ class Grammar(object):
                                                                                         self._failure = self._offset
                                                                                         self._expected = []
                                                                                     if self._offset == self._failure:
-                                                                                        self._expected.append(('ProvisionRefs::unit_en', '`sub-paragraphs`'))
+                                                                                        self._expected.append(('ProvisionRefs::unit_eng', '`sub-paragraphs`'))
                                                                                 if address0 is FAILURE:
                                                                                     self._offset = index1
                                                                                     chunk19, max19 = None, self._offset + 13
@@ -1579,7 +1845,7 @@ class Grammar(object):
                                                                                             self._failure = self._offset
                                                                                             self._expected = []
                                                                                         if self._offset == self._failure:
-                                                                                            self._expected.append(('ProvisionRefs::unit_en', '`sub-paragraph`'))
+                                                                                            self._expected.append(('ProvisionRefs::unit_eng', '`sub-paragraph`'))
                                                                                     if address0 is FAILURE:
                                                                                         self._offset = index1
                                                                                         chunk20, max20 = None, self._offset + 14
@@ -1594,7 +1860,7 @@ class Grammar(object):
                                                                                                 self._failure = self._offset
                                                                                                 self._expected = []
                                                                                             if self._offset == self._failure:
-                                                                                                self._expected.append(('ProvisionRefs::unit_en', '`subregulations`'))
+                                                                                                self._expected.append(('ProvisionRefs::unit_eng', '`subregulations`'))
                                                                                         if address0 is FAILURE:
                                                                                             self._offset = index1
                                                                                             chunk21, max21 = None, self._offset + 13
@@ -1609,7 +1875,7 @@ class Grammar(object):
                                                                                                     self._failure = self._offset
                                                                                                     self._expected = []
                                                                                                 if self._offset == self._failure:
-                                                                                                    self._expected.append(('ProvisionRefs::unit_en', '`subregulation`'))
+                                                                                                    self._expected.append(('ProvisionRefs::unit_eng', '`subregulation`'))
                                                                                             if address0 is FAILURE:
                                                                                                 self._offset = index1
                                                                                                 chunk22, max22 = None, self._offset + 15
@@ -1624,7 +1890,7 @@ class Grammar(object):
                                                                                                         self._failure = self._offset
                                                                                                         self._expected = []
                                                                                                     if self._offset == self._failure:
-                                                                                                        self._expected.append(('ProvisionRefs::unit_en', '`sub-regulations`'))
+                                                                                                        self._expected.append(('ProvisionRefs::unit_eng', '`sub-regulations`'))
                                                                                                 if address0 is FAILURE:
                                                                                                     self._offset = index1
                                                                                                     chunk23, max23 = None, self._offset + 14
@@ -1639,7 +1905,7 @@ class Grammar(object):
                                                                                                             self._failure = self._offset
                                                                                                             self._expected = []
                                                                                                         if self._offset == self._failure:
-                                                                                                            self._expected.append(('ProvisionRefs::unit_en', '`sub-regulation`'))
+                                                                                                            self._expected.append(('ProvisionRefs::unit_eng', '`sub-regulation`'))
                                                                                                     if address0 is FAILURE:
                                                                                                         self._offset = index1
                                                                                                         chunk24, max24 = None, self._offset + 11
@@ -1654,7 +1920,7 @@ class Grammar(object):
                                                                                                                 self._failure = self._offset
                                                                                                                 self._expected = []
                                                                                                             if self._offset == self._failure:
-                                                                                                                self._expected.append(('ProvisionRefs::unit_en', '`subsections`'))
+                                                                                                                self._expected.append(('ProvisionRefs::unit_eng', '`subsections`'))
                                                                                                         if address0 is FAILURE:
                                                                                                             self._offset = index1
                                                                                                             chunk25, max25 = None, self._offset + 10
@@ -1669,7 +1935,7 @@ class Grammar(object):
                                                                                                                     self._failure = self._offset
                                                                                                                     self._expected = []
                                                                                                                 if self._offset == self._failure:
-                                                                                                                    self._expected.append(('ProvisionRefs::unit_en', '`subsection`'))
+                                                                                                                    self._expected.append(('ProvisionRefs::unit_eng', '`subsection`'))
                                                                                                             if address0 is FAILURE:
                                                                                                                 self._offset = index1
                                                                                                                 chunk26, max26 = None, self._offset + 12
@@ -1684,7 +1950,7 @@ class Grammar(object):
                                                                                                                         self._failure = self._offset
                                                                                                                         self._expected = []
                                                                                                                     if self._offset == self._failure:
-                                                                                                                        self._expected.append(('ProvisionRefs::unit_en', '`sub-sections`'))
+                                                                                                                        self._expected.append(('ProvisionRefs::unit_eng', '`sub-sections`'))
                                                                                                                 if address0 is FAILURE:
                                                                                                                     self._offset = index1
                                                                                                                     chunk27, max27 = None, self._offset + 11
@@ -1699,15 +1965,15 @@ class Grammar(object):
                                                                                                                             self._failure = self._offset
                                                                                                                             self._expected = []
                                                                                                                         if self._offset == self._failure:
-                                                                                                                            self._expected.append(('ProvisionRefs::unit_en', '`sub-section`'))
+                                                                                                                            self._expected.append(('ProvisionRefs::unit_eng', '`sub-section`'))
                                                                                                                     if address0 is FAILURE:
                                                                                                                         self._offset = index1
-        self._cache['unit_en'][index0] = (address0, self._offset)
+        self._cache['unit_eng'][index0] = (address0, self._offset)
         return address0
 
-    def _read_unit_af(self):
+    def _read_unit_afr(self):
         address0, index0 = FAILURE, self._offset
-        cached = self._cache['unit_af'].get(index0)
+        cached = self._cache['unit_afr'].get(index0)
         if cached:
             self._offset = cached[1]
             return cached[0]
@@ -1724,7 +1990,7 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::unit_af', '`afdelings`'))
+                self._expected.append(('ProvisionRefs::unit_afr', '`afdelings`'))
         if address0 is FAILURE:
             self._offset = index1
             chunk1, max1 = None, self._offset + 8
@@ -1739,7 +2005,7 @@ class Grammar(object):
                     self._failure = self._offset
                     self._expected = []
                 if self._offset == self._failure:
-                    self._expected.append(('ProvisionRefs::unit_af', '`afdeling`'))
+                    self._expected.append(('ProvisionRefs::unit_afr', '`afdeling`'))
             if address0 is FAILURE:
                 self._offset = index1
                 chunk2, max2 = None, self._offset + 8
@@ -1754,7 +2020,7 @@ class Grammar(object):
                         self._failure = self._offset
                         self._expected = []
                     if self._offset == self._failure:
-                        self._expected.append(('ProvisionRefs::unit_af', '`artikels`'))
+                        self._expected.append(('ProvisionRefs::unit_afr', '`artikels`'))
                 if address0 is FAILURE:
                     self._offset = index1
                     index2, elements0 = self._offset, []
@@ -1771,7 +2037,7 @@ class Grammar(object):
                             self._failure = self._offset
                             self._expected = []
                         if self._offset == self._failure:
-                            self._expected.append(('ProvisionRefs::unit_af', '`artikel`'))
+                            self._expected.append(('ProvisionRefs::unit_afr', '`artikel`'))
                     if address1 is not FAILURE:
                         elements0.append(address1)
                         address2 = FAILURE
@@ -1787,7 +2053,7 @@ class Grammar(object):
                                 self._failure = self._offset
                                 self._expected = []
                             if self._offset == self._failure:
-                                self._expected.append(('ProvisionRefs::unit_af', '`dele`'))
+                                self._expected.append(('ProvisionRefs::unit_afr', '`dele`'))
                         if address2 is not FAILURE:
                             elements0.append(address2)
                         else:
@@ -1817,7 +2083,7 @@ class Grammar(object):
                                 self._failure = self._offset
                                 self._expected = []
                             if self._offset == self._failure:
-                                self._expected.append(('ProvisionRefs::unit_af', '`deel`'))
+                                self._expected.append(('ProvisionRefs::unit_afr', '`deel`'))
                         if address3 is not FAILURE:
                             elements1.append(address3)
                             address4 = FAILURE
@@ -1833,7 +2099,7 @@ class Grammar(object):
                                     self._failure = self._offset
                                     self._expected = []
                                 if self._offset == self._failure:
-                                    self._expected.append(('ProvisionRefs::unit_af', '`hoofstukke`'))
+                                    self._expected.append(('ProvisionRefs::unit_afr', '`hoofstukke`'))
                             if address4 is not FAILURE:
                                 elements1.append(address4)
                             else:
@@ -1861,7 +2127,7 @@ class Grammar(object):
                                     self._failure = self._offset
                                     self._expected = []
                                 if self._offset == self._failure:
-                                    self._expected.append(('ProvisionRefs::unit_af', '`hoofstuk`'))
+                                    self._expected.append(('ProvisionRefs::unit_afr', '`hoofstuk`'))
                             if address0 is FAILURE:
                                 self._offset = index1
                                 chunk8, max8 = None, self._offset + 9
@@ -1876,7 +2142,7 @@ class Grammar(object):
                                         self._failure = self._offset
                                         self._expected = []
                                     if self._offset == self._failure:
-                                        self._expected.append(('ProvisionRefs::unit_af', '`paragrawe`'))
+                                        self._expected.append(('ProvisionRefs::unit_afr', '`paragrawe`'))
                                 if address0 is FAILURE:
                                     self._offset = index1
                                     chunk9, max9 = None, self._offset + 9
@@ -1891,7 +2157,7 @@ class Grammar(object):
                                             self._failure = self._offset
                                             self._expected = []
                                         if self._offset == self._failure:
-                                            self._expected.append(('ProvisionRefs::unit_af', '`paragraaf`'))
+                                            self._expected.append(('ProvisionRefs::unit_afr', '`paragraaf`'))
                                     if address0 is FAILURE:
                                         self._offset = index1
                                         chunk10, max10 = None, self._offset + 5
@@ -1906,7 +2172,7 @@ class Grammar(object):
                                                 self._failure = self._offset
                                                 self._expected = []
                                             if self._offset == self._failure:
-                                                self._expected.append(('ProvisionRefs::unit_af', '`punte`'))
+                                                self._expected.append(('ProvisionRefs::unit_afr', '`punte`'))
                                         if address0 is FAILURE:
                                             self._offset = index1
                                             chunk11, max11 = None, self._offset + 4
@@ -1921,7 +2187,7 @@ class Grammar(object):
                                                     self._failure = self._offset
                                                     self._expected = []
                                                 if self._offset == self._failure:
-                                                    self._expected.append(('ProvisionRefs::unit_af', '`punt`'))
+                                                    self._expected.append(('ProvisionRefs::unit_afr', '`punt`'))
                                             if address0 is FAILURE:
                                                 self._offset = index1
                                                 chunk12, max12 = None, self._offset + 12
@@ -1936,7 +2202,7 @@ class Grammar(object):
                                                         self._failure = self._offset
                                                         self._expected = []
                                                     if self._offset == self._failure:
-                                                        self._expected.append(('ProvisionRefs::unit_af', '`subafdelings`'))
+                                                        self._expected.append(('ProvisionRefs::unit_afr', '`subafdelings`'))
                                                 if address0 is FAILURE:
                                                     self._offset = index1
                                                     chunk13, max13 = None, self._offset + 11
@@ -1951,7 +2217,7 @@ class Grammar(object):
                                                             self._failure = self._offset
                                                             self._expected = []
                                                         if self._offset == self._failure:
-                                                            self._expected.append(('ProvisionRefs::unit_af', '`subafdeling`'))
+                                                            self._expected.append(('ProvisionRefs::unit_afr', '`subafdeling`'))
                                                     if address0 is FAILURE:
                                                         self._offset = index1
                                                         chunk14, max14 = None, self._offset + 12
@@ -1966,7 +2232,7 @@ class Grammar(object):
                                                                 self._failure = self._offset
                                                                 self._expected = []
                                                             if self._offset == self._failure:
-                                                                self._expected.append(('ProvisionRefs::unit_af', '`subparagrawe`'))
+                                                                self._expected.append(('ProvisionRefs::unit_afr', '`subparagrawe`'))
                                                         if address0 is FAILURE:
                                                             self._offset = index1
                                                             chunk15, max15 = None, self._offset + 12
@@ -1981,31 +2247,15 @@ class Grammar(object):
                                                                     self._failure = self._offset
                                                                     self._expected = []
                                                                 if self._offset == self._failure:
-                                                                    self._expected.append(('ProvisionRefs::unit_af', '`subparagraaf`'))
+                                                                    self._expected.append(('ProvisionRefs::unit_afr', '`subparagraaf`'))
                                                             if address0 is FAILURE:
                                                                 self._offset = index1
-        self._cache['unit_af'][index0] = (address0, self._offset)
+        self._cache['unit_afr'][index0] = (address0, self._offset)
         return address0
 
-    def _read__and(self):
+    def _read_and_eng(self):
         address0, index0 = FAILURE, self._offset
-        cached = self._cache['_and'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        index1 = self._offset
-        address0 = self._read_and_en()
-        if address0 is FAILURE:
-            self._offset = index1
-            address0 = self._read_and_af()
-            if address0 is FAILURE:
-                self._offset = index1
-        self._cache['_and'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_and_en(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['and_en'].get(index0)
+        cached = self._cache['and_eng'].get(index0)
         if cached:
             self._offset = cached[1]
             return cached[0]
@@ -2021,13 +2271,13 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::and_en', '`and`'))
-        self._cache['and_en'][index0] = (address0, self._offset)
+                self._expected.append(('ProvisionRefs::and_eng', '`and`'))
+        self._cache['and_eng'][index0] = (address0, self._offset)
         return address0
 
-    def _read_and_af(self):
+    def _read_and_afr(self):
         address0, index0 = FAILURE, self._offset
-        cached = self._cache['and_af'].get(index0)
+        cached = self._cache['and_afr'].get(index0)
         if cached:
             self._offset = cached[1]
             return cached[0]
@@ -2043,29 +2293,13 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::and_af', '`en`'))
-        self._cache['and_af'][index0] = (address0, self._offset)
+                self._expected.append(('ProvisionRefs::and_afr', '`en`'))
+        self._cache['and_afr'][index0] = (address0, self._offset)
         return address0
 
-    def _read__or(self):
+    def _read_or_eng(self):
         address0, index0 = FAILURE, self._offset
-        cached = self._cache['_or'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        index1 = self._offset
-        address0 = self._read_or_en()
-        if address0 is FAILURE:
-            self._offset = index1
-            address0 = self._read_or_af()
-            if address0 is FAILURE:
-                self._offset = index1
-        self._cache['_or'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_or_en(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['or_en'].get(index0)
+        cached = self._cache['or_eng'].get(index0)
         if cached:
             self._offset = cached[1]
             return cached[0]
@@ -2081,181 +2315,286 @@ class Grammar(object):
                 self._failure = self._offset
                 self._expected = []
             if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::or_en', '`or`'))
-        self._cache['or_en'][index0] = (address0, self._offset)
+                self._expected.append(('ProvisionRefs::or_eng', '`or`'))
+        self._cache['or_eng'][index0] = (address0, self._offset)
         return address0
 
-    def _read_or_af(self):
+    def _read_or_afr(self):
         address0, index0 = FAILURE, self._offset
-        cached = self._cache['or_af'].get(index0)
+        cached = self._cache['or_afr'].get(index0)
         if cached:
             self._offset = cached[1]
             return cached[0]
-        address0 = self._read_or_en()
-        self._cache['or_af'][index0] = (address0, self._offset)
+        chunk0, max0 = None, self._offset + 2
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'of'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
+            self._offset = self._offset + 2
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::or_afr', '`of`'))
+        self._cache['or_afr'][index0] = (address0, self._offset)
         return address0
 
-    def _read_to(self):
+    def _read_to_eng(self):
         address0, index0 = FAILURE, self._offset
-        cached = self._cache['to'].get(index0)
+        cached = self._cache['to_eng'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 2
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'to'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
+            self._offset = self._offset + 2
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::to_eng', '`to`'))
+        self._cache['to_eng'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_to_afr(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['to_afr'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 3
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'tot'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 3], self._offset, [])
+            self._offset = self._offset + 3
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::to_afr', '`tot`'))
+        self._cache['to_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_eng(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_eng'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 2
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'of'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
+            self._offset = self._offset + 2
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_eng', '`of`'))
+        self._cache['of_eng'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_afr(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_afr'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 3
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'van'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 3], self._offset, [])
+            self._offset = self._offset + 3
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_afr', '`van`'))
+        self._cache['of_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_this_eng(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_this_eng'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 7
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'of this'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
+            self._offset = self._offset + 7
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_this_eng', '`of this`'))
+        self._cache['of_this_eng'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_this_afr(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_this_afr'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 11
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'van hierdie'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 11], self._offset, [])
+            self._offset = self._offset + 11
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_this_afr', '`van hierdie`'))
+        self._cache['of_this_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_the_act_eng(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_the_act_eng'].get(index0)
         if cached:
             self._offset = cached[1]
             return cached[0]
         index1 = self._offset
-        index2, elements0 = self._offset, []
-        address1 = FAILURE
-        index3, elements1, address2 = self._offset, [], None
-        while True:
-            address2 = self._read_WS()
-            if address2 is not FAILURE:
-                elements1.append(address2)
-            else:
-                break
-        if len(elements1) >= 0:
-            address1 = TreeNode(self._input[index3:self._offset], index3, elements1)
-            self._offset = self._offset
+        chunk0, max0 = None, self._offset + 10
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'of the Act'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 10], self._offset, [])
+            self._offset = self._offset + 10
         else:
-            address1 = FAILURE
-        if address1 is not FAILURE:
-            elements0.append(address1)
-            address3 = FAILURE
-            address3 = self._read_dash()
-            if address3 is not FAILURE:
-                elements0.append(address3)
-                address4 = FAILURE
-                index4, elements2, address5 = self._offset, [], None
-                while True:
-                    address5 = self._read_WS()
-                    if address5 is not FAILURE:
-                        elements2.append(address5)
-                    else:
-                        break
-                if len(elements2) >= 0:
-                    address4 = TreeNode(self._input[index4:self._offset], index4, elements2)
-                    self._offset = self._offset
-                else:
-                    address4 = FAILURE
-                if address4 is not FAILURE:
-                    elements0.append(address4)
-                else:
-                    elements0 = None
-                    self._offset = index2
-            else:
-                elements0 = None
-                self._offset = index2
-        else:
-            elements0 = None
-            self._offset = index2
-        if elements0 is None:
             address0 = FAILURE
-        else:
-            address0 = TreeNode19(self._input[index2:self._offset], index2, elements0)
-            self._offset = self._offset
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_the_act_eng', '`of the Act`'))
         if address0 is FAILURE:
             self._offset = index1
-            index5, elements3 = self._offset, []
-            address6 = FAILURE
-            index6, elements4, address7 = self._offset, [], None
-            while True:
-                address7 = self._read_WS()
-                if address7 is not FAILURE:
-                    elements4.append(address7)
-                else:
-                    break
-            if len(elements4) >= 1:
-                address6 = TreeNode(self._input[index6:self._offset], index6, elements4)
-                self._offset = self._offset
+            chunk1, max1 = None, self._offset + 10
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'of the act'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 10], self._offset, [])
+                self._offset = self._offset + 10
             else:
-                address6 = FAILURE
-            if address6 is not FAILURE:
-                elements3.append(address6)
-                address8 = FAILURE
-                address8 = self._read_to_af()
-                if address8 is not FAILURE:
-                    elements3.append(address8)
-                    address9 = FAILURE
-                    index7, elements5, address10 = self._offset, [], None
-                    while True:
-                        address10 = self._read_WS()
-                        if address10 is not FAILURE:
-                            elements5.append(address10)
-                        else:
-                            break
-                    if len(elements5) >= 1:
-                        address9 = TreeNode(self._input[index7:self._offset], index7, elements5)
-                        self._offset = self._offset
-                    else:
-                        address9 = FAILURE
-                    if address9 is not FAILURE:
-                        elements3.append(address9)
-                    else:
-                        elements3 = None
-                        self._offset = index5
-                else:
-                    elements3 = None
-                    self._offset = index5
-            else:
-                elements3 = None
-                self._offset = index5
-            if elements3 is None:
                 address0 = FAILURE
-            else:
-                address0 = TreeNode20(self._input[index5:self._offset], index5, elements3)
-                self._offset = self._offset
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::of_the_act_eng', '`of the act`'))
             if address0 is FAILURE:
                 self._offset = index1
-                index8, elements6 = self._offset, []
-                address11 = FAILURE
-                index9, elements7, address12 = self._offset, [], None
-                while True:
-                    address12 = self._read_WS()
-                    if address12 is not FAILURE:
-                        elements7.append(address12)
-                    else:
-                        break
-                if len(elements7) >= 1:
-                    address11 = TreeNode(self._input[index9:self._offset], index9, elements7)
-                    self._offset = self._offset
-                else:
-                    address11 = FAILURE
-                if address11 is not FAILURE:
-                    elements6.append(address11)
-                    address13 = FAILURE
-                    address13 = self._read_to_en()
-                    if address13 is not FAILURE:
-                        elements6.append(address13)
-                        address14 = FAILURE
-                        index10, elements8, address15 = self._offset, [], None
-                        while True:
-                            address15 = self._read_WS()
-                            if address15 is not FAILURE:
-                                elements8.append(address15)
-                            else:
-                                break
-                        if len(elements8) >= 1:
-                            address14 = TreeNode(self._input[index10:self._offset], index10, elements8)
-                            self._offset = self._offset
-                        else:
-                            address14 = FAILURE
-                        if address14 is not FAILURE:
-                            elements6.append(address14)
-                        else:
-                            elements6 = None
-                            self._offset = index8
-                    else:
-                        elements6 = None
-                        self._offset = index8
-                else:
-                    elements6 = None
-                    self._offset = index8
-                if elements6 is None:
-                    address0 = FAILURE
-                else:
-                    address0 = TreeNode21(self._input[index8:self._offset], index8, elements6)
-                    self._offset = self._offset
-                if address0 is FAILURE:
-                    self._offset = index1
-        self._cache['to'][index0] = (address0, self._offset)
+        self._cache['of_the_act_eng'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_of_the_act_afr(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['of_the_act_afr'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 11
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'van die Wet'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 11], self._offset, [])
+            self._offset = self._offset + 11
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::of_the_act_afr', '`van die Wet`'))
+        if address0 is FAILURE:
+            self._offset = index1
+            chunk1, max1 = None, self._offset + 11
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'van die wet'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 11], self._offset, [])
+                self._offset = self._offset + 11
+            else:
+                address0 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::of_the_act_afr', '`van die wet`'))
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['of_the_act_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_thereof_eng(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['thereof_eng'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 7
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'thereof'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
+            self._offset = self._offset + 7
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::thereof_eng', '`thereof`'))
+        self._cache['thereof_eng'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_thereof_afr(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['thereof_afr'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 7
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'daarvan'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
+            self._offset = self._offset + 7
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::thereof_afr', '`daarvan`'))
+        self._cache['thereof_afr'][index0] = (address0, self._offset)
         return address0
 
     def _read_dash(self):
@@ -2311,222 +2650,6 @@ class Grammar(object):
                 if address0 is FAILURE:
                     self._offset = index1
         self._cache['dash'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_to_en(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['to_en'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        chunk0, max0 = None, self._offset + 2
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'to'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
-            self._offset = self._offset + 2
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::to_en', '`to`'))
-        self._cache['to_en'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_to_af(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['to_af'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        chunk0, max0 = None, self._offset + 3
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'tot'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 3], self._offset, [])
-            self._offset = self._offset + 3
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::to_af', '`tot`'))
-        self._cache['to_af'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_of_en(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['of_en'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        chunk0, max0 = None, self._offset + 2
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'of'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 2], self._offset, [])
-            self._offset = self._offset + 2
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::of_en', '`of`'))
-        self._cache['of_en'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_of_af(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['of_af'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        chunk0, max0 = None, self._offset + 3
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'van'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 3], self._offset, [])
-            self._offset = self._offset + 3
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::of_af', '`van`'))
-        self._cache['of_af'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_of_this_en(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['of_this_en'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        chunk0, max0 = None, self._offset + 7
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'of this'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
-            self._offset = self._offset + 7
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::of_this_en', '`of this`'))
-        self._cache['of_this_en'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_of_this_af(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['of_this_af'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        chunk0, max0 = None, self._offset + 11
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'van hierdie'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 11], self._offset, [])
-            self._offset = self._offset + 11
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::of_this_af', '`van hierdie`'))
-        self._cache['of_this_af'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_of_the_act_en(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['of_the_act_en'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        index1 = self._offset
-        chunk0, max0 = None, self._offset + 10
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'of the Act'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 10], self._offset, [])
-            self._offset = self._offset + 10
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::of_the_act_en', '`of the Act`'))
-        if address0 is FAILURE:
-            self._offset = index1
-            chunk1, max1 = None, self._offset + 10
-            if max1 <= self._input_size:
-                chunk1 = self._input[self._offset:max1]
-            if chunk1 is not None and chunk1.lower() == 'of the act'.lower():
-                address0 = TreeNode(self._input[self._offset:self._offset + 10], self._offset, [])
-                self._offset = self._offset + 10
-            else:
-                address0 = FAILURE
-                if self._offset > self._failure:
-                    self._failure = self._offset
-                    self._expected = []
-                if self._offset == self._failure:
-                    self._expected.append(('ProvisionRefs::of_the_act_en', '`of the act`'))
-            if address0 is FAILURE:
-                self._offset = index1
-        self._cache['of_the_act_en'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_thereof_en(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['thereof_en'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        chunk0, max0 = None, self._offset + 7
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'thereof'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
-            self._offset = self._offset + 7
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::thereof_en', '`thereof`'))
-        self._cache['thereof_en'][index0] = (address0, self._offset)
-        return address0
-
-    def _read_thereof_af(self):
-        address0, index0 = FAILURE, self._offset
-        cached = self._cache['thereof_af'].get(index0)
-        if cached:
-            self._offset = cached[1]
-            return cached[0]
-        chunk0, max0 = None, self._offset + 7
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and chunk0.lower() == 'daarvan'.lower():
-            address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
-            self._offset = self._offset + 7
-        else:
-            address0 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::thereof_af', '`daarvan`'))
-        self._cache['thereof_af'][index0] = (address0, self._offset)
         return address0
 
     def _read_comma(self):

--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -79,7 +79,7 @@ def parse_provision_refs(text, lang_code='eng'):
         """
 
         # supported languages
-        lang_codes = ['eng', 'afr']
+        lang_codes = ['eng', 'afr', 'fra']
 
         def __init__(self, lang_code, *args, **kwargs):
             if lang_code not in self.lang_codes:

--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -68,7 +68,7 @@ class ParseResult:
     end: int
 
 
-def parse_provision_refs(text):
+def parse_provision_refs(text, lang_code='eng'):
     class CustomParser(Parser):
         """This is a custom parser that overrides the method that reads the tail of the text.
         The parent parser's implementation reads character by character and creates a new TreeNode for each character.
@@ -77,6 +77,29 @@ def parse_provision_refs(text):
 
         On a test input, this reduced parse time from 1.5sec to 0.003 sec!
         """
+
+        # supported languages
+        lang_codes = ['eng', 'afr']
+
+        def __init__(self, lang_code, *args, **kwargs):
+            if lang_code not in self.lang_codes:
+                log.warning(f"Unsupported language code: {lang_code}, using 'eng' instead")
+                lang_code = 'eng'
+            self.lang_code = lang_code
+            super().__init__(*args, **kwargs)
+            self.patch_i18n()
+
+        def patch_i18n(self):
+            # find all _read_foo__i18n methods and patch them to call _read_foo__<lang_code> instead
+            for name in dir(self):
+                if name.startswith('_read_') and name.endswith('__i18n'):
+                    lang_name = name[:-5] + self.lang_code
+                    if hasattr(self, lang_name):
+                        log.debug(f"Patching {name} to {lang_name}")
+                        setattr(self, name, getattr(self, lang_name))
+                    else:
+                        raise ValueError(f"Missing translated rule {lang_name} for {name}")
+
         def _read_tail(self):
             node = TreeNode(self._input[self._offset:self._input_size], self._offset, [])
             self._offset = self._input_size
@@ -152,7 +175,7 @@ def parse_provision_refs(text):
         def thereof(self, input, start, end, elements):
             return "thereof"
 
-    parser = CustomParser(text, Actions(), None)
+    parser = CustomParser(lang_code, text, Actions(), None)
     return parser.parse()
 
 
@@ -380,7 +403,7 @@ class ProvisionRefsMatcher(CitationMatcher):
         return parses
 
     def parse_refs(self, text: str) -> ParseResult:
-        return parse_provision_refs(text)
+        return parse_provision_refs(text, self.frbr_uri.language or 'eng')
 
     def handle_node_match(self, node, match, in_tail):
         """Process a potential citation match in the text (or tail) of a node.

--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -247,13 +247,6 @@ class ProvisionRefsResolver:
     ]
     minor_hier_elements = list(set(AkomaNtoso30.hier_elements) - set(major_hier_elements))
 
-    def resolve_references_str(self, text: str, root: Element):
-        """Parse a string into reference objects, and the resolve them to eIds in the given root element."""
-        refs = parse_provision_refs(text).references
-        for ref in refs:
-            self.resolve_references(ref, root)
-        return refs
-
     def resolve_references(self, main_ref: MainProvisionRef, local_root: Element):
         """Resolve a ref, including subreferences, to element eIds in an Akoma Ntoso document."""
         # when resolving a reference like "Section 32(1)(a) and (b)", everything is relative to the first reference,
@@ -403,7 +396,7 @@ class ProvisionRefsMatcher(CitationMatcher):
         return parses
 
     def parse_refs(self, text: str) -> ParseResult:
-        return parse_provision_refs(text, self.frbr_uri.language or 'eng')
+        return parse_provision_refs(text, self.frbr_uri.language)
 
     def handle_node_match(self, node, match, in_tail):
         """Process a potential citation match in the text (or tail) of a node.

--- a/indigo/tests/test_provision_refs.py
+++ b/indigo/tests/test_provision_refs.py
@@ -512,6 +512,7 @@ class ProvisionRefsMatcherTestCase(TestCase):
         )
 
     def test_local_sections_af(self):
+        self.frbr_uri = FrbrUri.parse("/akn/za/act/2009/1/afr@2009-01-01")
         doc = AkomaNtosoDocument(document_fixture(xml="""
             <section eId="sec_7">
               <num>7.</num>
@@ -863,7 +864,8 @@ class ProvisionRefsMatcherTestCase(TestCase):
             etree.tostring(actual, encoding='unicode')
         )
 
-    def test_remote_sections_af(self):
+    def test_remote_sections_afr(self):
+        self.frbr_uri = FrbrUri.parse("/akn/za/act/2009/1/afr@2009-01-01")
         doc = AkomaNtosoDocument(document_fixture(xml="""
             <section eId="sec_7">
               <num>7.</num>
@@ -1652,8 +1654,8 @@ class ProvisionRefsGrammarTest(TestCase):
         ], result.references)
         self.assertIsNone(result.target)
 
-    def test_mixed_af(self):
-        result = parse_provision_refs("Afdeling 1.2(1)(a),(c) tot (e), (f)(ii) en (2), en (3)(g),(h) en afdelings 32(a)")
+    def test_mixed_afr(self):
+        result = parse_provision_refs("Afdeling 1.2(1)(a),(c) tot (e), (f)(ii) en (2), en (3)(g),(h) en afdelings 32(a)", "afr")
         self.assertEqual([
             MainProvisionRef(
                 "Afdeling",
@@ -1770,15 +1772,15 @@ class ProvisionRefsGrammarTest(TestCase):
         self.assertEqual("of", result.target)
         self.assertEqual(result.end, 17)
 
-    def test_target_af(self):
-        result = parse_provision_refs("Afdeling 2 van hierdie Wet")
+    def test_target_afr(self):
+        result = parse_provision_refs("Afdeling 2 van hierdie Wet", "afr")
         self.assertEqual("this", result.target)
         self.assertEqual(result.end, 23)
 
-        result = parse_provision_refs("Afdeling 2 daarvan")
+        result = parse_provision_refs("Afdeling 2 daarvan", "afr")
         self.assertEqual("thereof", result.target)
         self.assertEqual(result.end, 18)
 
-        result = parse_provision_refs("Afdeling 2 van die Wet met kak")
-        self.assertEqual("of", result.target)
-        self.assertEqual(result.end, 15)
+        result = parse_provision_refs("Afdeling 2 van die Wet met kak", "afr")
+        self.assertEqual("the_act", result.target)
+        self.assertEqual(result.end, 22)

--- a/indigo/tests/test_provision_refs.py
+++ b/indigo/tests/test_provision_refs.py
@@ -620,6 +620,67 @@ class ProvisionRefsMatcherTestCase(TestCase):
             etree.tostring(actual, encoding='unicode')
         )
 
+    def test_local_sections_fra(self):
+        self.frbr_uri = FrbrUri.parse("/akn/za/act/2009/1/fra@2009-01-01")
+        doc = AkomaNtosoDocument(document_fixture(xml="""
+            <article eId="art_7">
+              <num>7.</num>
+              <heading>Article 7</heading>
+              <content>
+                <p>la période de validité des titres visés à l’article 8 sont</p>
+              </content>
+            </article>
+            <article eId="art_8">
+              <num>8.</num>
+              <heading>Article 8</heading>
+              <subsection eId="art_8__subsec_a">
+                <num>(a)</num>
+                <paragraph eId="art_8__subsec_a__para_1">
+                  <num>(1)</num>
+                </paragraph>
+                <paragraph eId="art_8__subsec_a__para_2">
+                  <num>(2)</num>
+                </paragraph>
+              </subsection>
+              <subsection eId="art_8__subsec_b">
+                <num>(b)</num>
+              </subsection>
+            </article>
+        """))
+
+        expected = AkomaNtosoDocument(document_fixture(xml="""
+            <article eId="art_7">
+              <num>7.</num>
+              <heading>Article 7</heading>
+              <content>
+                <p>la période de validité des titres visés à l’article <ref href="#art_8">8</ref> sont</p>
+              </content>
+            </article>
+            <article eId="art_8">
+              <num>8.</num>
+              <heading>Article 8</heading>
+              <subsection eId="art_8__subsec_a">
+                <num>(a)</num>
+                <paragraph eId="art_8__subsec_a__para_1">
+                  <num>(1)</num>
+                </paragraph>
+                <paragraph eId="art_8__subsec_a__para_2">
+                  <num>(2)</num>
+                </paragraph>
+              </subsection>
+              <subsection eId="art_8__subsec_b">
+                <num>(b)</num>
+              </subsection>
+            </article>
+        """))
+
+        actual = etree.fromstring(doc.to_xml())
+        self.finder.markup_xml_matches(self.frbr_uri, actual)
+        self.assertEqual(
+            expected.to_xml(encoding='unicode'),
+            etree.tostring(actual, encoding='unicode')
+        )
+
     def test_local_relative(self):
         doc = AkomaNtosoDocument(document_fixture(xml="""
             <section eId="sec_1">
@@ -1452,405 +1513,3 @@ class ProvisionRefsMatcherTestCase(TestCase):
         self.assertEqual([
             ExtractedCitation("Act No. 1 of 2009", 30, 38, "/akn/za/act/2009/1", 0, 'of Act No. ', '.' ),
         ], self.finder.citations)
-
-
-class ProvisionRefsGrammarTest(TestCase):
-    maxDiff = None
-
-    def test_single(self):
-        result = parse_provision_refs("Section 1")
-        self.assertEqual([
-            MainProvisionRef(
-                "Section",
-                ProvisionRef("1", 8, 9)
-            )
-        ], result.references)
-        self.assertEqual(result.end, 9)
-
-        result = parse_provision_refs("paragraph (a)")
-        self.assertEqual([
-            MainProvisionRef(
-                "paragraph",
-                ProvisionRef("(a)", 10, 13)
-            )
-        ], result.references)
-
-    def test_single_whitespace(self):
-        result = parse_provision_refs("Section 1\n")
-        self.assertEqual([
-            MainProvisionRef(
-                "Section",
-                ProvisionRef("1", 8, 9)
-            )
-        ], result.references)
-        self.assertEqual(result.end, 9)
-
-        result = parse_provision_refs("paragraph (a)\n")
-        self.assertEqual([
-            MainProvisionRef(
-                "paragraph",
-                ProvisionRef("(a)", 10, 13)
-            )
-        ], result.references)
-
-    def test_multiple_main_numbers(self):
-        result = parse_provision_refs("Section 1, 32 and 33")
-        self.assertEqual([
-            MainProvisionRef(
-                "Section",
-                ProvisionRef("1", 8, 9)
-            ),
-            MainProvisionRef(
-                "Section",
-                ProvisionRef("32", 11, 13)
-            ),
-            MainProvisionRef(
-                "Section",
-                ProvisionRef("33", 18, 20)
-            )
-        ], result.references)
-        self.assertEqual(result.end, 20)
-
-        result = parse_provision_refs("paragraph (a) and subparagraph (c)")
-        self.assertEqual([
-            MainProvisionRef(
-                "paragraph",
-                ProvisionRef("(a)", 10, 13)
-            ),
-            MainProvisionRef(
-                "subparagraph",
-                ProvisionRef("(c)", 31, 34)
-            )
-        ], result.references)
-
-    def test_multiple_main(self):
-        result = parse_provision_refs("Section 1 and section 2, section 3 and chapter 4")
-        self.assertEqual([
-            MainProvisionRef(
-                "Section",
-                ProvisionRef("1", 8, 9)
-            ),
-            MainProvisionRef(
-                "section",
-                ProvisionRef("2", 22, 23)
-            ),
-            MainProvisionRef(
-                "section",
-                ProvisionRef("3", 33, 34)
-            ),
-            MainProvisionRef(
-                "chapter",
-                ProvisionRef("4", 47, 48)
-            )
-        ], result.references)
-
-    def test_mixed(self):
-        result = parse_provision_refs("Section 1.2(1)(a),(c) to (e), (f)(ii) and (2), and (3)(g),(h) and section 32(a)")
-        self.assertEqual([
-            MainProvisionRef(
-                "Section",
-                ProvisionRef("1.2", 8, 11, None,
-                    ProvisionRef("(1)", 11, 14, None,
-                        ProvisionRef("(a)", 14, 17)
-                    ),
-                ), [
-                    ProvisionRef("(c)", 18, 21, "and_or"),
-                    ProvisionRef("(e)", 25, 28, "range"),
-                    ProvisionRef("(f)", 30, 33, "and_or",
-                        ProvisionRef("(ii)", 33, 37),
-                    ),
-                    ProvisionRef("(2)", 42, 45, "and_or"),
-                    ProvisionRef("(3)", 51, 54, "and_or",
-                        ProvisionRef("(g)", 54, 57),
-                    ),
-                    ProvisionRef("(h)", 58, 61, "and_or"),
-                ]
-            ),
-            MainProvisionRef(
-                "section",
-                ProvisionRef("32", 74, 76, None,
-                    ProvisionRef("(a)", 76, 79),
-                ),
-            )
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_mixed_newlines(self):
-        result = parse_provision_refs("Section 1.2(1)(a),\n(c) to (e), (f)(ii)\nand (2), and (3)\n(g),(h)\nand section 32(a)\n")
-        self.assertEqual([
-            MainProvisionRef(
-                "Section",
-                ProvisionRef("1.2", 8, 11, None,
-                             ProvisionRef("(1)", 11, 14, None,
-                                          ProvisionRef("(a)", 14, 17)
-                                          ),
-                             ), [
-                    ProvisionRef("(c)", 19, 22, "and_or"),
-                    ProvisionRef("(e)", 26, 29, "range"),
-                    ProvisionRef("(f)", 31, 34, "and_or",
-                                 ProvisionRef("(ii)", 34, 38),
-                                 ),
-                    ProvisionRef("(2)", 43, 46, "and_or"),
-                    ProvisionRef("(3)", 52, 55, "and_or",
-                                 ProvisionRef("(g)", 56, 59),
-                                 ),
-                    ProvisionRef("(h)", 60, 63, "and_or"),
-                ]
-            ),
-            MainProvisionRef(
-                "section",
-                ProvisionRef("32", 76, 78, None,
-                             ProvisionRef("(a)", 78, 81),
-                             ),
-            )
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_range(self):
-        result = parse_provision_refs("Section 1.2(1) to (3), (ii) — (iii), (g)- (j)")
-        self.assertEqual([
-            MainProvisionRef(
-                'Section',
-                ProvisionRef('1.2', 8, 11, None,
-                             ProvisionRef('(1)', 11, 14)),
-                             [
-                                 ProvisionRef('(3)', 18, 21, 'range'),
-                                 ProvisionRef('(ii)', 23, 27, 'and_or'),
-                                 ProvisionRef('(iii)', 30, 35, 'range'),
-                                 ProvisionRef('(g)', 37, 40, 'and_or'),
-                                 ProvisionRef('(j)', 42, 45, 'range')
-                             ]
-            )
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_range_space_before(self):
-        result = parse_provision_refs("Section 1.2(1) to (3), (ii) — (iii), (g) -(j)")
-        self.assertEqual([
-            MainProvisionRef(
-                'Section',
-                ProvisionRef('1.2', 8, 11, None,
-                             ProvisionRef('(1)', 11, 14)),
-                             [
-                                 ProvisionRef('(3)', 18, 21, 'range'),
-                                 ProvisionRef('(ii)', 23, 27, 'and_or'),
-                                 ProvisionRef('(iii)', 30, 35, 'range'),
-                                 ProvisionRef('(g)', 37, 40, 'and_or'),
-                                 ProvisionRef('(j)', 42, 45, 'range')
-                             ]
-            )
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_range_no_spaces(self):
-        result = parse_provision_refs("Section 1.2(1) to (3), (ii) — (iii), (g)-(j)")
-        self.assertEqual([
-            MainProvisionRef(
-                'Section',
-                ProvisionRef('1.2', 8, 11, None,
-                             ProvisionRef('(1)', 11, 14)),
-                             [
-                                 ProvisionRef('(3)', 18, 21, 'range'),
-                                 ProvisionRef('(ii)', 23, 27, 'and_or'),
-                                 ProvisionRef('(iii)', 30, 35, 'range'),
-                                 ProvisionRef('(g)', 37, 40, 'and_or'),
-                                 ProvisionRef('(j)', 41, 44, 'range')
-                             ]
-            )
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_mixed_afr(self):
-        result = parse_provision_refs("Afdeling 1.2(1)(a),(c) tot (e), (f)(ii) en (2), en (3)(g),(h) en afdelings 32(a)", "afr")
-        self.assertEqual([
-            MainProvisionRef(
-                "Afdeling",
-                ProvisionRef("1.2", 9, 12, None,
-                    ProvisionRef("(1)", 12, 15, None,
-                        ProvisionRef("(a)", 15, 18)
-                    ),
-                ), [
-                    ProvisionRef("(c)", 19, 22, "and_or"),
-                    ProvisionRef("(e)", 27, 30, "range"),
-                    ProvisionRef("(f)", 32, 35, "and_or",
-                        ProvisionRef("(ii)", 35, 39)),
-                    ProvisionRef("(2)", 43, 46, "and_or"),
-                    ProvisionRef("(3)", 51, 54, "and_or",
-                        ProvisionRef("(g)", 54, 57)),
-                    ProvisionRef("(h)", 58, 61, "and_or"),
-                ]
-            ),
-            MainProvisionRef(
-                "afdelings",
-                ProvisionRef("32", 75, 77, None,
-                    ProvisionRef("(a)", 77, 80),
-                ),
-            )
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_simple_fra(self):
-        result = parse_provision_refs("chapitre 1", "fra")
-        self.assertEqual([
-            MainProvisionRef('chapitre', ProvisionRef('1', 9, 10))
-        ], result.references)
-
-        result = parse_provision_refs("chapitre 1 et sous-section 2(a)", "fra")
-        self.assertEqual([
-            MainProvisionRef('chapitre', ProvisionRef('1', 9, 10)),
-            MainProvisionRef('sous-section', ProvisionRef('2', 27, 28, None,
-                                                          ProvisionRef('(a)', 28, 31)))
-        ], result.references)
-
-        result = parse_provision_refs("chapitre 32 de Loi 3 de 1999", "fra")
-        self.assertEqual([
-            MainProvisionRef('chapitre', ProvisionRef('32', 9, 11)),
-        ], result.references)
-
-    def test_mixed_fra(self):
-        result = parse_provision_refs("Chapitres 1.2(1)(a),(c) à (e), (f)(ii) et (2), et (3)(g),(h) et chapitre 32(a)", "fra")
-        self.assertEqual([
-            MainProvisionRef(
-                "Chapitres",
-                ProvisionRef("1.2", 10, 13, None,
-                             ProvisionRef("(1)", 13, 16, None,
-                                          ProvisionRef("(a)", 16, 19)
-                                          ),
-                             ), [
-                    ProvisionRef("(c)", 20, 23, "and_or"),
-                    ProvisionRef("(e)", 26, 29, "range"),
-                    ProvisionRef("(f)", 31, 34, "and_or",
-                                 ProvisionRef("(ii)", 34, 38)),
-                    ProvisionRef("(2)", 42, 45, "and_or"),
-                    ProvisionRef("(3)", 50, 53, "and_or",
-                                 ProvisionRef("(g)", 53, 56)),
-                    ProvisionRef("(h)", 57, 60, "and_or"),
-                ]
-            ),
-            MainProvisionRef(
-                "chapitre",
-                ProvisionRef("32", 73, 75, None,
-                             ProvisionRef("(a)", 75, 78),
-                             ),
-            )
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_multiple_mains(self):
-        result = parse_provision_refs("Section 2(1), section 3(b) and section 32(a)")
-        self.assertEqual([
-            MainProvisionRef('Section', ProvisionRef('2', 8, 9, None, ProvisionRef('(1)', 9, 12))),
-            MainProvisionRef('section', ProvisionRef('3', 22, 23, None, ProvisionRef('(b)', 23, 26))),
-            MainProvisionRef('section', ProvisionRef('32', 39, 41, None, ProvisionRef('(a)', 41, 44)))
-        ], result.references)
-        self.assertIsNone(result.target)
-
-        result = parse_provision_refs("Sections 26 and 31")
-        self.assertEqual([
-            MainProvisionRef('Sections', ProvisionRef('26', 9, 11)),
-            MainProvisionRef('Sections', ProvisionRef('31', 16, 18)),
-        ], result.references)
-        self.assertIsNone(result.target)
-
-        result = parse_provision_refs("Sections 26 and 31.")
-        self.assertEqual([
-            MainProvisionRef('Sections', ProvisionRef('26', 9, 11)),
-            MainProvisionRef('Sections', ProvisionRef('31', 16, 18)),
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_multiple_mains_range(self):
-        result = parse_provision_refs("Sections 26 to 31")
-        self.assertEqual([
-            MainProvisionRef('Sections', ProvisionRef('26', 9, 11)),
-            MainProvisionRef('Sections', ProvisionRef('31', 15, 17)),
-        ], result.references)
-        self.assertIsNone(result.target)
-
-        result = parse_provision_refs("Sections 26, 27 and 28 to 31")
-        self.assertEqual([
-            MainProvisionRef('Sections', ProvisionRef('26', 9, 11)),
-            MainProvisionRef('Sections', ProvisionRef('27', 13, 15)),
-            MainProvisionRef('Sections', ProvisionRef('28', 20, 22)),
-            MainProvisionRef('Sections', ProvisionRef('31', 26, 28)),
-        ], result.references)
-        self.assertIsNone(result.target)
-
-    def test_multiple_mains_target(self):
-        result = parse_provision_refs("Sections 2(1), section 3(b) and section 32(a) of another Act")
-        self.assertEqual([
-            MainProvisionRef('Sections', ProvisionRef('2', 9, 10, None, ProvisionRef('(1)', 10, 13))),
-            MainProvisionRef('section', ProvisionRef('3', 23, 24, None, ProvisionRef('(b)', 24, 27))),
-            MainProvisionRef('section', ProvisionRef('32', 40, 42, None, ProvisionRef('(a)', 42, 45)))
-        ], result.references)
-        self.assertEqual("of", result.target)
-        self.assertEqual(result.end, 49)
-
-    def test_target(self):
-        result = parse_provision_refs("Section 2 of this Act")
-        self.assertEqual("this", result.target)
-        self.assertEqual(result.end, 18)
-
-        result = parse_provision_refs("Section 2, of this Act")
-        self.assertEqual("this", result.target)
-        self.assertEqual(result.end, 19)
-
-        result = parse_provision_refs("Section 2 thereof")
-        self.assertEqual("thereof", result.target)
-        self.assertEqual(result.end, 17)
-
-        result = parse_provision_refs("Section 2, thereof and some")
-        self.assertEqual("thereof", result.target)
-        self.assertEqual(result.end, 18)
-
-        result = parse_provision_refs("Section 2 of the Act")
-        self.assertEqual("the_act", result.target)
-        self.assertEqual(result.end, 20)
-
-        result = parse_provision_refs("Section 2, of the Act with junk")
-        self.assertEqual("the_act", result.target)
-        self.assertEqual(result.end, 21)
-
-        result = parse_provision_refs("Section 2,\nof the Act with junk")
-        self.assertEqual("the_act", result.target)
-        self.assertEqual(result.end, 21)
-
-        result = parse_provision_refs("Section 2\nof the Act with junk")
-        self.assertEqual("the_act", result.target)
-        self.assertEqual(result.end, 20)
-
-    def test_target_truncated(self):
-        # the remainder of the text is wrapped in another tag
-        result = parse_provision_refs("section 26(a) of ")
-        self.assertEqual("of", result.target)
-        self.assertEqual(result.end, 17)
-
-    def test_target_afr(self):
-        result = parse_provision_refs("Afdeling 2 van hierdie Wet", "afr")
-        self.assertEqual("this", result.target)
-        self.assertEqual(result.end, 23)
-
-        result = parse_provision_refs("Afdeling 2 daarvan", "afr")
-        self.assertEqual("thereof", result.target)
-        self.assertEqual(result.end, 18)
-
-        result = parse_provision_refs("Afdeling 2 van die Wet met kak", "afr")
-        self.assertEqual("the_act", result.target)
-        self.assertEqual(result.end, 22)
-
-    def test_target_fra(self):
-        result = parse_provision_refs("Section 2 de cette loi", "fra")
-        self.assertEqual("this", result.target)
-        self.assertEqual(result.end, 19)
-
-        result = parse_provision_refs("Section 2 de ce reglement", "fra")
-        self.assertEqual("this", result.target)
-        self.assertEqual(result.end, 16)
-
-        result = parse_provision_refs("Section 2 de cela", "fra")
-        self.assertEqual("thereof", result.target)
-        self.assertEqual(result.end, 17)
-
-        result = parse_provision_refs("Section 2 de la loi mais", "fra")
-        self.assertEqual("the_act", result.target)
-        self.assertEqual(result.end, 19)

--- a/indigo/tests/test_provision_refs_grammar.py
+++ b/indigo/tests/test_provision_refs_grammar.py
@@ -1,0 +1,410 @@
+import unittest.util
+
+from django.test import TestCase
+
+from indigo.analysis.refs.provisions import ProvisionRef, parse_provision_refs, MainProvisionRef
+
+
+unittest.util._MAX_LENGTH = 999999999
+
+
+class ProvisionRefsGrammarTest(TestCase):
+    maxDiff = None
+
+    def test_single(self):
+        result = parse_provision_refs("Section 1")
+        self.assertEqual([
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("1", 8, 9)
+            )
+        ], result.references)
+        self.assertEqual(result.end, 9)
+
+        result = parse_provision_refs("paragraph (a)")
+        self.assertEqual([
+            MainProvisionRef(
+                "paragraph",
+                ProvisionRef("(a)", 10, 13)
+            )
+        ], result.references)
+
+    def test_single_whitespace(self):
+        result = parse_provision_refs("Section 1\n")
+        self.assertEqual([
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("1", 8, 9)
+            )
+        ], result.references)
+        self.assertEqual(result.end, 9)
+
+        result = parse_provision_refs("paragraph (a)\n")
+        self.assertEqual([
+            MainProvisionRef(
+                "paragraph",
+                ProvisionRef("(a)", 10, 13)
+            )
+        ], result.references)
+
+    def test_multiple_main_numbers(self):
+        result = parse_provision_refs("Section 1, 32 and 33")
+        self.assertEqual([
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("1", 8, 9)
+            ),
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("32", 11, 13)
+            ),
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("33", 18, 20)
+            )
+        ], result.references)
+        self.assertEqual(result.end, 20)
+
+        result = parse_provision_refs("paragraph (a) and subparagraph (c)")
+        self.assertEqual([
+            MainProvisionRef(
+                "paragraph",
+                ProvisionRef("(a)", 10, 13)
+            ),
+            MainProvisionRef(
+                "subparagraph",
+                ProvisionRef("(c)", 31, 34)
+            )
+        ], result.references)
+
+    def test_multiple_main(self):
+        result = parse_provision_refs("Section 1 and section 2, section 3 and chapter 4")
+        self.assertEqual([
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("1", 8, 9)
+            ),
+            MainProvisionRef(
+                "section",
+                ProvisionRef("2", 22, 23)
+            ),
+            MainProvisionRef(
+                "section",
+                ProvisionRef("3", 33, 34)
+            ),
+            MainProvisionRef(
+                "chapter",
+                ProvisionRef("4", 47, 48)
+            )
+        ], result.references)
+
+    def test_mixed(self):
+        result = parse_provision_refs("Section 1.2(1)(a),(c) to (e), (f)(ii) and (2), and (3)(g),(h) and section 32(a)")
+        self.assertEqual([
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("1.2", 8, 11, None,
+                    ProvisionRef("(1)", 11, 14, None,
+                        ProvisionRef("(a)", 14, 17)
+                    ),
+                ), [
+                    ProvisionRef("(c)", 18, 21, "and_or"),
+                    ProvisionRef("(e)", 25, 28, "range"),
+                    ProvisionRef("(f)", 30, 33, "and_or",
+                        ProvisionRef("(ii)", 33, 37),
+                    ),
+                    ProvisionRef("(2)", 42, 45, "and_or"),
+                    ProvisionRef("(3)", 51, 54, "and_or",
+                        ProvisionRef("(g)", 54, 57),
+                    ),
+                    ProvisionRef("(h)", 58, 61, "and_or"),
+                ]
+            ),
+            MainProvisionRef(
+                "section",
+                ProvisionRef("32", 74, 76, None,
+                    ProvisionRef("(a)", 76, 79),
+                ),
+            )
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_mixed_newlines(self):
+        result = parse_provision_refs("Section 1.2(1)(a),\n(c) to (e), (f)(ii)\nand (2), and (3)\n(g),(h)\nand section 32(a)\n")
+        self.assertEqual([
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("1.2", 8, 11, None,
+                             ProvisionRef("(1)", 11, 14, None,
+                                          ProvisionRef("(a)", 14, 17)
+                                          ),
+                             ), [
+                    ProvisionRef("(c)", 19, 22, "and_or"),
+                    ProvisionRef("(e)", 26, 29, "range"),
+                    ProvisionRef("(f)", 31, 34, "and_or",
+                                 ProvisionRef("(ii)", 34, 38),
+                                 ),
+                    ProvisionRef("(2)", 43, 46, "and_or"),
+                    ProvisionRef("(3)", 52, 55, "and_or",
+                                 ProvisionRef("(g)", 56, 59),
+                                 ),
+                    ProvisionRef("(h)", 60, 63, "and_or"),
+                ]
+            ),
+            MainProvisionRef(
+                "section",
+                ProvisionRef("32", 76, 78, None,
+                             ProvisionRef("(a)", 78, 81),
+                             ),
+            )
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_range(self):
+        result = parse_provision_refs("Section 1.2(1) to (3), (ii) — (iii), (g)- (j)")
+        self.assertEqual([
+            MainProvisionRef(
+                'Section',
+                ProvisionRef('1.2', 8, 11, None,
+                             ProvisionRef('(1)', 11, 14)),
+                             [
+                                 ProvisionRef('(3)', 18, 21, 'range'),
+                                 ProvisionRef('(ii)', 23, 27, 'and_or'),
+                                 ProvisionRef('(iii)', 30, 35, 'range'),
+                                 ProvisionRef('(g)', 37, 40, 'and_or'),
+                                 ProvisionRef('(j)', 42, 45, 'range')
+                             ]
+            )
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_range_space_before(self):
+        result = parse_provision_refs("Section 1.2(1) to (3), (ii) — (iii), (g) -(j)")
+        self.assertEqual([
+            MainProvisionRef(
+                'Section',
+                ProvisionRef('1.2', 8, 11, None,
+                             ProvisionRef('(1)', 11, 14)),
+                             [
+                                 ProvisionRef('(3)', 18, 21, 'range'),
+                                 ProvisionRef('(ii)', 23, 27, 'and_or'),
+                                 ProvisionRef('(iii)', 30, 35, 'range'),
+                                 ProvisionRef('(g)', 37, 40, 'and_or'),
+                                 ProvisionRef('(j)', 42, 45, 'range')
+                             ]
+            )
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_range_no_spaces(self):
+        result = parse_provision_refs("Section 1.2(1) to (3), (ii) — (iii), (g)-(j)")
+        self.assertEqual([
+            MainProvisionRef(
+                'Section',
+                ProvisionRef('1.2', 8, 11, None,
+                             ProvisionRef('(1)', 11, 14)),
+                             [
+                                 ProvisionRef('(3)', 18, 21, 'range'),
+                                 ProvisionRef('(ii)', 23, 27, 'and_or'),
+                                 ProvisionRef('(iii)', 30, 35, 'range'),
+                                 ProvisionRef('(g)', 37, 40, 'and_or'),
+                                 ProvisionRef('(j)', 41, 44, 'range')
+                             ]
+            )
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_mixed_afr(self):
+        result = parse_provision_refs("Afdeling 1.2(1)(a),(c) tot (e), (f)(ii) en (2), en (3)(g),(h) en afdelings 32(a)", "afr")
+        self.assertEqual([
+            MainProvisionRef(
+                "Afdeling",
+                ProvisionRef("1.2", 9, 12, None,
+                    ProvisionRef("(1)", 12, 15, None,
+                        ProvisionRef("(a)", 15, 18)
+                    ),
+                ), [
+                    ProvisionRef("(c)", 19, 22, "and_or"),
+                    ProvisionRef("(e)", 27, 30, "range"),
+                    ProvisionRef("(f)", 32, 35, "and_or",
+                        ProvisionRef("(ii)", 35, 39)),
+                    ProvisionRef("(2)", 43, 46, "and_or"),
+                    ProvisionRef("(3)", 51, 54, "and_or",
+                        ProvisionRef("(g)", 54, 57)),
+                    ProvisionRef("(h)", 58, 61, "and_or"),
+                ]
+            ),
+            MainProvisionRef(
+                "afdelings",
+                ProvisionRef("32", 75, 77, None,
+                    ProvisionRef("(a)", 77, 80),
+                ),
+            )
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_simple_fra(self):
+        result = parse_provision_refs("chapitre 1", "fra")
+        self.assertEqual([
+            MainProvisionRef('chapitre', ProvisionRef('1', 9, 10))
+        ], result.references)
+
+        result = parse_provision_refs("chapitre 1 et sous-section 2(a)", "fra")
+        self.assertEqual([
+            MainProvisionRef('chapitre', ProvisionRef('1', 9, 10)),
+            MainProvisionRef('sous-section', ProvisionRef('2', 27, 28, None,
+                                                          ProvisionRef('(a)', 28, 31)))
+        ], result.references)
+
+        result = parse_provision_refs("chapitre 32 de Loi 3 de 1999", "fra")
+        self.assertEqual([
+            MainProvisionRef('chapitre', ProvisionRef('32', 9, 11)),
+        ], result.references)
+
+    def test_mixed_fra(self):
+        result = parse_provision_refs("Chapitres 1.2(1)(a),(c) à (e), (f)(ii) et (2), et (3)(g),(h) et chapitre 32(a)", "fra")
+        self.assertEqual([
+            MainProvisionRef(
+                "Chapitres",
+                ProvisionRef("1.2", 10, 13, None,
+                             ProvisionRef("(1)", 13, 16, None,
+                                          ProvisionRef("(a)", 16, 19)
+                                          ),
+                             ), [
+                    ProvisionRef("(c)", 20, 23, "and_or"),
+                    ProvisionRef("(e)", 26, 29, "range"),
+                    ProvisionRef("(f)", 31, 34, "and_or",
+                                 ProvisionRef("(ii)", 34, 38)),
+                    ProvisionRef("(2)", 42, 45, "and_or"),
+                    ProvisionRef("(3)", 50, 53, "and_or",
+                                 ProvisionRef("(g)", 53, 56)),
+                    ProvisionRef("(h)", 57, 60, "and_or"),
+                ]
+            ),
+            MainProvisionRef(
+                "chapitre",
+                ProvisionRef("32", 73, 75, None,
+                             ProvisionRef("(a)", 75, 78),
+                             ),
+            )
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_multiple_mains(self):
+        result = parse_provision_refs("Section 2(1), section 3(b) and section 32(a)")
+        self.assertEqual([
+            MainProvisionRef('Section', ProvisionRef('2', 8, 9, None, ProvisionRef('(1)', 9, 12))),
+            MainProvisionRef('section', ProvisionRef('3', 22, 23, None, ProvisionRef('(b)', 23, 26))),
+            MainProvisionRef('section', ProvisionRef('32', 39, 41, None, ProvisionRef('(a)', 41, 44)))
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("Sections 26 and 31")
+        self.assertEqual([
+            MainProvisionRef('Sections', ProvisionRef('26', 9, 11)),
+            MainProvisionRef('Sections', ProvisionRef('31', 16, 18)),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("Sections 26 and 31.")
+        self.assertEqual([
+            MainProvisionRef('Sections', ProvisionRef('26', 9, 11)),
+            MainProvisionRef('Sections', ProvisionRef('31', 16, 18)),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_multiple_mains_range(self):
+        result = parse_provision_refs("Sections 26 to 31")
+        self.assertEqual([
+            MainProvisionRef('Sections', ProvisionRef('26', 9, 11)),
+            MainProvisionRef('Sections', ProvisionRef('31', 15, 17)),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("Sections 26, 27 and 28 to 31")
+        self.assertEqual([
+            MainProvisionRef('Sections', ProvisionRef('26', 9, 11)),
+            MainProvisionRef('Sections', ProvisionRef('27', 13, 15)),
+            MainProvisionRef('Sections', ProvisionRef('28', 20, 22)),
+            MainProvisionRef('Sections', ProvisionRef('31', 26, 28)),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_multiple_mains_target(self):
+        result = parse_provision_refs("Sections 2(1), section 3(b) and section 32(a) of another Act")
+        self.assertEqual([
+            MainProvisionRef('Sections', ProvisionRef('2', 9, 10, None, ProvisionRef('(1)', 10, 13))),
+            MainProvisionRef('section', ProvisionRef('3', 23, 24, None, ProvisionRef('(b)', 24, 27))),
+            MainProvisionRef('section', ProvisionRef('32', 40, 42, None, ProvisionRef('(a)', 42, 45)))
+        ], result.references)
+        self.assertEqual("of", result.target)
+        self.assertEqual(result.end, 49)
+
+    def test_target(self):
+        result = parse_provision_refs("Section 2 of this Act")
+        self.assertEqual("this", result.target)
+        self.assertEqual(result.end, 18)
+
+        result = parse_provision_refs("Section 2, of this Act")
+        self.assertEqual("this", result.target)
+        self.assertEqual(result.end, 19)
+
+        result = parse_provision_refs("Section 2 thereof")
+        self.assertEqual("thereof", result.target)
+        self.assertEqual(result.end, 17)
+
+        result = parse_provision_refs("Section 2, thereof and some")
+        self.assertEqual("thereof", result.target)
+        self.assertEqual(result.end, 18)
+
+        result = parse_provision_refs("Section 2 of the Act")
+        self.assertEqual("the_act", result.target)
+        self.assertEqual(result.end, 20)
+
+        result = parse_provision_refs("Section 2, of the Act with junk")
+        self.assertEqual("the_act", result.target)
+        self.assertEqual(result.end, 21)
+
+        result = parse_provision_refs("Section 2,\nof the Act with junk")
+        self.assertEqual("the_act", result.target)
+        self.assertEqual(result.end, 21)
+
+        result = parse_provision_refs("Section 2\nof the Act with junk")
+        self.assertEqual("the_act", result.target)
+        self.assertEqual(result.end, 20)
+
+    def test_target_truncated(self):
+        # the remainder of the text is wrapped in another tag
+        result = parse_provision_refs("section 26(a) of ")
+        self.assertEqual("of", result.target)
+        self.assertEqual(result.end, 17)
+
+    def test_target_afr(self):
+        result = parse_provision_refs("Afdeling 2 van hierdie Wet", "afr")
+        self.assertEqual("this", result.target)
+        self.assertEqual(result.end, 23)
+
+        result = parse_provision_refs("Afdeling 2 daarvan", "afr")
+        self.assertEqual("thereof", result.target)
+        self.assertEqual(result.end, 18)
+
+        result = parse_provision_refs("Afdeling 2 van die Wet met kak", "afr")
+        self.assertEqual("the_act", result.target)
+        self.assertEqual(result.end, 22)
+
+    def test_target_fra(self):
+        result = parse_provision_refs("Section 2 de cette loi", "fra")
+        self.assertEqual("this", result.target)
+        self.assertEqual(result.end, 19)
+
+        result = parse_provision_refs("Section 2 de ce reglement", "fra")
+        self.assertEqual("this", result.target)
+        self.assertEqual(result.end, 16)
+
+        result = parse_provision_refs("Section 2 de cela", "fra")
+        self.assertEqual("thereof", result.target)
+        self.assertEqual(result.end, 17)
+
+        result = parse_provision_refs("Section 2 de la loi mais", "fra")
+        self.assertEqual("the_act", result.target)
+        self.assertEqual(result.end, 19)


### PR DESCRIPTION
* make provision refs grammar choose different parse trees based on the current language; this means that only one language is used when parsing, so languages can have terms that clash
* add basics of French provision lookups