### PR TITLE
don't use the latest version of django-allauth just yet

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'django-ckeditor>=5.8',
         'dj-database-url>=0.3.0',
         'django-activity-stream>=0.10.0',
-        'django-allauth[socialaccount]>=0.62.0',
+        'django-allauth[socialaccount]>=0.62.0,<64.0.0',
         'django-background-tasks>=1.2.5',
         'django-compressor>=3.1,<=4.4',
         'django-cors-headers>=3.11.0',


### PR DESCRIPTION
https://docs.allauth.org/en/latest/release-notes/recent.html#backwards-incompatible-changes

> Dropped support for Django 3.2, 4.0 and 4.1 (which all reached end of life). As Django 3.2 was the last to support Python 3.7, support for Python 3.7 is now dropped as well.

