### PR TITLE
latest docpipe, use alias and title refs matchers

### DIFF
--- a/indigo/analysis/refs/__init__.py
+++ b/indigo/analysis/refs/__init__.py
@@ -1,2 +1,3 @@
 import indigo.analysis.refs.base  # noqa
 import indigo.analysis.refs.provisions  # noqa
+import indigo.analysis.refs.works  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "django-treebeard>=4.5.1",
     "djangorestframework-xml>=1.3.0",
     "djangorestframework>=3.15.0",
-    "docpipe @ git+https://github.com/laws-africa/docpipe@78850974709df154fd2f9ddd318598a644250a74",
+    "docpipe @ git+https://github.com/laws-africa/docpipe@07533f5e4cc5cf54aba680018903ee2584b73608",
     "drf-spectacular==0.27.2",
     "EbookLib>=0.15",
     "google-api-python-client>=1.7.9",


### PR DESCRIPTION
* latest docpipe (which fixes `)` at end of refs)
* correctly import plugins for common work titles