### PR TITLE
prevent long lines of non-breakable content overflowing

### DIFF
--- a/indigo_app/static/stylesheets/_akn.scss
+++ b/indigo_app/static/stylesheets/_akn.scss
@@ -43,3 +43,8 @@ la-akoma-ntoso .akn-remark {
 la-akoma-ntoso[frbr-country="na"] .akn-remark {
   background-color: inherit;
 }
+
+la-akoma-ntoso {
+  // prevent long lines of dots and other things that would not normally be broken from overflowing the content box
+  word-break: break-word;
+}


### PR DESCRIPTION
the document area

see https://developer.mozilla.org/en-US/docs/Web/CSS/word-break#break-word

before:

![image](https://github.com/user-attachments/assets/78706151-9596-496f-87f0-9909349df1cc)



after:

![image](https://github.com/user-attachments/assets/25a97e91-917f-4a7b-941d-0265b8080e32)
