### PR TITLE
ensure the comment form validates when just posting a comment

### DIFF
--- a/indigo_app/templates/comments/preview.html
+++ b/indigo_app/templates/comments/preview.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+{# this file is used when the comment form is invalid, which usually means permission denied #}
+{% trans "You're not logged in, or something went wrong." %}

--- a/indigo_app/templates/indigo_api/_task_timeline.html
+++ b/indigo_app/templates/indigo_api/_task_timeline.html
@@ -21,7 +21,7 @@
   <li class="activity-item card">
     {% if user.is_authenticated %}
       {% get_comment_form for task as comment_form %}
-      <form hx-target="#task-{{ task.pk }}">
+      <form hx-target="#task-{{ task.pk }}" hx-post="{% comment_form_target %}">
         <div class="card-body">
           {% csrf_token %}
           {{ comment_form.honeypot.as_hidden }}
@@ -38,7 +38,6 @@
           <!-- TODO: disable button if there's no comment -->
           <button
               class="btn btn-primary ms-auto" type="submit"
-              hx-post="{% comment_form_target %}"
               hx-target="#task-timeline-{{ task.pk }}"
               name="next"
               value="{% url 'task_timeline' place=task.place.place_code pk=task.pk %}?next_url={{ next_url }}"

--- a/indigo_app/views/base.py
+++ b/indigo_app/views/base.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.template.response import TemplateResponse
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.views import redirect_to_login
@@ -46,6 +47,9 @@ class AbstractAuthedIndigoView(PermissionRequiredMixin, IndigoJSViewMixin):
 
         if self.requires_authentication():
             if not request.user.is_authenticated:
+                if request.htmx:
+                    # don't redirect HTMX requests
+                    raise PermissionDenied()
                 return redirect_to_login(self.request.get_full_path(), self.get_login_url(), self.get_redirect_field_name())
 
         if request.user.is_authenticated and self.must_accept_terms and not request.user.editor.accepted_terms:


### PR DESCRIPTION
This works because htmx obeys form validation *when submitting a form*. So the "Comment" button is a normal form submission button and the form's submit is triggered, which performs validation and prevents submission if validation fails.

The other buttons have `hx-post` on the button itself so htmx doesn't consider it a form submission and doesn't check validation, even though it includes the form details in the submission.

* also prevent htmx requests from redirecting to login page
* also override the comment preview template to show an error, rather than a weird form if the user is not logged in and the comment is posted via htmx - this is the only opportunity we have to change what the comment system does when the form is submitted without authentication

![image](https://github.com/user-attachments/assets/3131aaf3-209a-4f74-87c1-ba655857f333)
