### PR TITLE
don't default to a language in the content api

### DIFF
--- a/indigo_content_api/tests/v2/test_content_api.py
+++ b/indigo_content_api/tests/v2/test_content_api.py
@@ -465,19 +465,19 @@ class ContentAPIV2TestMixin:
         links.sort(key=lambda k: k['title'])
 
         self.assertEqual(links, [
-            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng.xml',
+            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng@2001-10-01.xml',
              'mediaType': 'application/xml', 'rel': 'alternate', 'title': 'Akoma Ntoso'},
-            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng.html', 'mediaType': 'text/html',
+            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng@2001-10-01.html', 'mediaType': 'text/html',
              'rel': 'alternate', 'title': 'HTML'},
-            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng/media.json',
+            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng@2001-10-01/media.json',
              'mediaType': 'application/json', 'rel': 'media', 'title': 'Media'},
-            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng.pdf',
+            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng@2001-10-01.pdf',
              'mediaType': 'application/pdf', 'rel': 'alternate', 'title': 'PDF'},
-            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng.html?standalone=1',
+            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng@2001-10-01.html?standalone=1',
              'mediaType': 'text/html', 'rel': 'alternate', 'title': 'Standalone HTML'},
-            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng/toc.json',
+            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng@2001-10-01/toc.json',
              'mediaType': 'application/json', 'rel': 'toc', 'title': 'Table of Contents'},
-            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng.epub',
+            {'href': 'http://' + self.api_host + self.api_path + '/akn/za/act/2001/8/eng@2001-10-01.epub',
              'mediaType': 'application/epub+zip', 'rel': 'alternate', 'title': 'ePUB'},
         ])
 

--- a/indigo_content_api/tests/v2/test_content_api.py
+++ b/indigo_content_api/tests/v2/test_content_api.py
@@ -735,6 +735,10 @@ class ContentAPIV2TestMixin:
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(0, response.json()['count'])
 
+        response = self.client.get(self.api_path + '/akn/za/act/2014/10/.json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual("/akn/za/act/2014/10/eng@2014-02-12", response.json()['expression_frbr_uri'])
+
 
 @override_settings(STORAGES=TEST_STORAGES)
 class ContentAPIV2Test(ContentAPIV2TestMixin, APITestCase):

--- a/indigo_content_api/v2/views.py
+++ b/indigo_content_api/v2/views.py
@@ -68,15 +68,12 @@ class FrbrUriViewMixin(PlaceAPIBase):
         self.frbr_uri = self.parse_frbr_uri(self.kwargs['frbr_uri'])
 
     def parse_frbr_uri(self, frbr_uri):
+        # clear the default language so that we don't get an erroneous language if it hasn't been specified in the url
         FrbrUri.default_language = None
         try:
             frbr_uri = FrbrUri.parse(frbr_uri)
         except ValueError:
             return None
-
-        frbr_uri.default_language = self.country.primary_language.code
-        if not frbr_uri.language:
-            frbr_uri.language = frbr_uri.default_language
 
         return frbr_uri
 
@@ -213,7 +210,7 @@ class PublishedDocumentDetailView(DocumentViewMixin,
                 serializer = self.get_serializer(document)
                 # use the request URI as the basis for this document
                 serializer.context['url'] = serializer.published_doc_url(
-                    document, request, frbr_uri=self.frbr_uri.expression_uri()
+                    document, request, frbr_uri=document.expression_frbr_uri
                 )
                 return Response(serializer.data)
 


### PR DESCRIPTION
if the FRBR URI doesn't have a language, we should just try to find any document, and then consistently and unambiguously use that in the response.

Otherwise, if the default language in a country is `fra` and (for some reason) we only have an `eng` expression, then using the content API without a language gives us a 404, rather than just finding an expression with any language.

Fixes #2261 