### PR TITLE
citator mustn't match subtypes mid-word, or lowercase

### DIFF
--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -142,7 +142,7 @@ class SubtypeNumberCitationMatcherENG(DocumentPatternMatcherMixin, CitationMatch
     def setup_subtypes(self):
         self.subtypes = [s for s in Subtype.objects.all()]
         subtype_names = [s.name for s in self.subtypes]
-        subtype_abbreviations = [s.abbreviation for s in self.subtypes]
+        subtype_abbreviations = [s.abbreviation.upper() for s in self.subtypes]
 
         # sort, longest first
         subtypes = sorted(subtype_names + subtype_abbreviations, key=len, reverse=True)
@@ -160,13 +160,13 @@ class SubtypeNumberCitationMatcherENG(DocumentPatternMatcherMixin, CitationMatch
         self.pattern_re = re.compile(
             fr'''
                 (?P<ref>
-                    (?P<subtype>{subtypes_string})\s*
-                    (No\.?\s*)?
+                    \b(?P<subtype>{subtypes_string})\s*
+                    ([nN]o\.?\s*)?
                     (?P<num>[a-z0-9-]+)
                     (\s+of\s+|/)
                     (?P<year>\d{{4}})
                 )
-            ''', re.X | re.I)
+            ''', re.X)
 
     def extract_paged_text_matches(self):
         # don't do anything if there are no subtypes

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -35,6 +35,7 @@ class RefsFinderSubtypesENGTestCase(TestCase):
               <p>And another thing about SI 4a of 1998.</p>
               <p>don't match lowercase gn no 102 of 2012.</p>
               <p>don't match where it's at the end of somethign no 102 of 2012.</p>
+              <p>don't match where it's at the end of somethiGN no 102 of 2012.</p>
             </content>
           </paragraph>
         </section>"""
@@ -54,6 +55,7 @@ class RefsFinderSubtypesENGTestCase(TestCase):
               <p>And another thing about <ref href="/akn/za/act/si/1998/4a">SI 4a of 1998</ref>.</p>
               <p>don't match lowercase gn no 102 of 2012.</p>
               <p>don't match where it's at the end of somethign no 102 of 2012.</p>
+              <p>don't match where it's at the end of somethiGN no 102 of 2012.</p>
             </content>
           </paragraph>
         </section>"""

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -33,6 +33,8 @@ class RefsFinderSubtypesENGTestCase(TestCase):
             <content>
               <p>Something to do with GN no 102 of 2012.</p>
               <p>And another thing about SI 4a of 1998.</p>
+              <p>don't match lowercase gn no 102 of 2012.</p>
+              <p>don't match where it's at the end of somethign no 102 of 2012.</p>
             </content>
           </paragraph>
         </section>"""
@@ -50,6 +52,8 @@ class RefsFinderSubtypesENGTestCase(TestCase):
             <content>
               <p>Something to do with <ref href="/akn/za/act/gn/2012/102">GN no 102 of 2012</ref>.</p>
               <p>And another thing about <ref href="/akn/za/act/si/1998/4a">SI 4a of 1998</ref>.</p>
+              <p>don't match lowercase gn no 102 of 2012.</p>
+              <p>don't match where it's at the end of somethign no 102 of 2012.</p>
             </content>
           </paragraph>
         </section>"""


### PR DESCRIPTION
otherwise application 2 of 2022 is match as "on 2 of 2022"

fixes https://github.com/laws-africa/indigo/issues/2253