### PR TITLE
default to title when there's no numbered title for an amending work

### DIFF
--- a/indigo_app/views/documents.py
+++ b/indigo_app/views/documents.py
@@ -60,7 +60,7 @@ class DocumentDetailView(AbstractAuthedIndigoView, DetailView):
         if plugin:
             for a in amendments:
                 amending_work = Work.objects.get(frbr_uri=a['amending_work']['frbr_uri'])
-                a['amending_work']['numbered_title_localised'] = plugin.work_numbered_title(amending_work)
+                a['amending_work']['numbered_title_localised'] = plugin.work_numbered_title(amending_work) or amending_work.title
         context['amendments_json'] = json.dumps(amendments)
 
         context['form'] = DocumentForm(instance=doc)


### PR DESCRIPTION
avoids getting 'null' as the linked text.

Before:
<img width="833" alt="image" src="https://github.com/user-attachments/assets/f2031178-a582-4ac5-9b5e-78a557bb0a24" />

After:
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/156e28e1-fc3e-4652-9627-8ff1ec528f5d" />
