### PR TITLE
ensure subtype has whitespace after it when matching

### DIFF
--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -160,7 +160,7 @@ class SubtypeNumberCitationMatcherENG(DocumentPatternMatcherMixin, CitationMatch
         self.pattern_re = re.compile(
             fr'''
                 (?P<ref>
-                    \b(?P<subtype>{subtypes_string})\s*
+                    \b(?P<subtype>{subtypes_string})\s+
                     ([nN]o\.?\s*)?
                     (?P<num>[a-zA-Z0-9-]+)
                     (\s+of\s+|/)

--- a/indigo/tests/test_refs.py
+++ b/indigo/tests/test_refs.py
@@ -37,6 +37,7 @@ class RefsFinderSubtypesENGTestCase(TestCase):
               <p>don't match lowercase gn no 102 of 2012.</p>
               <p>don't match where it's at the end of somethign no 102 of 2012.</p>
               <p>don't match where it's at the end of somethiGN no 102 of 2012.</p>
+              <p>don't match on Proclamations of 2012</p>
             </content>
           </paragraph>
         </section>"""
@@ -58,6 +59,7 @@ class RefsFinderSubtypesENGTestCase(TestCase):
               <p>don't match lowercase gn no 102 of 2012.</p>
               <p>don't match where it's at the end of somethign no 102 of 2012.</p>
               <p>don't match where it's at the end of somethiGN no 102 of 2012.</p>
+              <p>don't match on Proclamations of 2012</p>
             </content>
           </paragraph>
         </section>"""


### PR DESCRIPTION
Fixes #2295