### PR TITLE
Client-side bluebell parsing with pyodide

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -169,6 +169,9 @@ INDIGO = {
     'LINK_REFERENCES_PLUGINS': [
         'refs-act-numbers', 'refs-act-names', 'refs-subtype-numbers', 'refs-aliases', 'refs-cap', 'internal-refs'
     ],
+
+    # should we use pyodide to parse documents on the client?
+    'USE_PYODIDE': True,
 }
 
 # Database

--- a/indigo_app/static/javascript/indigo/views/bluebell.js
+++ b/indigo_app/static/javascript/indigo/views/bluebell.js
@@ -1,0 +1,99 @@
+/**
+ * Parses bluebell text into Akoma Ntoso XML.
+ *
+ * Either uses pyodide to run the python code in the browser, or sends the text to the server to be parsed.
+ */
+class BluebellParser {
+  constructor (url, headers) {
+    this.url = url;
+    this.headers = headers;
+    this.pyodide = null;
+    // python dependencies
+    this.packages = [
+      "lxml",
+      "https://files.pythonhosted.org/packages/6c/0c/f37b6a241f0759b7653ffa7213889d89ad49a2b76eb2ddf3b57b2738c347/iso8601-2.1.0-py3-none-any.whl",
+      "https://files.pythonhosted.org/packages/15/83/d5be80b572064329066b8738e91f6b8dd42712007ae0c13e5e8911cdb1b0/cobalt-9.0.1-py3-none-any.whl",
+      "https://files.pythonhosted.org/packages/c2/92/10103079d1ed56a950235ca23399d6a5bd3a38ea7d0c6c17b67e1dbc2abe/bluebell_akn-3.1.0-py3-none-any.whl",
+    ]
+    this.pyBootstrap = `
+from bluebell.parser import AkomaNtosoParser
+from cobalt import FrbrUri
+from cobalt.akn import AKN_NAMESPACES, DEFAULT_VERSION
+from lxml import etree
+
+def parseBluebellText(text, frbr_uri, fragment, eid_prefix):
+    # see indigo.pipelines.base.ParseBluebellText for context
+    frbr_uri = FrbrUri.parse(frbr_uri)
+    frbr_uri.work_component = 'main'
+    root = fragment or frbr_uri.doctype
+
+    parser = AkomaNtosoParser(frbr_uri, eid_prefix or '')
+    xml = parser.parse_to_xml(text, root)
+
+    if fragment:
+        # fragment must be wrapped in AKN tags
+        xml = etree.tostring(xml, encoding='unicode')
+        ns = AKN_NAMESPACES[DEFAULT_VERSION]
+        xml = f'<akomaNtoso xmlns="{ns}">{xml}</akomaNtoso>'
+        return xml
+            
+    return etree.tostring(xml, encoding='unicode')
+`;
+  }
+
+  async setup () {
+    // TODO: where does this come from?
+    let pyodide = await loadPyodide();
+
+    //await pyodide.loadPackage("micropip");
+    //micropip = pyodide.pyimport("micropip");
+    //await micropip.install('bluebell-akn');
+
+    await pyodide.loadPackage(this.packages);
+    pyodide.runPython(this.pyBootstrap);
+
+    this.pyodide = pyodide;
+  }
+
+  async parse (text, frbr_uri, fragment, eidPrefix) {
+    if (this.pyodide) {
+      return this.parseWithPyodide(text, frbr_uri, fragment, eidPrefix);
+    } else {
+      return this.parseWithServer(text, frbr_uri, fragment, eidPrefix);
+    }
+  }
+
+  async parseWithPyodide (text, frbr_uri, fragment, eidPrefix) {
+    return this.pyodide.globals.get('parseBluebellText')(text, frbr_uri, fragment, eidPrefix);
+  }
+
+  async parseWithServer (text, frbr_uri, fragment, eidPrefix) {
+    const body = {
+      content: text,
+    };
+
+    if (fragment) {
+      body.fragment = fragment;
+    }
+
+    if (eidPrefix) {
+      body.id_prefix = eidPrefix;
+    }
+
+    const resp = await fetch(this.url, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify(body),
+    });
+
+    if (resp.ok) {
+      return (await resp.json()).output;
+    } else if (resp.status === 400) {
+      throw (await resp.json()).content || resp.statusText;
+    } else {
+      throw resp.statusText;
+    }
+  }
+}
+
+Indigo.BluebellParser = BluebellParser;

--- a/indigo_app/static/javascript/indigo/views/document_xml_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_xml_editor.js
@@ -22,6 +22,14 @@ class AknTextEditor {
 
     this.setupMonacoEditor();
     this.setupToolbar();
+    this.bluebellParser = new Indigo.BluebellParser(
+      this.document.url() + '/parse',
+      {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-CSRFToken': Indigo.csrfToken,
+      }
+    );
+    this.bluebellParser.setup();
   }
 
   setupMonacoEditor () {
@@ -102,41 +110,34 @@ class AknTextEditor {
 
     const fragmentRule = this.document.tradition().grammarRule(this.xmlElement);
     const eId = this.xmlElement.getAttribute('eId');
-    const body = {
-      'content': this.monacoEditor.getValue()
-    };
+    let fragment = null;
+    let eidPrefix = null;
 
     if (fragmentRule !== 'akomaNtoso') {
-      body.fragment = fragmentRule;
+      fragment = fragmentRule;
       if (eId && eId.lastIndexOf('__') > -1) {
         // retain the eId of the parent element as the prefix
-        body.id_prefix = eId.substring(0, eId.lastIndexOf('__'));
+        eidPrefix = eId.substring(0, eId.lastIndexOf('__'));
       }
     }
 
-    const resp = await fetch(this.document.url() + '/parse', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8',
-        'X-CSRFToken': Indigo.csrfToken,
-      },
-      body: JSON.stringify(body),
-    });
+    try {
+      const xml = await this.bluebellParser.parse(
+        text,
+        this.document.get('expression_frbr_uri'),
+        fragment,
+        eidPrefix,
+      );
 
-    if (resp.ok) {
-      const xml = (await resp.json()).output;
       let newElement = $.parseXML(xml);
-
       if (fragmentRule === 'akomaNtoso') {
         // entire document
         return [newElement.documentElement];
       } else {
         return newElement.documentElement.children;
       }
-    } else if (resp.status === 400) {
-      Indigo.errorView.show((await resp.json()).content || resp.statusText);
-    } else {
-      Indigo.errorView.show(resp.statusText);
+    } catch (e) {
+      Indigo.errorView.show(e);
     }
 
     return null;

--- a/indigo_app/templates/indigo_api/document/show.html
+++ b/indigo_app/templates/indigo_api/document/show.html
@@ -134,11 +134,16 @@
   window.Indigo.Preloads.documentContent = {{ document_content_json|safe }};
   window.Indigo.Preloads.amendments = {{ amendments_json|safe }};
   window.Indigo.Preloads.expressions = {{ expressions_json|safe }};
+  {% if pyodide_packages_json %}
+    window.Indigo.pyodide_packages = {{ pyodide_packages_json|safe }};
+  {% endif %}
 
   CKEDITOR_BASEPATH = '/static/ckeditor/';
   </script>
 
-  <script src="https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide.js"></script>
+  {% if pyodide_packages_json %}
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide.js"></script>
+  {% endif %}
   <script type="text/javascript" src="{% static 'ckeditor/ckeditor.js' %}"></script>
   <script src="{% static 'javascript/monaco/monaco.js' %}"></script>
   <script id="breadcrumb-template" type="text/x-handlebars-template">

--- a/indigo_app/templates/indigo_api/document/show.html
+++ b/indigo_app/templates/indigo_api/document/show.html
@@ -138,6 +138,7 @@
   CKEDITOR_BASEPATH = '/static/ckeditor/';
   </script>
 
+  <script src="https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide.js"></script>
   <script type="text/javascript" src="{% static 'ckeditor/ckeditor.js' %}"></script>
   <script src="{% static 'javascript/monaco/monaco.js' %}"></script>
   <script id="breadcrumb-template" type="text/x-handlebars-template">

--- a/indigo_app/views/documents.py
+++ b/indigo_app/views/documents.py
@@ -1,8 +1,11 @@
 import json
 
+from django.conf import settings
 from django.views.generic import DetailView
 from django.http import Http404
 from django.urls import reverse
+import bluebell
+import cobalt
 
 from indigo.plugins import plugins
 from indigo_api.models import Document, Country, Subtype, Work
@@ -73,6 +76,12 @@ class DocumentDetailView(AbstractAuthedIndigoView, DetailView):
             'title': r.title
         } for r in DocumentViewSet.renderer_classes if hasattr(r, 'icon')]
         context['download_formats'].sort(key=lambda f: f['title'])
+
+        if settings.INDIGO['USE_PYODIDE']:
+            context['pyodide_packages_json'] = json.dumps([
+                f'cobalt=={cobalt.__version__}',
+                f'bluebell-akn=={bluebell.__version__}',
+            ])
 
         return context
 


### PR DESCRIPTION
Optionally use pyodide to run bluebell in the client. This is about 3 times faster (especially for large documents) than going to the server and parsing.

Note that pyodide has lxml >= 5 built in, but currently we use lxml < 5 on the server. This doesn't impact bluebell but we should align them just to be safe.
