### PR TITLE
Better re-rendering on quick-edit

### DIFF
--- a/indigo_app/static/javascript/indigo/models.js
+++ b/indigo_app/static/javascript/indigo/models.js
@@ -84,8 +84,7 @@
           return 'replaced';
         }
 
-        const ownerDocument = target.nodeType === Node.DOCUMENT_NODE ? target : target.ownerDocument;
-        if (!ownerDocument.contains(element)) {
+        if (!this.xmlDocument.contains(element)) {
           // the change removed xmlElement from the tree
           return 'removed';
         }
@@ -182,6 +181,11 @@
       }
       var del = !newNodes;
       var first = del ? null : newNodes[0];
+
+      if (oldNode && !this.xmlDocument.contains(oldNode)) {
+        console.log('Old node is not in the document');
+        return;
+      }
 
       if (!oldNode || !oldNode.parentElement) {
         if (del) {

--- a/indigo_app/static/javascript/indigo/models.js
+++ b/indigo_app/static/javascript/indigo/models.js
@@ -193,12 +193,14 @@
           throw "Expected exactly one newNode, got " + newNodes.length;
         }
         this.xmlDocument.adoptNode(first);
+        // mutation record will have both add and remove in one record (a replace)
         this.xmlDocument.documentElement.replaceWith(first);
 
       } else {
         if (del) {
           // delete this node
           console.log('Deleting node');
+          // mutation record will have a remove
           oldNode.remove();
 
         } else {
@@ -206,6 +208,7 @@
           console.log('Replacing node with ' + newNodes.length + ' new node(s)');
 
           oldNode.ownerDocument.adoptNode(first);
+          // mutation record will have both add and remove in one record (a replace)
           oldNode.parentElement.replaceChild(first, oldNode);
 
           // now append the other nodes, starting at the end
@@ -215,8 +218,10 @@
             first.ownerDocument.adoptNode(node);
 
             if (first.nextElementSibling) {
+              // mutation record will have an add
               first.parentElement.insertBefore(node, first.nextElementSibling);
             } else {
+              // mutation record will have an add
               first.parentElement.appendChild(node);
             }
           }

--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -192,7 +192,7 @@
      * @param mutation a MutationRecord object
      */
     onDomMutated: function(model, mutation) {
-      let eid = mutation.target?.getAttribute('eId');
+      let eid = mutation.target.getAttribute ? mutation.target.getAttribute('eId') : null;
 
       switch (model.getMutationImpact(mutation, this.xmlElement)) {
         case 'replaced':

--- a/indigo_app/static/javascript/indigo/views/document_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_editor.js
@@ -214,7 +214,7 @@
                   // it was replaced but retained the eid
                   eid = this.quickEditEid;
                 } else {
-                  // it was replaced with a different eId; re-render the target but track the new eid
+                  // it was replaced with a different eid; re-render the target but track the new eid
                   this.quickEditEid = mutation.addedNodes[0].getAttribute('eId');
                 }
               } else {
@@ -297,7 +297,7 @@
         oldElement = null;
       }
 
-      // ensure the rendered is ready
+      // ensure the renderer is ready
       await Indigo.deferredToAsync(this.htmlRenderer.ready);
 
       const html = this.htmlRenderer.renderXmlElement(this.document, toRender);

--- a/indigo_app/static/javascript/indigo/views/document_xml_editor.js
+++ b/indigo_app/static/javascript/indigo/views/document_xml_editor.js
@@ -265,7 +265,6 @@ class AknTextEditor {
         // remove element
         this.document.content.replaceNode(this.xmlElement, null);
       }
-
     }
   }
 


### PR DESCRIPTION
* This saves us from re-rendering an entire document when quick editing just a portion.
* renderCoverpage uses async

In the common case of a quick-edit without an eid change, the quick-edited element is replaced.

In the other case where the eid changes or for some reason another portion of the tree changes, then the target of the mutation (If chp_1__sec_1 is quick edited, then the mutation target will be chp_1) is re-rendered.

This also fixes a bug where changing the eid and then deleting the portion would nuke the whole document.

https://www.loom.com/share/a64501a5e30d4118a3f12b3bf90d80d9