### PR TITLE
if pyodide fails, then parse with the server

### DIFF
--- a/indigo_app/static/javascript/indigo/views/bluebell.js
+++ b/indigo_app/static/javascript/indigo/views/bluebell.js
@@ -63,10 +63,14 @@ def parseBluebellText(text, frbr_uri, fragment, eid_prefix):
 
   async parse (text, frbr_uri, fragment, eidPrefix) {
     if (this.pyodide) {
-      return this.parseWithPyodide(text, frbr_uri, fragment, eidPrefix);
-    } else {
-      return this.parseWithServer(text, frbr_uri, fragment, eidPrefix);
+      try {
+        return await this.parseWithPyodide(text, frbr_uri, fragment, eidPrefix);
+      } catch (e) {
+        console.error('Error parsing with pyodide, will fall back to server:', e);
+      }
     }
+
+    return await this.parseWithServer(text, frbr_uri, fragment, eidPrefix);
   }
 
   async parseWithPyodide (text, frbr_uri, fragment, eidPrefix) {


### PR DESCRIPTION
This will handle an unexpected failure in python (eg. a memory error) by falling back to server-side parsing.

If the parse fails because the grammar is not matched, it's still shown as an error.