### PR TITLE
publish the work title of a document separately to the expression title

### DIFF
--- a/indigo_content_api/tests/v2/test_content_api.py
+++ b/indigo_content_api/tests/v2/test_content_api.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from rest_framework.test import APITestCase
 
 from indigo_api.exporters import PDFExporter
-from indigo_api.models import Country, Language
+from indigo_api.models import Country, Language, Work
 from indigo_app.tests.utils import TEST_STORAGES
 from languages_plus.models import Language as MasterLanguage
 
@@ -59,6 +59,15 @@ class ContentAPIV2TestMixin:
         response = self.client.get(self.api_path + '/akn/za/act/2014/10')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['numbered_title'], 'Act 10 of 2014')
+
+    def test_published_work_title(self):
+        work = Work.objects.get(frbr_uri='/akn/za/act/2014/10')
+        work.title = 'Work title'
+        work.save()
+        response = self.client.get(self.api_path + '/akn/za/act/2014/10')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['work_title'], 'Work title')
+        self.assertEqual(response.data['title'], 'Watêr Act')
 
     def test_published_type_name(self):
         response = self.client.get(self.api_path + '/akn/za/act/2014/10')

--- a/indigo_content_api/v2/serializers.py
+++ b/indigo_content_api/v2/serializers.py
@@ -208,6 +208,8 @@ class PointInTimeSerializer(serializers.Serializer):
 @extend_schema_serializer(component_name="WorkExpression")
 class PublishedDocumentSerializer(DocumentSerializer, PublishedDocUrlMixin):
     """ Details of a published work expression (document). """
+    work_title = serializers.CharField(help_text="Title of the work, which may be different to the title of the expression.",
+                                       source="work.title")
     country = serializers.CharField(help_text="ISO 3166-1 alpha-2 country code that this work belongs to.")
     locality = serializers.CharField(help_text="The code of the locality within the country.", required=False)
     nature = serializers.CharField(help_text="Doctype component of the work FRBR URI.")
@@ -243,7 +245,7 @@ class PublishedDocumentSerializer(DocumentSerializer, PublishedDocUrlMixin):
     class Meta:
         model = Document
         fields = (
-            'url', 'title',
+            'url', 'title', 'work_title',
             'created_at', 'updated_at',
 
             # frbr_uri components


### PR DESCRIPTION
This is useful when the expression and the work have different titles, either for historical reasons or due to language variants.