### PR TITLE
Footnote marker

### DIFF
--- a/indigo_api/static/xsl/fo/_footnotes.xsl
+++ b/indigo_api/static/xsl/fo/_footnotes.xsl
@@ -27,10 +27,6 @@
               </fo:list-item-label>
               <fo:list-item-body start-indent="body-start()">
                 <fo:block>
-                  <!-- don't bold footnotes in headings -->
-                  <xsl:if test="ancestor::akn:heading">
-                    <xsl:attribute name="font-weight">normal</xsl:attribute>
-                  </xsl:if>
                   <xsl:apply-templates/>
                 </fo:block>
               </fo:list-item-body>

--- a/indigo_api/static/xsl/fo/_footnotes.xsl
+++ b/indigo_api/static/xsl/fo/_footnotes.xsl
@@ -8,7 +8,7 @@
   <xsl:template match="akn:authorialNote">
     <fo:footnote>
       <fo:inline>
-        <xsl:apply-templates select="@marker"/>
+        <xsl:apply-templates select="@marker"/><xsl:text>&#8203;</xsl:text>
       </fo:inline>
       <fo:footnote-body>
         <fo:block-container margin="0">

--- a/indigo_api/static/xsl/fo/_footnotes.xsl
+++ b/indigo_api/static/xsl/fo/_footnotes.xsl
@@ -11,16 +11,27 @@
         <xsl:apply-templates select="@marker"/><xsl:text>&#8203;</xsl:text>
       </fo:inline>
       <fo:footnote-body>
-        <fo:block-container margin="0">
-          <fo:block margin-top="{$para-spacing}" font-size="{$fontsize-footnote}">
-            <fo:inline-container width="0" margin-left="-{$indent}"
-                                 baseline-shift="super" font-size="{$fontsize-small}">
-              <fo:block>
-                <xsl:apply-templates select="@marker"/>
-              </fo:block>
-            </fo:inline-container>
-            <xsl:apply-templates/>
-          </fo:block>
+        <fo:block-container margin-left="0" margin-top="{$para-spacing}" font-size="{$fontsize-footnote}">
+          <fo:list-block start-indent="0" provisional-label-separation="{$indent}" text-align="start">
+            <fo:list-item>
+              <fo:list-item-label end-indent="label-end()">
+                <fo:block margin-top="{$para-spacing}" font-size="{$fontsize-small}">
+                  <fo:inline baseline-shift="super">
+                    <xsl:apply-templates select="@marker"/>
+                  </fo:inline>
+                </fo:block>
+              </fo:list-item-label>
+              <fo:list-item-body start-indent="body-start()">
+                <fo:block>
+                  <!-- don't bold footnotes in headings -->
+                  <xsl:if test="ancestor::akn:heading">
+                    <xsl:attribute name="font-weight">normal</xsl:attribute>
+                  </xsl:if>
+                  <xsl:apply-templates/>
+                </fo:block>
+              </fo:list-item-body>
+            </fo:list-item>
+          </fo:list-block>
         </fo:block-container>
       </fo:footnote-body>
     </fo:footnote>

--- a/indigo_api/static/xsl/fo/_footnotes.xsl
+++ b/indigo_api/static/xsl/fo/_footnotes.xsl
@@ -12,6 +12,10 @@
       </fo:inline>
       <fo:footnote-body>
         <fo:block-container margin-left="0" margin-top="{$para-spacing}" font-size="{$fontsize-footnote}">
+          <!-- don't bold footnotes in headings -->
+          <xsl:if test="ancestor::akn:heading">
+            <xsl:attribute name="font-weight">normal</xsl:attribute>
+          </xsl:if>
           <fo:list-block start-indent="0" provisional-label-separation="{$indent}" text-align="start">
             <fo:list-item>
               <fo:list-item-label end-indent="label-end()">

--- a/indigo_api/static/xsl/fo/_hier.xsl
+++ b/indigo_api/static/xsl/fo/_hier.xsl
@@ -130,7 +130,8 @@
    -->
   <xsl:template name="hier-container">
     <fo:block-container>
-      <fo:block margin-top="{$para-spacing}*2" font-size="{$fontsize-h2}" text-align="center" widows="2" orphans="2" keep-with-next="always" id="{@eId}" start-indent="0" font-weight="bold">
+      <fo:block margin-top="{$para-spacing}*2" font-size="{$fontsize-h2}" text-align="center" widows="2" orphans="2"
+                keep-with-next="always" keep-together.within-page="always" id="{@eId}" start-indent="0" font-weight="bold">
         <!-- optionally include startQuote character -->
         <xsl:if test="parent::akn:embeddedStructure and not(preceding-sibling::*)">
           <xsl:call-template name="start-quote">

--- a/indigo_api/static/xsl/fo/_variables.xsl
+++ b/indigo_api/static/xsl/fo/_variables.xsl
@@ -25,9 +25,9 @@
   </xsl:variable>
   <!-- 9pt -->
   <xsl:variable name="fontsize-h4" select="$fontsize"/>
-  <!-- 7.2pt -->
+  <!-- 7.65pt -->
   <xsl:variable name="fontsize-footnote">
-    <xsl:value-of select="$fontsize"/> * 0.8
+    <xsl:value-of select="$fontsize"/> * 0.85
   </xsl:variable>
   <!-- 11.25pt -->
   <xsl:variable name="fontsize-frontmatter" select="$fontsize-h2"/>

--- a/indigo_api/tests/pdf_fixtures/swahili_out.xml
+++ b/indigo_api/tests/pdf_fixtures/swahili_out.xml
@@ -45,11 +45,11 @@
       <fo:block-container text-align="start" line-height="1.3" font-size="9pt" font-family="PT Serif">
         <fo:block>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Kwanza" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Kwanza<fo:block keep-with-previous="always">(ib 1-32)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Kwanza" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Kwanza<fo:block keep-with-previous="always">(ib 1-32)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">JAMHURI YA MUUNGANO, VYAMA VYA SIASA, WATU NA SIASA YA UJAMAA NA KUJITEGEMEA</fo:block>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Kwanza__part_Kwanza" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Jamhuri ya muungano na watu (ib 1-5)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Kwanza__part_Kwanza" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Jamhuri ya muungano na watu (ib 1-5)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -344,7 +344,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Kwanza__part_Pili" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Kwanza__part_Pili" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block margin-top="0.8em" keep-with-next="always">MALENGO MUHIMU NA MISINGI YA MWELEKEO</fo:block>
                   <fo:block margin-top="0.8em" keep-with-next="always">WA SHUGHULI ZA SERIKALI (ss 6-11)</fo:block>
@@ -681,7 +681,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Kwanza__part_Tatu" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Kwanza__part_Tatu" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block margin-top="0.8em" keep-with-next="always">HAKI NA WAJIBU MUHIMU (Ib 12-32)</fo:block>
                   <fo:block margin-top="0.8em" keep-with-next="always">Haki ya Usawa (Ib 12-13)</fo:block>
@@ -2269,11 +2269,11 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Pili" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Pili<fo:block keep-with-previous="always">(ib 33-61)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Pili" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Pili<fo:block keep-with-previous="always">(ib 33-61)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">SERIKALI YA JAMHURI YA MUUNGANO</fo:block>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Pili__part_Kwanza" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Rais (ib 33-46b)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Pili__part_Kwanza" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Rais (ib 33-46b)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -3814,7 +3814,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Pili__part_Pili" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili – Makamu wa rais (ib 47-50)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Pili__part_Pili" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili – Makamu wa rais (ib 47-50)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -4288,7 +4288,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Pili__part_Tatu" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Pili__part_Tatu" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block margin-top="0.8em" keep-with-next="always">WAZIRI MKUU, BARAZA LA MAWAZIRI NA SERIKALI (Ib 51-61)</fo:block>
                   <fo:block margin-top="0.8em" keep-with-next="always">Waziri Mkuu (Ib 51-53A)</fo:block>
@@ -5154,11 +5154,11 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Tatu" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Tatu<fo:block keep-with-previous="always">(ib 62-101)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Tatu" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Tatu<fo:block keep-with-previous="always">(ib 62-101)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">BUNGE LA JAMHURI YA MUUNGANO</fo:block>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tatu__part_Kwanza" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Bunge (ib 62-65)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tatu__part_Kwanza" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Bunge (ib 62-65)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -5463,7 +5463,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tatu__part_Pili" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tatu__part_Pili" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block margin-top="0.8em" keep-with-next="always">WABUNGE, WILAYA ZA UCHAGUZI NA UCHAGUZI WA WABUNGE (Ib 66-83)</fo:block>
                   <fo:block margin-top="0.8em" keep-with-next="always">Wajumbe wa Bunge (Ib 66-73)</fo:block>
@@ -6989,7 +6989,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tatu__part_Tatu" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tatu__part_Tatu" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block margin-top="0.8em" keep-with-next="always">UTARATIBU, MADARAKA NA HAKI ZA BUNGE (Ib 84-101)</fo:block>
                   <fo:block margin-top="0.8em" keep-with-next="always">Spika na Naibu wa Spika (Ib 84-86)</fo:block>
@@ -8169,11 +8169,11 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Nne" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Nne<fo:block keep-with-previous="always">(ib 102-107)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Nne" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Nne<fo:block keep-with-previous="always">(ib 102-107)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">SERIKALI YA MAPINDUZI YA ZANZIBAR, BARAZA LA MAPINDUZI LA ZANZIBAR NA BARAZA LA WAWAKILISHI LA ZANZIBAR</fo:block>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Nne__part_Kwanza" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Serikali ya mapinduzi ya zanzibar na rais wa zanzibar (ib 102-104)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Nne__part_Kwanza" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Serikali ya mapinduzi ya zanzibar na rais wa zanzibar (ib 102-104)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -8370,7 +8370,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Nne__part_Pili" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili – Baraza la mapinduzi la zanzibar (s 105)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Nne__part_Pili" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili – Baraza la mapinduzi la zanzibar (s 105)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -8459,7 +8459,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Nne__part_Tatu" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu – Baraza la wawakilishi la zanzibar (ib 106-107)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Nne__part_Tatu" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu – Baraza la wawakilishi la zanzibar (ib 106-107)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -8622,11 +8622,11 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Tano" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Tano<fo:block keep-with-previous="always">(ib 107a-128)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Tano" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Tano<fo:block keep-with-previous="always">(ib 107a-128)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">UTOAJI HAKI KATIKA JAMHURI YA MUUNGANO, MAHAKAMA KUU YA JAMHURI YA MUUNGANO, TUME YA KUAJIRI YA MAHAKAMA YA TANZANIA BARA, MAHAKAMA KUU YA ZANZIBAR, MAHAKAMA YA RUFANI YA JAMHURI YA MUUNGANO NA MAHAKAMA MAALUM YA KATIBA YA JAMHURI YA MUUNGANO</fo:block>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Kwanza" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Utoaji haki katika jamhuri ya muungano (ib 107a-107b)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Kwanza" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Utoaji haki katika jamhuri ya muungano (ib 107a-107b)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -8728,7 +8728,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Pili" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili – Mahakama kuu ya jamhuri ya muungano (ib 108-111)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Pili" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili – Mahakama kuu ya jamhuri ya muungano (ib 108-111)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -9109,7 +9109,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Tatu" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Tatu" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tatu</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block margin-top="0.8em" keep-with-next="always">MADARAKA YA KUAJIRI MAHAKIMU NA WATUMISHI WENGINE WA MAHAKAMA ZA TANZANIA BARA NA TUME YA KUAJIRI YA MAHAKAMA (Ib 112-113A)</fo:block>
                   <fo:block-container>
@@ -9284,7 +9284,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Nne" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Nne – Mahakama kuu ya zanzibar (ib 114-115)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Nne" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Nne – Mahakama kuu ya zanzibar (ib 114-115)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -9338,7 +9338,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Tano" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tano – Mahakama ya rufani ya jamhuri ya muungano (ib 116-123)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Tano" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Tano – Mahakama ya rufani ya jamhuri ya muungano (ib 116-123)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -9783,7 +9783,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Sita" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Sita</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Sita" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Sita</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block margin-top="0.8em" keep-with-next="always">UTARATIBU WA KUPELEKA HATI ZA KUTEKELEZA MAAGIZO YALIYOMO KATIKA HATI ZILIZOTOLEWA NA MAHAKAMA (Ib 124)</fo:block>
                   <fo:block-container>
@@ -9861,7 +9861,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Saba" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Saba – Mahakama maalum ya katiba ya jamhuri ya muungano (ib 125-128)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Tano__part_Saba" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Saba – Mahakama maalum ya katiba ya jamhuri ya muungano (ib 125-128)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -10038,11 +10038,11 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Sita" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Sita<fo:block keep-with-previous="always">(ib 129-132)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Sita" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Sita<fo:block keep-with-previous="always">(ib 129-132)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">TUME YA HAKI ZA BINADAMU NA UTAWALA BORA NA SEKRETARIETI YA MAADILI YA VIONGOZI WA UMMA</fo:block>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Sita__part_Kwanza" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Tume ya haki za binadamu na utawala bora (ib 129-131)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Sita__part_Kwanza" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Tume ya haki za binadamu na utawala bora (ib 129-131)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -10576,7 +10576,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Sita__part_Pili" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Sita__part_Pili" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block margin-top="0.8em" keep-with-next="always">SEKRETARIETI YA MAADILI YA VIONGOZI</fo:block>
                   <fo:block margin-top="0.8em" keep-with-next="always">WA UMMA (s 132)</fo:block>
@@ -10741,11 +10741,11 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Saba" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Saba<fo:block keep-with-previous="always">(ib 133-144)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Saba" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Saba<fo:block keep-with-previous="always">(ib 133-144)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">MASHARTI KUHUSU MCHANGO WA SERIKALI NA MAMBO MENGINEYO YA FEDHA ZINAZOINGIA KATIKA HAZINA YA SERIKALI YA JAMHURI YA MUUNGANO</fo:block>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Saba__part_Kwanza" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Mchango na mgawanyo wa mapato ya jamhuri ya muungano (ib 133-134)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Saba__part_Kwanza" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Kwanza – Mchango na mgawanyo wa mapato ya jamhuri ya muungano (ib 133-134)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -10835,7 +10835,7 @@
                 </fo:block>
               </fo:block-container>
               <fo:block-container>
-                <fo:block font-weight="bold" start-indent="0" id="chp_Saba__part_Pili" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili – Mfuko mkuu wa hazina na fedha za jamhuri ya muungano (ib 135-144)</fo:block>
+                <fo:block font-weight="bold" start-indent="0" id="chp_Saba__part_Pili" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sehemu ya Pili – Mfuko mkuu wa hazina na fedha za jamhuri ya muungano (ib 135-144)</fo:block>
                 <fo:block margin-top="0.8em">
                   <fo:block-container>
                     <fo:list-block margin-top="0.8em*2" start-indent="0">
@@ -11502,7 +11502,7 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Nane" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Nane<fo:block keep-with-previous="always">(ib 145-146)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Nane" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Nane<fo:block keep-with-previous="always">(ib 145-146)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">MADARAKA YA UMMA</fo:block>
               <fo:block-container>
@@ -11616,7 +11616,7 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Tisa" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Tisa<fo:block keep-with-previous="always">(ib 147-148)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Tisa" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Tisa<fo:block keep-with-previous="always">(ib 147-148)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">MAJESHI YA ULINZI</fo:block>
               <fo:block-container>
@@ -11778,7 +11778,7 @@
             </fo:block>
           </fo:block-container>
           <fo:block-container>
-            <fo:block font-weight="bold" start-indent="0" id="chp_Kumi" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Kumi<fo:block keep-with-previous="always">(ib 149-152)</fo:block></fo:block>
+            <fo:block font-weight="bold" start-indent="0" id="chp_Kumi" keep-together.within-page="always" keep-with-next="always" orphans="2" widows="2" text-align="center" font-size="9pt * 1.25&#10;  " margin-top="0.8em*2">Sura ya Kumi<fo:block keep-with-previous="always">(ib 149-152)</fo:block></fo:block>
             <fo:block margin-top="0.8em">
               <fo:block margin-top="0.8em" keep-with-next="always">MENGINEYO</fo:block>
               <fo:block-container>


### PR DESCRIPTION
Deals with `/` between footnote references when rendering `2/3/4/` in a row:
<img width="737" alt="image" src="https://github.com/user-attachments/assets/17817f07-8520-4022-a1ee-030bd68a5636" />

Example of a heading/subheading that was breaking over a page:
<img width="734" alt="image" src="https://github.com/user-attachments/assets/8cfd6c87-9cac-49a0-a978-8202a9852c08" />
