### PR TITLE
fall back to today when a document is ready to import

### DIFF
--- a/indigo/tasks.py
+++ b/indigo/tasks.py
@@ -9,6 +9,7 @@ class TaskBroker:
         # the works, filtered
         self.works, self.ignored_works = self.get_works_and_ignored_works(works)
         self.import_task_works = self.works.filter(principal=True)
+        self.missing_import_date_works = [w for w in self.import_task_works if not w.get_import_date()]
         self.gazette_task_works = [w for w in self.works if not w.has_publication_document()]
         all_amendments = [w.amendments.all() for w in works if w.amendments.exists()] + \
                          [w.amendments_made.all() for w in works if w.amendments_made.exists()]

--- a/indigo_api/models/tasks.py
+++ b/indigo_api/models/tasks.py
@@ -393,7 +393,7 @@ class Task(models.Model):
         # create the document
         document = Document()
         document.work = self.work
-        document.expression_date = self.timeline_date or self.work.get_import_date()
+        document.expression_date = self.timeline_date or self.work.get_import_date() or datetime.date.today()
         document.language = self.country.primary_language
         document.created_by_user = user
         document.save()

--- a/indigo_api/models/tasks.py
+++ b/indigo_api/models/tasks.py
@@ -392,15 +392,17 @@ class Task(models.Model):
     def create_and_import_document(self, user):
         # create the document
         document = Document()
+        import_date = self.work.get_import_date()
         document.work = self.work
-        document.expression_date = self.timeline_date or self.work.get_import_date() or datetime.date.today()
+        document.expression_date = self.timeline_date or import_date or datetime.date.today()
         document.language = self.country.primary_language
         document.created_by_user = user
         document.save()
 
-        # link it to the related import task
+        # link it to the related import task (only if the work has an import date)
         import_task = Task.objects.filter(work=self.work, code='import-content',
-                                          timeline_date=self.timeline_date or self.work.get_import_date()).first()
+                                          timeline_date=self.timeline_date or self.work.get_import_date()).first() \
+            if import_date else None
         if import_task:
             import_task.document = document
             import_task.save()

--- a/indigo_app/templates/indigo_app/place/_bulk_approve_form.html
+++ b/indigo_app/templates/indigo_app/place/_bulk_approve_form.html
@@ -23,7 +23,7 @@
         {% for work in form.broker.works %}
           <input type="hidden" name="works" value="{{ work.pk }}">
         {% endfor %}
-        {% if form.broker.works  %}
+        {% if form.broker.works %}
           <div class="alert alert-warning">
             <ul>
               {% for work in form.broker.works %}
@@ -62,8 +62,15 @@
                 <ul>
                   {% for work in form.broker.import_task_works %}
                     <li>
+                      {% if work in form.broker.missing_import_date_works %}
+                        <i class="fas fa-exclamation-triangle text-warning"></i>
+                      {% endif %}
                       <a target="_blank" href="{% url 'work' work.frbr_uri %}">{{ work.title }}</a>
                       <span class="text-muted">{{ work.frbr_uri }}</span>
+                      {% if work in form.broker.missing_import_date_works %}
+                        <i class="fas fa-exclamation-triangle text-warning"></i>
+                        <span class="alert alert-danger p-1">{% trans "Import date missing – add a publication date or a consolidation date" %}</span>
+                      {% endif %}
                     </li>
                   {% endfor %}
                 </ul>


### PR DESCRIPTION
fixes https://github.com/laws-africa/indigo/issues/2135

should the query we do a few lines down also use `today`, or should it not include the timeline date in the filter if it's going to be done, and then find the most recent task instead?