### PR TITLE
check parentNode, parentElement (null when editing Entire document)

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -142,7 +142,7 @@
         if (elements.length) {
           this.onTextElementParsed(elements);
           this.closeTextEditor();
-        } else if (this.xmlElement.parentElement.tagName === 'portionBody') {
+        } else if (this.xmlElement.parentNode.tagName === 'portionBody') {
           alert($t('You cannot delete the whole provision in provision editing mode.'));
         } else if (confirm($t('Go ahead and delete this provision from the document?'))) {
           this.parent.removeFragment(this.editingXmlElement);

--- a/indigo_app/static/javascript/indigo/views/document_xml_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_xml_editor.js
@@ -136,7 +136,7 @@ class AknTextEditor {
       let newElement = $.parseXML(xml);
 
       // if the top-level eId changed in provision mode, reload the page when saving later (just set the flag here)
-      if (this.xmlElement.parentElement.tagName === 'portionBody') {
+      if (this.xmlElement.parentNode.tagName === 'portionBody') {
         // set it back to false if the eId is changed back before saving too
         this.reloadOnSave = newElement.firstChild.firstChild.getAttribute('eId') !== Indigo.Preloads.provisionEid;
       }


### PR DESCRIPTION
fixes a bug where we can't edit the whole document:
![image](https://github.com/user-attachments/assets/d77dd896-dddd-4e8a-90c7-94424b3dae3d)
