### PR TITLE
Handle refs to schedules

### DIFF
--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -7,18 +7,29 @@ grammar ProvisionRefs
 
   root        <- references (to_and_or references)* target? tail %root
 
+  references  <- attachment_ref / unit_refs
+
+  attachment_ref <- attachment_num_ref / the_attachment_ref
+
+                 # Schedule 1
+                 # Schedule 1A
+  attachment_num_ref <- "Schedule" WS+ main_num %attachment_num_ref
+
+  # TODO: the First Schedule etc.
+  the_attachment_ref <- "the Schedule" ![a-zA-Z] %the_attachment_ref
+
                  # section 32
                  # section (a)
                  # section 32(a)(c)
                  # section 32.1a.2
-  references  <- unit__i18n WS+ main_ref (to_and_or main_ref)* %references
+  unit_refs    <- unit__i18n WS+ main_ref (to_and_or main_ref)* %unit_refs
 
   main_ref    <- (main_num / num) (WS* sub_refs)? %main_ref
 
                  # section 32
                  # section 32A
                  # section 32.1a.2
-  main_num    <- digit alpha_num_dot* %main_num
+  main_num    <- digit alpha_num_no_trailing_dot* %main_num
 
                  # (a)(ii) to (iv)
                  # (a), (b) and (f)(ii)
@@ -176,4 +187,5 @@ grammar ProvisionRefs
   comma       <- [,;]
   digit       <- [0-9]
   alpha_num_dot <- [a-zA-Z0-9.-]
+  alpha_num_no_trailing_dot <- [a-zA-Z0-9-] / ('.' [a-zA-Z0-9])
   WS          <- " " / "\t" / "\n"

--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -24,7 +24,7 @@ grammar ProvisionRefs
                  # section (a)
                  # section 32(a)(c)
                  # section 32.1a.2
-  unit_refs    <- unit__i18n WS+ main_ref (to_and_or main_ref)* %unit_refs
+  unit_refs   <- unit__i18n WS+ main_ref (to_and_or main_ref)* %unit_refs
 
   main_ref    <- (main_num / num) (WS* sub_refs)? %main_ref
 

--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -13,8 +13,8 @@ grammar ProvisionRefs
 
                  # Schedule 1
                  # Schedule 1A
-                 # TODO: Schedule 1 and 2
-  attachment_num_ref <- schedule__i18n WS+ main_num %attachment_num_ref
+                 # Schedule 1 and 2
+  attachment_num_ref <- schedule__i18n WS+ main_num (to_and_or main_num)* %attachment_num_ref
 
                  # the Schedule
                  # TODO: the First Schedule etc.

--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -13,10 +13,12 @@ grammar ProvisionRefs
 
                  # Schedule 1
                  # Schedule 1A
-  attachment_num_ref <- "Schedule" WS+ main_num %attachment_num_ref
+                 # TODO: Schedule 1 and 2
+  attachment_num_ref <- schedule__i18n WS+ main_num %attachment_num_ref
 
-  # TODO: the First Schedule etc.
-  the_attachment_ref <- "the Schedule" ![a-zA-Z] %the_attachment_ref
+                 # the Schedule
+                 # TODO: the First Schedule etc.
+  the_attachment_ref <- the_schedule__i18n ![a-zA-Z] %the_attachment_ref
 
                  # section 32
                  # section (a)
@@ -29,7 +31,7 @@ grammar ProvisionRefs
                  # section 32
                  # section 32A
                  # section 32.1a.2
-  main_num    <- digit alpha_num_no_trailing_dot* %main_num
+  main_num    <- digit alpha_num_no_trailing_dot* %num
 
                  # (a)(ii) to (iv)
                  # (a), (b) and (f)(ii)
@@ -99,6 +101,8 @@ grammar ProvisionRefs
   thereof__i18n     <- ""
   to__i18n          <- ""
   unit__i18n        <- ""
+  schedule__i18n    <- ""
+  the_schedule__i18n <- ""
 
   # --------
   # translated terminals
@@ -146,6 +150,13 @@ grammar ProvisionRefs
                   `sous-règlements` / `sous-règlement` /
                   `sous-reglements` / `sous-reglement` /
                   `sous-sections` / `sous-section`
+
+  schedule_eng <- `schedules` / `schedule`
+  schedule_afr <- `bylae` / `bylaag`
+  schedule_fra <- `annexes` / `annexe`
+  the_schedule_eng <- `the schedule`
+  the_schedule_afr <- `die bylaag`
+  the_schedule_fra <- `l'annexe`
 
   and_eng      <- `and`
   and_afr      <- `en`

--- a/indigo/analysis/refs/provision_refs.peg
+++ b/indigo/analysis/refs/provision_refs.peg
@@ -106,6 +106,9 @@ grammar ProvisionRefs
 
   # --------
   # translated terminals
+  #
+  # NB: if items are changed or added here, the list of the XML elements they correspond to must be updated in
+  #     ProvisionRefsReslover.element_names in indigo/analysis/refs/provisions.py
   # --------
 
                  # english

--- a/indigo/analysis/refs/provision_refs.py
+++ b/indigo/analysis/refs/provision_refs.py
@@ -33,106 +33,107 @@ class TreeNode2(TreeNode):
 class TreeNode3(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode3, self).__init__(text, offset, elements)
+        self.schedule__i18n = elements[0]
         self.main_num = elements[2]
 
 
 class TreeNode4(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode4, self).__init__(text, offset, elements)
-        self.unit__i18n = elements[0]
-        self.main_ref = elements[2]
+        self.the_schedule__i18n = elements[0]
 
 
 class TreeNode5(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode5, self).__init__(text, offset, elements)
-        self.to_and_or = elements[0]
-        self.main_ref = elements[1]
+        self.unit__i18n = elements[0]
+        self.main_ref = elements[2]
 
 
 class TreeNode6(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode6, self).__init__(text, offset, elements)
-        self.sub_refs = elements[1]
+        self.to_and_or = elements[0]
+        self.main_ref = elements[1]
 
 
 class TreeNode7(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode7, self).__init__(text, offset, elements)
-        self.digit = elements[0]
+        self.sub_refs = elements[1]
 
 
 class TreeNode8(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode8, self).__init__(text, offset, elements)
-        self.sub_ref = elements[0]
+        self.digit = elements[0]
 
 
 class TreeNode9(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode9, self).__init__(text, offset, elements)
-        self.to_and_or = elements[0]
-        self.sub_ref = elements[1]
+        self.sub_ref = elements[0]
 
 
 class TreeNode10(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode10, self).__init__(text, offset, elements)
-        self.num = elements[0]
+        self.to_and_or = elements[0]
+        self.sub_ref = elements[1]
 
 
 class TreeNode11(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode11, self).__init__(text, offset, elements)
-        self.num = elements[1]
+        self.num = elements[0]
 
 
 class TreeNode12(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode12, self).__init__(text, offset, elements)
-        self.to = elements[1]
+        self.num = elements[1]
 
 
 class TreeNode13(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode13, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.to = elements[1]
 
 
 class TreeNode14(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode14, self).__init__(text, offset, elements)
-        self.dash = elements[1]
+        self.comma = elements[1]
 
 
 class TreeNode15(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode15, self).__init__(text, offset, elements)
-        self.to__i18n = elements[1]
+        self.dash = elements[1]
 
 
 class TreeNode16(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode16, self).__init__(text, offset, elements)
-        self.and__i18n = elements[2]
+        self.to__i18n = elements[1]
 
 
 class TreeNode17(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode17, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.and__i18n = elements[2]
 
 
 class TreeNode18(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode18, self).__init__(text, offset, elements)
-        self.or__i18n = elements[2]
+        self.comma = elements[1]
 
 
 class TreeNode19(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode19, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.or__i18n = elements[2]
 
 
 class TreeNode20(TreeNode):
@@ -144,30 +145,36 @@ class TreeNode20(TreeNode):
 class TreeNode21(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode21, self).__init__(text, offset, elements)
-        self.of_this__i18n = elements[2]
+        self.comma = elements[1]
 
 
 class TreeNode22(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode22, self).__init__(text, offset, elements)
-        self.of_the_act__i18n = elements[2]
+        self.of_this__i18n = elements[2]
 
 
 class TreeNode23(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode23, self).__init__(text, offset, elements)
-        self.of__i18n = elements[2]
+        self.of_the_act__i18n = elements[2]
 
 
 class TreeNode24(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode24, self).__init__(text, offset, elements)
-        self.thereof__i18n = elements[2]
+        self.of__i18n = elements[2]
 
 
 class TreeNode25(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode25, self).__init__(text, offset, elements)
+        self.thereof__i18n = elements[2]
+
+
+class TreeNode26(TreeNode):
+    def __init__(self, text, offset, elements):
+        super(TreeNode26, self).__init__(text, offset, elements)
         self.of_that_act__i18n = elements[2]
 
 
@@ -299,19 +306,7 @@ class Grammar(object):
             return cached[0]
         index1, elements0 = self._offset, []
         address1 = FAILURE
-        chunk0, max0 = None, self._offset + 8
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 == 'Schedule':
-            address1 = TreeNode(self._input[self._offset:self._offset + 8], self._offset, [])
-            self._offset = self._offset + 8
-        else:
-            address1 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::attachment_num_ref', '"Schedule"'))
+        address1 = self._read_schedule__i18n()
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
@@ -358,27 +353,15 @@ class Grammar(object):
             return cached[0]
         index1, elements0 = self._offset, []
         address1 = FAILURE
-        chunk0, max0 = None, self._offset + 12
-        if max0 <= self._input_size:
-            chunk0 = self._input[self._offset:max0]
-        if chunk0 == 'the Schedule':
-            address1 = TreeNode(self._input[self._offset:self._offset + 12], self._offset, [])
-            self._offset = self._offset + 12
-        else:
-            address1 = FAILURE
-            if self._offset > self._failure:
-                self._failure = self._offset
-                self._expected = []
-            if self._offset == self._failure:
-                self._expected.append(('ProvisionRefs::the_attachment_ref', '"the Schedule"'))
+        address1 = self._read_the_schedule__i18n()
         if address1 is not FAILURE:
             elements0.append(address1)
             address2 = FAILURE
             index2 = self._offset
-            chunk1, max1 = None, self._offset + 1
-            if max1 <= self._input_size:
-                chunk1 = self._input[self._offset:max1]
-            if chunk1 is not None and Grammar.REGEX_1.search(chunk1):
+            chunk0, max0 = None, self._offset + 1
+            if max0 <= self._input_size:
+                chunk0 = self._input[self._offset:max0]
+            if chunk0 is not None and Grammar.REGEX_1.search(chunk0):
                 address2 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
                 self._offset = self._offset + 1
             else:
@@ -461,7 +444,7 @@ class Grammar(object):
                         if elements3 is None:
                             address6 = FAILURE
                         else:
-                            address6 = TreeNode5(self._input[index4:self._offset], index4, elements3)
+                            address6 = TreeNode6(self._input[index4:self._offset], index4, elements3)
                             self._offset = self._offset
                         if address6 is not FAILURE:
                             elements2.append(address6)
@@ -542,7 +525,7 @@ class Grammar(object):
             if elements1 is None:
                 address2 = FAILURE
             else:
-                address2 = TreeNode6(self._input[index4:self._offset], index4, elements1)
+                address2 = TreeNode7(self._input[index4:self._offset], index4, elements1)
                 self._offset = self._offset
             if address2 is FAILURE:
                 address2 = TreeNode(self._input[index3:index3], index3, [])
@@ -598,7 +581,7 @@ class Grammar(object):
         if elements0 is None:
             address0 = FAILURE
         else:
-            address0 = self._actions.main_num(self._input, index1, self._offset, elements0)
+            address0 = self._actions.num(self._input, index1, self._offset, elements0)
             self._offset = self._offset
         self._cache['main_num'][index0] = (address0, self._offset)
         return address0
@@ -635,7 +618,7 @@ class Grammar(object):
                 if elements2 is None:
                     address3 = FAILURE
                 else:
-                    address3 = TreeNode9(self._input[index3:self._offset], index3, elements2)
+                    address3 = TreeNode10(self._input[index3:self._offset], index3, elements2)
                     self._offset = self._offset
                 if address3 is not FAILURE:
                     elements1.append(address3)
@@ -705,7 +688,7 @@ class Grammar(object):
                 if elements2 is None:
                     address3 = FAILURE
                 else:
-                    address3 = TreeNode11(self._input[index3:self._offset], index3, elements2)
+                    address3 = TreeNode12(self._input[index3:self._offset], index3, elements2)
                     self._offset = self._offset
                 if address3 is not FAILURE:
                     elements1.append(address3)
@@ -857,7 +840,7 @@ class Grammar(object):
         if elements1 is None:
             address1 = FAILURE
         else:
-            address1 = TreeNode13(self._input[index3:self._offset], index3, elements1)
+            address1 = TreeNode14(self._input[index3:self._offset], index3, elements1)
             self._offset = self._offset
         if address1 is FAILURE:
             address1 = TreeNode(self._input[index2:index2], index2, [])
@@ -936,7 +919,7 @@ class Grammar(object):
         if elements0 is None:
             address0 = FAILURE
         else:
-            address0 = TreeNode14(self._input[index2:self._offset], index2, elements0)
+            address0 = TreeNode15(self._input[index2:self._offset], index2, elements0)
             self._offset = self._offset
         if address0 is FAILURE:
             self._offset = index1
@@ -987,7 +970,7 @@ class Grammar(object):
             if elements3 is None:
                 address0 = FAILURE
             else:
-                address0 = TreeNode15(self._input[index5:self._offset], index5, elements3)
+                address0 = TreeNode16(self._input[index5:self._offset], index5, elements3)
                 self._offset = self._offset
             if address0 is FAILURE:
                 self._offset = index1
@@ -1033,7 +1016,7 @@ class Grammar(object):
         if elements1 is None:
             address1 = FAILURE
         else:
-            address1 = TreeNode17(self._input[index4:self._offset], index4, elements1)
+            address1 = TreeNode18(self._input[index4:self._offset], index4, elements1)
             self._offset = self._offset
         if address1 is FAILURE:
             address1 = TreeNode(self._input[index3:index3], index3, [])
@@ -1125,7 +1108,7 @@ class Grammar(object):
             if elements6 is None:
                 address10 = FAILURE
             else:
-                address10 = TreeNode19(self._input[index10:self._offset], index10, elements6)
+                address10 = TreeNode20(self._input[index10:self._offset], index10, elements6)
                 self._offset = self._offset
             if address10 is FAILURE:
                 address10 = TreeNode(self._input[index9:index9], index9, [])
@@ -1781,6 +1764,50 @@ class Grammar(object):
             if self._offset == self._failure:
                 self._expected.append(('ProvisionRefs::unit__i18n', '""'))
         self._cache['unit__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_schedule__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['schedule__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::schedule__i18n', '""'))
+        self._cache['schedule__i18n'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_the_schedule__i18n(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['the_schedule__i18n'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 0
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == '':
+            address0 = TreeNode(self._input[self._offset:self._offset + 0], self._offset, [])
+            self._offset = self._offset + 0
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::the_schedule__i18n', '""'))
+        self._cache['the_schedule__i18n'][index0] = (address0, self._offset)
         return address0
 
     def _read_unit_eng(self):
@@ -2953,6 +2980,192 @@ class Grammar(object):
                                                                                                     if address0 is FAILURE:
                                                                                                         self._offset = index1
         self._cache['unit_fra'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_schedule_eng(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['schedule_eng'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 9
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'schedules'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 9], self._offset, [])
+            self._offset = self._offset + 9
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::schedule_eng', '`schedules`'))
+        if address0 is FAILURE:
+            self._offset = index1
+            chunk1, max1 = None, self._offset + 8
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'schedule'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 8], self._offset, [])
+                self._offset = self._offset + 8
+            else:
+                address0 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::schedule_eng', '`schedule`'))
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['schedule_eng'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_schedule_afr(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['schedule_afr'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 5
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'bylae'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 5], self._offset, [])
+            self._offset = self._offset + 5
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::schedule_afr', '`bylae`'))
+        if address0 is FAILURE:
+            self._offset = index1
+            chunk1, max1 = None, self._offset + 6
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'bylaag'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 6], self._offset, [])
+                self._offset = self._offset + 6
+            else:
+                address0 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::schedule_afr', '`bylaag`'))
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['schedule_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_schedule_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['schedule_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 7
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'annexes'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 7], self._offset, [])
+            self._offset = self._offset + 7
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::schedule_fra', '`annexes`'))
+        if address0 is FAILURE:
+            self._offset = index1
+            chunk1, max1 = None, self._offset + 6
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and chunk1.lower() == 'annexe'.lower():
+                address0 = TreeNode(self._input[self._offset:self._offset + 6], self._offset, [])
+                self._offset = self._offset + 6
+            else:
+                address0 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::schedule_fra', '`annexe`'))
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['schedule_fra'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_the_schedule_eng(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['the_schedule_eng'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 12
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'the schedule'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 12], self._offset, [])
+            self._offset = self._offset + 12
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::the_schedule_eng', '`the schedule`'))
+        self._cache['the_schedule_eng'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_the_schedule_afr(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['the_schedule_afr'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 10
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'die bylaag'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 10], self._offset, [])
+            self._offset = self._offset + 10
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::the_schedule_afr', '`die bylaag`'))
+        self._cache['the_schedule_afr'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_the_schedule_fra(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['the_schedule_fra'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        chunk0, max0 = None, self._offset + 8
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and chunk0.lower() == 'l\'annexe'.lower():
+            address0 = TreeNode(self._input[self._offset:self._offset + 8], self._offset, [])
+            self._offset = self._offset + 8
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::the_schedule_fra', '`l\'annexe`'))
+        self._cache['the_schedule_fra'][index0] = (address0, self._offset)
         return address0
 
     def _read_and_eng(self):

--- a/indigo/analysis/refs/provision_refs.py
+++ b/indigo/analysis/refs/provision_refs.py
@@ -33,100 +33,100 @@ class TreeNode2(TreeNode):
 class TreeNode3(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode3, self).__init__(text, offset, elements)
-        self.unit__i18n = elements[0]
-        self.main_ref = elements[2]
+        self.main_num = elements[2]
 
 
 class TreeNode4(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode4, self).__init__(text, offset, elements)
-        self.to_and_or = elements[0]
-        self.main_ref = elements[1]
+        self.unit__i18n = elements[0]
+        self.main_ref = elements[2]
 
 
 class TreeNode5(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode5, self).__init__(text, offset, elements)
-        self.sub_refs = elements[1]
+        self.to_and_or = elements[0]
+        self.main_ref = elements[1]
 
 
 class TreeNode6(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode6, self).__init__(text, offset, elements)
-        self.digit = elements[0]
+        self.sub_refs = elements[1]
 
 
 class TreeNode7(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode7, self).__init__(text, offset, elements)
-        self.sub_ref = elements[0]
+        self.digit = elements[0]
 
 
 class TreeNode8(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode8, self).__init__(text, offset, elements)
-        self.to_and_or = elements[0]
-        self.sub_ref = elements[1]
+        self.sub_ref = elements[0]
 
 
 class TreeNode9(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode9, self).__init__(text, offset, elements)
-        self.num = elements[0]
+        self.to_and_or = elements[0]
+        self.sub_ref = elements[1]
 
 
 class TreeNode10(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode10, self).__init__(text, offset, elements)
-        self.num = elements[1]
+        self.num = elements[0]
 
 
 class TreeNode11(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode11, self).__init__(text, offset, elements)
-        self.to = elements[1]
+        self.num = elements[1]
 
 
 class TreeNode12(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode12, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.to = elements[1]
 
 
 class TreeNode13(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode13, self).__init__(text, offset, elements)
-        self.dash = elements[1]
+        self.comma = elements[1]
 
 
 class TreeNode14(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode14, self).__init__(text, offset, elements)
-        self.to__i18n = elements[1]
+        self.dash = elements[1]
 
 
 class TreeNode15(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode15, self).__init__(text, offset, elements)
-        self.and__i18n = elements[2]
+        self.to__i18n = elements[1]
 
 
 class TreeNode16(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode16, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.and__i18n = elements[2]
 
 
 class TreeNode17(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode17, self).__init__(text, offset, elements)
-        self.or__i18n = elements[2]
+        self.comma = elements[1]
 
 
 class TreeNode18(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode18, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.or__i18n = elements[2]
 
 
 class TreeNode19(TreeNode):
@@ -138,30 +138,36 @@ class TreeNode19(TreeNode):
 class TreeNode20(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode20, self).__init__(text, offset, elements)
-        self.of_this__i18n = elements[2]
+        self.comma = elements[1]
 
 
 class TreeNode21(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode21, self).__init__(text, offset, elements)
-        self.of_the_act__i18n = elements[2]
+        self.of_this__i18n = elements[2]
 
 
 class TreeNode22(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode22, self).__init__(text, offset, elements)
-        self.of__i18n = elements[2]
+        self.of_the_act__i18n = elements[2]
 
 
 class TreeNode23(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode23, self).__init__(text, offset, elements)
-        self.thereof__i18n = elements[2]
+        self.of__i18n = elements[2]
 
 
 class TreeNode24(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode24, self).__init__(text, offset, elements)
+        self.thereof__i18n = elements[2]
+
+
+class TreeNode25(TreeNode):
+    def __init__(self, text, offset, elements):
+        super(TreeNode25, self).__init__(text, offset, elements)
         self.of_that_act__i18n = elements[2]
 
 
@@ -169,9 +175,12 @@ FAILURE = object()
 
 
 class Grammar(object):
-    REGEX_1 = re.compile('^[,;]')
-    REGEX_2 = re.compile('^[0-9]')
-    REGEX_3 = re.compile('^[a-zA-Z0-9.-]')
+    REGEX_1 = re.compile('^[a-zA-Z]')
+    REGEX_2 = re.compile('^[,;]')
+    REGEX_3 = re.compile('^[0-9]')
+    REGEX_4 = re.compile('^[a-zA-Z0-9.-]')
+    REGEX_5 = re.compile('^[a-zA-Z0-9-]')
+    REGEX_6 = re.compile('^[a-zA-Z0-9]')
 
     def _read_root(self):
         address0, index0 = FAILURE, self._offset
@@ -256,6 +265,157 @@ class Grammar(object):
         if cached:
             self._offset = cached[1]
             return cached[0]
+        index1 = self._offset
+        address0 = self._read_attachment_ref()
+        if address0 is FAILURE:
+            self._offset = index1
+            address0 = self._read_unit_refs()
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['references'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_attachment_ref(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['attachment_ref'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        address0 = self._read_attachment_num_ref()
+        if address0 is FAILURE:
+            self._offset = index1
+            address0 = self._read_the_attachment_ref()
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['attachment_ref'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_attachment_num_ref(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['attachment_num_ref'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1, elements0 = self._offset, []
+        address1 = FAILURE
+        chunk0, max0 = None, self._offset + 8
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == 'Schedule':
+            address1 = TreeNode(self._input[self._offset:self._offset + 8], self._offset, [])
+            self._offset = self._offset + 8
+        else:
+            address1 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::attachment_num_ref', '"Schedule"'))
+        if address1 is not FAILURE:
+            elements0.append(address1)
+            address2 = FAILURE
+            index2, elements1, address3 = self._offset, [], None
+            while True:
+                address3 = self._read_WS()
+                if address3 is not FAILURE:
+                    elements1.append(address3)
+                else:
+                    break
+            if len(elements1) >= 1:
+                address2 = TreeNode(self._input[index2:self._offset], index2, elements1)
+                self._offset = self._offset
+            else:
+                address2 = FAILURE
+            if address2 is not FAILURE:
+                elements0.append(address2)
+                address4 = FAILURE
+                address4 = self._read_main_num()
+                if address4 is not FAILURE:
+                    elements0.append(address4)
+                else:
+                    elements0 = None
+                    self._offset = index1
+            else:
+                elements0 = None
+                self._offset = index1
+        else:
+            elements0 = None
+            self._offset = index1
+        if elements0 is None:
+            address0 = FAILURE
+        else:
+            address0 = self._actions.attachment_num_ref(self._input, index1, self._offset, elements0)
+            self._offset = self._offset
+        self._cache['attachment_num_ref'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_the_attachment_ref(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['the_attachment_ref'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1, elements0 = self._offset, []
+        address1 = FAILURE
+        chunk0, max0 = None, self._offset + 12
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 == 'the Schedule':
+            address1 = TreeNode(self._input[self._offset:self._offset + 12], self._offset, [])
+            self._offset = self._offset + 12
+        else:
+            address1 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::the_attachment_ref', '"the Schedule"'))
+        if address1 is not FAILURE:
+            elements0.append(address1)
+            address2 = FAILURE
+            index2 = self._offset
+            chunk1, max1 = None, self._offset + 1
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 is not None and Grammar.REGEX_1.search(chunk1):
+                address2 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
+                self._offset = self._offset + 1
+            else:
+                address2 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::the_attachment_ref', '[a-zA-Z]'))
+            self._offset = index2
+            if address2 is FAILURE:
+                address2 = TreeNode(self._input[self._offset:self._offset], self._offset, [])
+                self._offset = self._offset
+            else:
+                address2 = FAILURE
+            if address2 is not FAILURE:
+                elements0.append(address2)
+            else:
+                elements0 = None
+                self._offset = index1
+        else:
+            elements0 = None
+            self._offset = index1
+        if elements0 is None:
+            address0 = FAILURE
+        else:
+            address0 = self._actions.the_attachment_ref(self._input, index1, self._offset, elements0)
+            self._offset = self._offset
+        self._cache['the_attachment_ref'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_unit_refs(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['unit_refs'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
         index1, elements0 = self._offset, []
         address1 = FAILURE
         address1 = self._read_unit__i18n()
@@ -301,7 +461,7 @@ class Grammar(object):
                         if elements3 is None:
                             address6 = FAILURE
                         else:
-                            address6 = TreeNode4(self._input[index4:self._offset], index4, elements3)
+                            address6 = TreeNode5(self._input[index4:self._offset], index4, elements3)
                             self._offset = self._offset
                         if address6 is not FAILURE:
                             elements2.append(address6)
@@ -329,9 +489,9 @@ class Grammar(object):
         if elements0 is None:
             address0 = FAILURE
         else:
-            address0 = self._actions.references(self._input, index1, self._offset, elements0)
+            address0 = self._actions.unit_refs(self._input, index1, self._offset, elements0)
             self._offset = self._offset
-        self._cache['references'][index0] = (address0, self._offset)
+        self._cache['unit_refs'][index0] = (address0, self._offset)
         return address0
 
     def _read_main_ref(self):
@@ -382,7 +542,7 @@ class Grammar(object):
             if elements1 is None:
                 address2 = FAILURE
             else:
-                address2 = TreeNode5(self._input[index4:self._offset], index4, elements1)
+                address2 = TreeNode6(self._input[index4:self._offset], index4, elements1)
                 self._offset = self._offset
             if address2 is FAILURE:
                 address2 = TreeNode(self._input[index3:index3], index3, [])
@@ -417,7 +577,7 @@ class Grammar(object):
             address2 = FAILURE
             index2, elements1, address3 = self._offset, [], None
             while True:
-                address3 = self._read_alpha_num_dot()
+                address3 = self._read_alpha_num_no_trailing_dot()
                 if address3 is not FAILURE:
                     elements1.append(address3)
                 else:
@@ -475,7 +635,7 @@ class Grammar(object):
                 if elements2 is None:
                     address3 = FAILURE
                 else:
-                    address3 = TreeNode8(self._input[index3:self._offset], index3, elements2)
+                    address3 = TreeNode9(self._input[index3:self._offset], index3, elements2)
                     self._offset = self._offset
                 if address3 is not FAILURE:
                     elements1.append(address3)
@@ -545,7 +705,7 @@ class Grammar(object):
                 if elements2 is None:
                     address3 = FAILURE
                 else:
-                    address3 = TreeNode10(self._input[index3:self._offset], index3, elements2)
+                    address3 = TreeNode11(self._input[index3:self._offset], index3, elements2)
                     self._offset = self._offset
                 if address3 is not FAILURE:
                     elements1.append(address3)
@@ -697,7 +857,7 @@ class Grammar(object):
         if elements1 is None:
             address1 = FAILURE
         else:
-            address1 = TreeNode12(self._input[index3:self._offset], index3, elements1)
+            address1 = TreeNode13(self._input[index3:self._offset], index3, elements1)
             self._offset = self._offset
         if address1 is FAILURE:
             address1 = TreeNode(self._input[index2:index2], index2, [])
@@ -776,7 +936,7 @@ class Grammar(object):
         if elements0 is None:
             address0 = FAILURE
         else:
-            address0 = TreeNode13(self._input[index2:self._offset], index2, elements0)
+            address0 = TreeNode14(self._input[index2:self._offset], index2, elements0)
             self._offset = self._offset
         if address0 is FAILURE:
             self._offset = index1
@@ -827,7 +987,7 @@ class Grammar(object):
             if elements3 is None:
                 address0 = FAILURE
             else:
-                address0 = TreeNode14(self._input[index5:self._offset], index5, elements3)
+                address0 = TreeNode15(self._input[index5:self._offset], index5, elements3)
                 self._offset = self._offset
             if address0 is FAILURE:
                 self._offset = index1
@@ -873,7 +1033,7 @@ class Grammar(object):
         if elements1 is None:
             address1 = FAILURE
         else:
-            address1 = TreeNode16(self._input[index4:self._offset], index4, elements1)
+            address1 = TreeNode17(self._input[index4:self._offset], index4, elements1)
             self._offset = self._offset
         if address1 is FAILURE:
             address1 = TreeNode(self._input[index3:index3], index3, [])
@@ -965,7 +1125,7 @@ class Grammar(object):
             if elements6 is None:
                 address10 = FAILURE
             else:
-                address10 = TreeNode18(self._input[index10:self._offset], index10, elements6)
+                address10 = TreeNode19(self._input[index10:self._offset], index10, elements6)
                 self._offset = self._offset
             if address10 is FAILURE:
                 address10 = TreeNode(self._input[index9:index9], index9, [])
@@ -3531,7 +3691,7 @@ class Grammar(object):
         chunk0, max0 = None, self._offset + 1
         if max0 <= self._input_size:
             chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and Grammar.REGEX_1.search(chunk0):
+        if chunk0 is not None and Grammar.REGEX_2.search(chunk0):
             address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
             self._offset = self._offset + 1
         else:
@@ -3553,7 +3713,7 @@ class Grammar(object):
         chunk0, max0 = None, self._offset + 1
         if max0 <= self._input_size:
             chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and Grammar.REGEX_2.search(chunk0):
+        if chunk0 is not None and Grammar.REGEX_3.search(chunk0):
             address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
             self._offset = self._offset + 1
         else:
@@ -3575,7 +3735,7 @@ class Grammar(object):
         chunk0, max0 = None, self._offset + 1
         if max0 <= self._input_size:
             chunk0 = self._input[self._offset:max0]
-        if chunk0 is not None and Grammar.REGEX_3.search(chunk0):
+        if chunk0 is not None and Grammar.REGEX_4.search(chunk0):
             address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
             self._offset = self._offset + 1
         else:
@@ -3586,6 +3746,77 @@ class Grammar(object):
             if self._offset == self._failure:
                 self._expected.append(('ProvisionRefs::alpha_num_dot', '[a-zA-Z0-9.-]'))
         self._cache['alpha_num_dot'][index0] = (address0, self._offset)
+        return address0
+
+    def _read_alpha_num_no_trailing_dot(self):
+        address0, index0 = FAILURE, self._offset
+        cached = self._cache['alpha_num_no_trailing_dot'].get(index0)
+        if cached:
+            self._offset = cached[1]
+            return cached[0]
+        index1 = self._offset
+        chunk0, max0 = None, self._offset + 1
+        if max0 <= self._input_size:
+            chunk0 = self._input[self._offset:max0]
+        if chunk0 is not None and Grammar.REGEX_5.search(chunk0):
+            address0 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
+            self._offset = self._offset + 1
+        else:
+            address0 = FAILURE
+            if self._offset > self._failure:
+                self._failure = self._offset
+                self._expected = []
+            if self._offset == self._failure:
+                self._expected.append(('ProvisionRefs::alpha_num_no_trailing_dot', '[a-zA-Z0-9-]'))
+        if address0 is FAILURE:
+            self._offset = index1
+            index2, elements0 = self._offset, []
+            address1 = FAILURE
+            chunk1, max1 = None, self._offset + 1
+            if max1 <= self._input_size:
+                chunk1 = self._input[self._offset:max1]
+            if chunk1 == '.':
+                address1 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
+                self._offset = self._offset + 1
+            else:
+                address1 = FAILURE
+                if self._offset > self._failure:
+                    self._failure = self._offset
+                    self._expected = []
+                if self._offset == self._failure:
+                    self._expected.append(('ProvisionRefs::alpha_num_no_trailing_dot', '\'.\''))
+            if address1 is not FAILURE:
+                elements0.append(address1)
+                address2 = FAILURE
+                chunk2, max2 = None, self._offset + 1
+                if max2 <= self._input_size:
+                    chunk2 = self._input[self._offset:max2]
+                if chunk2 is not None and Grammar.REGEX_6.search(chunk2):
+                    address2 = TreeNode(self._input[self._offset:self._offset + 1], self._offset, [])
+                    self._offset = self._offset + 1
+                else:
+                    address2 = FAILURE
+                    if self._offset > self._failure:
+                        self._failure = self._offset
+                        self._expected = []
+                    if self._offset == self._failure:
+                        self._expected.append(('ProvisionRefs::alpha_num_no_trailing_dot', '[a-zA-Z0-9]'))
+                if address2 is not FAILURE:
+                    elements0.append(address2)
+                else:
+                    elements0 = None
+                    self._offset = index2
+            else:
+                elements0 = None
+                self._offset = index2
+            if elements0 is None:
+                address0 = FAILURE
+            else:
+                address0 = TreeNode(self._input[index2:self._offset], index2, elements0)
+                self._offset = self._offset
+            if address0 is FAILURE:
+                self._offset = index1
+        self._cache['alpha_num_no_trailing_dot'][index0] = (address0, self._offset)
         return address0
 
     def _read_WS(self):

--- a/indigo/analysis/refs/provision_refs.py
+++ b/indigo/analysis/refs/provision_refs.py
@@ -40,106 +40,107 @@ class TreeNode3(TreeNode):
 class TreeNode4(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode4, self).__init__(text, offset, elements)
-        self.the_schedule__i18n = elements[0]
+        self.to_and_or = elements[0]
+        self.main_num = elements[1]
 
 
 class TreeNode5(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode5, self).__init__(text, offset, elements)
-        self.unit__i18n = elements[0]
-        self.main_ref = elements[2]
+        self.the_schedule__i18n = elements[0]
 
 
 class TreeNode6(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode6, self).__init__(text, offset, elements)
-        self.to_and_or = elements[0]
-        self.main_ref = elements[1]
+        self.unit__i18n = elements[0]
+        self.main_ref = elements[2]
 
 
 class TreeNode7(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode7, self).__init__(text, offset, elements)
-        self.sub_refs = elements[1]
+        self.to_and_or = elements[0]
+        self.main_ref = elements[1]
 
 
 class TreeNode8(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode8, self).__init__(text, offset, elements)
-        self.digit = elements[0]
+        self.sub_refs = elements[1]
 
 
 class TreeNode9(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode9, self).__init__(text, offset, elements)
-        self.sub_ref = elements[0]
+        self.digit = elements[0]
 
 
 class TreeNode10(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode10, self).__init__(text, offset, elements)
-        self.to_and_or = elements[0]
-        self.sub_ref = elements[1]
+        self.sub_ref = elements[0]
 
 
 class TreeNode11(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode11, self).__init__(text, offset, elements)
-        self.num = elements[0]
+        self.to_and_or = elements[0]
+        self.sub_ref = elements[1]
 
 
 class TreeNode12(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode12, self).__init__(text, offset, elements)
-        self.num = elements[1]
+        self.num = elements[0]
 
 
 class TreeNode13(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode13, self).__init__(text, offset, elements)
-        self.to = elements[1]
+        self.num = elements[1]
 
 
 class TreeNode14(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode14, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.to = elements[1]
 
 
 class TreeNode15(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode15, self).__init__(text, offset, elements)
-        self.dash = elements[1]
+        self.comma = elements[1]
 
 
 class TreeNode16(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode16, self).__init__(text, offset, elements)
-        self.to__i18n = elements[1]
+        self.dash = elements[1]
 
 
 class TreeNode17(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode17, self).__init__(text, offset, elements)
-        self.and__i18n = elements[2]
+        self.to__i18n = elements[1]
 
 
 class TreeNode18(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode18, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.and__i18n = elements[2]
 
 
 class TreeNode19(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode19, self).__init__(text, offset, elements)
-        self.or__i18n = elements[2]
+        self.comma = elements[1]
 
 
 class TreeNode20(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode20, self).__init__(text, offset, elements)
-        self.comma = elements[1]
+        self.or__i18n = elements[2]
 
 
 class TreeNode21(TreeNode):
@@ -151,30 +152,36 @@ class TreeNode21(TreeNode):
 class TreeNode22(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode22, self).__init__(text, offset, elements)
-        self.of_this__i18n = elements[2]
+        self.comma = elements[1]
 
 
 class TreeNode23(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode23, self).__init__(text, offset, elements)
-        self.of_the_act__i18n = elements[2]
+        self.of_this__i18n = elements[2]
 
 
 class TreeNode24(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode24, self).__init__(text, offset, elements)
-        self.of__i18n = elements[2]
+        self.of_the_act__i18n = elements[2]
 
 
 class TreeNode25(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode25, self).__init__(text, offset, elements)
-        self.thereof__i18n = elements[2]
+        self.of__i18n = elements[2]
 
 
 class TreeNode26(TreeNode):
     def __init__(self, text, offset, elements):
         super(TreeNode26, self).__init__(text, offset, elements)
+        self.thereof__i18n = elements[2]
+
+
+class TreeNode27(TreeNode):
+    def __init__(self, text, offset, elements):
+        super(TreeNode27, self).__init__(text, offset, elements)
         self.of_that_act__i18n = elements[2]
 
 
@@ -328,6 +335,43 @@ class Grammar(object):
                 address4 = self._read_main_num()
                 if address4 is not FAILURE:
                     elements0.append(address4)
+                    address5 = FAILURE
+                    index3, elements2, address6 = self._offset, [], None
+                    while True:
+                        index4, elements3 = self._offset, []
+                        address7 = FAILURE
+                        address7 = self._read_to_and_or()
+                        if address7 is not FAILURE:
+                            elements3.append(address7)
+                            address8 = FAILURE
+                            address8 = self._read_main_num()
+                            if address8 is not FAILURE:
+                                elements3.append(address8)
+                            else:
+                                elements3 = None
+                                self._offset = index4
+                        else:
+                            elements3 = None
+                            self._offset = index4
+                        if elements3 is None:
+                            address6 = FAILURE
+                        else:
+                            address6 = TreeNode4(self._input[index4:self._offset], index4, elements3)
+                            self._offset = self._offset
+                        if address6 is not FAILURE:
+                            elements2.append(address6)
+                        else:
+                            break
+                    if len(elements2) >= 0:
+                        address5 = TreeNode(self._input[index3:self._offset], index3, elements2)
+                        self._offset = self._offset
+                    else:
+                        address5 = FAILURE
+                    if address5 is not FAILURE:
+                        elements0.append(address5)
+                    else:
+                        elements0 = None
+                        self._offset = index1
                 else:
                     elements0 = None
                     self._offset = index1
@@ -444,7 +488,7 @@ class Grammar(object):
                         if elements3 is None:
                             address6 = FAILURE
                         else:
-                            address6 = TreeNode6(self._input[index4:self._offset], index4, elements3)
+                            address6 = TreeNode7(self._input[index4:self._offset], index4, elements3)
                             self._offset = self._offset
                         if address6 is not FAILURE:
                             elements2.append(address6)
@@ -525,7 +569,7 @@ class Grammar(object):
             if elements1 is None:
                 address2 = FAILURE
             else:
-                address2 = TreeNode7(self._input[index4:self._offset], index4, elements1)
+                address2 = TreeNode8(self._input[index4:self._offset], index4, elements1)
                 self._offset = self._offset
             if address2 is FAILURE:
                 address2 = TreeNode(self._input[index3:index3], index3, [])
@@ -618,7 +662,7 @@ class Grammar(object):
                 if elements2 is None:
                     address3 = FAILURE
                 else:
-                    address3 = TreeNode10(self._input[index3:self._offset], index3, elements2)
+                    address3 = TreeNode11(self._input[index3:self._offset], index3, elements2)
                     self._offset = self._offset
                 if address3 is not FAILURE:
                     elements1.append(address3)
@@ -688,7 +732,7 @@ class Grammar(object):
                 if elements2 is None:
                     address3 = FAILURE
                 else:
-                    address3 = TreeNode12(self._input[index3:self._offset], index3, elements2)
+                    address3 = TreeNode13(self._input[index3:self._offset], index3, elements2)
                     self._offset = self._offset
                 if address3 is not FAILURE:
                     elements1.append(address3)
@@ -840,7 +884,7 @@ class Grammar(object):
         if elements1 is None:
             address1 = FAILURE
         else:
-            address1 = TreeNode14(self._input[index3:self._offset], index3, elements1)
+            address1 = TreeNode15(self._input[index3:self._offset], index3, elements1)
             self._offset = self._offset
         if address1 is FAILURE:
             address1 = TreeNode(self._input[index2:index2], index2, [])
@@ -919,7 +963,7 @@ class Grammar(object):
         if elements0 is None:
             address0 = FAILURE
         else:
-            address0 = TreeNode15(self._input[index2:self._offset], index2, elements0)
+            address0 = TreeNode16(self._input[index2:self._offset], index2, elements0)
             self._offset = self._offset
         if address0 is FAILURE:
             self._offset = index1
@@ -970,7 +1014,7 @@ class Grammar(object):
             if elements3 is None:
                 address0 = FAILURE
             else:
-                address0 = TreeNode16(self._input[index5:self._offset], index5, elements3)
+                address0 = TreeNode17(self._input[index5:self._offset], index5, elements3)
                 self._offset = self._offset
             if address0 is FAILURE:
                 self._offset = index1
@@ -1016,7 +1060,7 @@ class Grammar(object):
         if elements1 is None:
             address1 = FAILURE
         else:
-            address1 = TreeNode18(self._input[index4:self._offset], index4, elements1)
+            address1 = TreeNode19(self._input[index4:self._offset], index4, elements1)
             self._offset = self._offset
         if address1 is FAILURE:
             address1 = TreeNode(self._input[index3:index3], index3, [])
@@ -1108,7 +1152,7 @@ class Grammar(object):
             if elements6 is None:
                 address10 = FAILURE
             else:
-                address10 = TreeNode20(self._input[index10:self._offset], index10, elements6)
+                address10 = TreeNode21(self._input[index10:self._offset], index10, elements6)
                 self._offset = self._offset
             if address10 is FAILURE:
                 address10 = TreeNode(self._input[index9:index9], index9, [])

--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -114,8 +114,21 @@ def parse_provision_refs(text, lang_code='eng'):
             return ParseResult(refs, target, elements[3].offset)
 
         def attachment_num_ref(self, input, start, end, elements):
-            ref = ProvisionRef(input[start:end], start, end)
-            return [MainProvisionRef("attachment", ref)]
+            # extend the ref to cover the full thing, not just the number
+            ref = elements[2]
+            refs = [MainProvisionRef("attachment", ref)]
+            # "2" -> "Schedule 2"
+            ref.start_pos = start
+            ref.text = input[start:ref.end_pos]
+
+            for el in elements[3].elements or []:
+                ref = MainProvisionRef("attachment", el.main_num)
+                # "2" -> "Schedule 2"
+                ref.ref.text = elements[0].text + elements[1].text + ref.ref.text
+                ref.ref.separator = el.elements[0]
+                refs.append(ref)
+
+            return refs
 
         def the_attachment_ref(self, input, start, end, elements):
             text = input[start:end]

--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -200,6 +200,12 @@ def parse_provision_refs(text, lang_code='eng'):
 class ProvisionRefsResolver:
     """Resolves references such as Section 32(a) to eIds in an Akoma Ntoso document."""
 
+    # These are the keywords that can be matched in the text, and their corresponding element names to search for.
+    # If these items change, then the grammar must be updated to match them
+    # (see 'translated terminals' in provision_refs.peg)
+    #
+    # These also act as the basis of the pattern to look for potential references in the text to which the grammar
+    # must be applied.
     element_names = {
         # all languages
         "attachment": "attachment",

--- a/indigo/tests/test_provision_refs.py
+++ b/indigo/tests/test_provision_refs.py
@@ -9,7 +9,7 @@ from docpipe.matchers import ExtractedCitation
 
 from indigo.analysis.refs.provisions import ProvisionRefsResolver, ProvisionRef, ProvisionRefsMatcher, parse_provision_refs, MainProvisionRef
 from indigo.xmlutils import parse_html_str
-from indigo_api.tests.fixtures import document_fixture
+from indigo_api.tests.fixtures import document_fixture, component_fixture
 
 
 unittest.util._MAX_LENGTH = 999999999
@@ -224,6 +224,17 @@ class ProvisionRefsResolverTestCase(TestCase):
                 )
             )
         ], self.resolve_references_str("paragraph (a)(i)", root))
+
+    def test_schedule(self):
+        self.doc = AkomaNtosoDocument(component_fixture(text="test", heading="Schedule 2")).root
+        # xpath for the body element with any namespace
+        root = self.doc.xpath('//*[local-name()="body"]')[0]
+        att_1 = self.doc.xpath('//*[@eId="att_1"]')[0]
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("Schedule 2", 0, 10, element=att_1, eId='att_1'))
+        ], self.resolve_references_str("Schedule 2", root))
 
 
 class ProvisionRefsMatcherTestCase(TestCase):
@@ -1490,6 +1501,76 @@ class ProvisionRefsMatcherTestCase(TestCase):
               <heading>Important heading</heading>
             </section>
         """))
+
+        actual = etree.fromstring(doc.to_xml())
+        self.finder.markup_xml_matches(self.frbr_uri, actual)
+        self.assertEqual(
+            expected.to_xml(encoding='unicode'),
+            etree.tostring(actual, encoding='unicode')
+        )
+
+    def test_schedule_num(self):
+        doc = AkomaNtosoDocument(component_fixture(xml="""
+            <section eId="sec_7">
+              <num>7.</num>
+              <heading>Section 7</heading>
+              <content>
+                <p>In Schedule 2</p>
+                <p>In Schedule 2.</p>
+                <p>In Schedule 2 and Schedule 2.</p>
+                <p>In Scheduled work...</p>
+                <p>In the Schedule</p>
+              </content>
+            </section>
+        """, heading="Schedule 2"))
+
+        expected = AkomaNtosoDocument(component_fixture(xml="""
+            <section eId="sec_7">
+              <num>7.</num>
+              <heading>Section 7</heading>
+              <content>
+                <p>In <ref href="#att_1">Schedule 2</ref></p>
+                <p>In <ref href="#att_1">Schedule 2</ref>.</p>
+                <p>In <ref href="#att_1">Schedule 2</ref> and <ref href="#att_1">Schedule 2</ref>.</p>
+                <p>In Scheduled work...</p>
+                <p>In the Schedule</p>
+              </content>
+            </section>
+        """, heading="Schedule 2"))
+
+        actual = etree.fromstring(doc.to_xml())
+        self.finder.markup_xml_matches(self.frbr_uri, actual)
+        self.assertEqual(
+            expected.to_xml(encoding='unicode'),
+            etree.tostring(actual, encoding='unicode')
+        )
+
+    def test_schedule_name(self):
+        doc = AkomaNtosoDocument(component_fixture(xml="""
+            <section eId="sec_7">
+              <num>7.</num>
+              <heading>Section 7</heading>
+              <content>
+                <p>In the Schedule</p>
+                <p>In the Schedule.</p>
+                <p>In the Schedule and the Schedule.</p>
+                <p>In Scheduled work...</p>
+              </content>
+            </section>
+        """, heading="Schedule"))
+
+        expected = AkomaNtosoDocument(component_fixture(xml="""
+            <section eId="sec_7">
+              <num>7.</num>
+              <heading>Section 7</heading>
+              <content>
+                <p>In the <ref href="#att_1">Schedule</ref></p>
+                <p>In the <ref href="#att_1">Schedule</ref>.</p>
+                <p>In the <ref href="#att_1">Schedule</ref> and the <ref href="#att_1">Schedule</ref>.</p>
+                <p>In Scheduled work...</p>
+              </content>
+            </section>
+        """, heading="Schedule"))
 
         actual = etree.fromstring(doc.to_xml())
         self.finder.markup_xml_matches(self.frbr_uri, actual)

--- a/indigo/tests/test_provision_refs.py
+++ b/indigo/tests/test_provision_refs.py
@@ -1518,6 +1518,7 @@ class ProvisionRefsMatcherTestCase(TestCase):
                 <p>In Schedule 2</p>
                 <p>In Schedule 2.</p>
                 <p>In Schedule 2 and Schedule 2.</p>
+                <p>In Schedule 2 to 2.</p>
                 <p>In Scheduled work...</p>
                 <p>In the Schedule</p>
               </content>
@@ -1532,6 +1533,7 @@ class ProvisionRefsMatcherTestCase(TestCase):
                 <p>In <ref href="#att_1">Schedule 2</ref></p>
                 <p>In <ref href="#att_1">Schedule 2</ref>.</p>
                 <p>In <ref href="#att_1">Schedule 2</ref> and <ref href="#att_1">Schedule 2</ref>.</p>
+                <p>In <ref href="#att_1">Schedule 2</ref> to <ref href="#att_1">2</ref>.</p>
                 <p>In Scheduled work...</p>
                 <p>In the Schedule</p>
               </content>

--- a/indigo/tests/test_provision_refs_grammar.py
+++ b/indigo/tests/test_provision_refs_grammar.py
@@ -3,6 +3,7 @@ import unittest.util
 from django.test import TestCase
 
 from indigo.analysis.refs.provisions import ProvisionRef, parse_provision_refs, MainProvisionRef
+from indigo.analysis.refs.provision_refs import ParseError
 
 
 unittest.util._MAX_LENGTH = 999999999
@@ -26,6 +27,14 @@ class ProvisionRefsGrammarTest(TestCase):
             MainProvisionRef(
                 "paragraph",
                 ProvisionRef("(a)", 10, 13)
+            )
+        ], result.references)
+
+        result = parse_provision_refs("Section 1.2")
+        self.assertEqual([
+            MainProvisionRef(
+                "Section",
+                ProvisionRef("1.2", 8, 11)
             )
         ], result.references)
 
@@ -339,6 +348,59 @@ class ProvisionRefsGrammarTest(TestCase):
         ], result.references)
         self.assertEqual("of", result.target)
         self.assertEqual(result.end, 49)
+
+    def test_schedules_num_eng(self):
+        result = parse_provision_refs("Schedule 2a")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("Schedule 2a", 0, 11)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("Schedule 2a.")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("Schedule 2a", 0, 11)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_schedules_the_eng(self):
+        result = parse_provision_refs("the Schedule")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("the Schedule", 0, 12)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("the Schedule.")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("the Schedule", 0, 12)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("the Schedule and also")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("the Schedule", 0, 12)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_schedules_no_match(self):
+        # these must not match as schedule references
+        for s in ["the Scheduled work", "the Schedules are also"]:
+            with self.assertRaises(ParseError):
+                result = parse_provision_refs(s)
 
     def test_target(self):
         result = parse_provision_refs("Section 2 of this Act")

--- a/indigo/tests/test_provision_refs_grammar.py
+++ b/indigo/tests/test_provision_refs_grammar.py
@@ -373,7 +373,7 @@ class ProvisionRefsGrammarTest(TestCase):
         self.assertEqual([
             MainProvisionRef(
                 "attachment",
-                ProvisionRef("the Schedule", 0, 12)
+                ProvisionRef("Schedule", 4, 12)
             ),
         ], result.references)
         self.assertIsNone(result.target)
@@ -382,7 +382,7 @@ class ProvisionRefsGrammarTest(TestCase):
         self.assertEqual([
             MainProvisionRef(
                 "attachment",
-                ProvisionRef("the Schedule", 0, 12)
+                ProvisionRef("Schedule", 4, 12)
             ),
         ], result.references)
         self.assertIsNone(result.target)
@@ -391,7 +391,63 @@ class ProvisionRefsGrammarTest(TestCase):
         self.assertEqual([
             MainProvisionRef(
                 "attachment",
-                ProvisionRef("the Schedule", 0, 12)
+                ProvisionRef("Schedule", 4, 12)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_schedules_the_afr(self):
+        result = parse_provision_refs("die Bylaag", "afr")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("Bylaag", 4, 10)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("die Bylaag.", "afr")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("Bylaag", 4, 10)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("die Bylaag en ook", "afr")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("Bylaag", 4, 10)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_schedules_the_fra(self):
+        result = parse_provision_refs("l'annexe", "fra")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("l'annexe", 0, 8)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("l'annexe.", "fra")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("l'annexe", 0, 8)
+            ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+        result = parse_provision_refs("l'annexe et aussi", "fra")
+        self.assertEqual([
+            MainProvisionRef(
+                "attachment",
+                ProvisionRef("l'annexe", 0, 8)
             ),
         ], result.references)
         self.assertIsNone(result.target)

--- a/indigo/tests/test_provision_refs_grammar.py
+++ b/indigo/tests/test_provision_refs_grammar.py
@@ -349,7 +349,7 @@ class ProvisionRefsGrammarTest(TestCase):
         self.assertEqual("of", result.target)
         self.assertEqual(result.end, 49)
 
-    def test_schedules_num_eng(self):
+    def test_schedules_num(self):
         result = parse_provision_refs("Schedule 2a")
         self.assertEqual([
             MainProvisionRef(
@@ -365,6 +365,14 @@ class ProvisionRefsGrammarTest(TestCase):
                 "attachment",
                 ProvisionRef("Schedule 2a", 0, 11)
             ),
+        ], result.references)
+        self.assertIsNone(result.target)
+
+    def test_schedules_num_range(self):
+        result = parse_provision_refs("Schedule 2 to 30")
+        self.assertEqual([
+            MainProvisionRef('attachment', ProvisionRef('Schedule 2', 0, 10)),
+            MainProvisionRef('attachment', ProvisionRef('Schedule 30', 14, 16, separator='range')),
         ], result.references)
         self.assertIsNone(result.target)
 

--- a/indigo_api/tests/fixtures.py
+++ b/indigo_api/tests/fixtures.py
@@ -115,8 +115,8 @@ COMPONENT_FIXTURE = """<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/
     </body>
     <attachments>
       <attachment eId="att_1">
-        <heading>Schedule 1</heading>
-        <subheading>Subheading</subheading>
+        <heading>%(heading)s</heading>
+        <subheading>%(subheading)s</subheading>
         <doc name="schedule">
           <meta>
             <identification source="#slaw">
@@ -144,7 +144,7 @@ COMPONENT_FIXTURE = """<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/
             </identification>
           </meta>
           <mainBody>
-            %s
+            %(body)s
           </mainBody>
         </doc>
       </attachment>
@@ -172,8 +172,8 @@ def portion_fixture(text=None, xml=None):
     return PORTION_FIXTURE % xml
 
 
-def component_fixture(text=None, xml=None):
+def component_fixture(text=None, xml=None, heading="Schedule 1", subheading="Subheading"):
     if text:
         xml = """<section eId="sec_1"><content><p>%s</p></content></section>""" % text
 
-    return COMPONENT_FIXTURE % xml
+    return COMPONENT_FIXTURE % {'body': xml, 'heading': heading, 'subheading': subheading}


### PR DESCRIPTION
Handles:

* Schedule 1
* Schedule 1 to 4
* Schedule 1 and 4 (etc.)
* the Schedule

Does not handle:

* the First Schedule (etc.)


It works by looking for an `<attachment>` with an exact match on `<heading>`.