### PR TITLE
don't break PDF when a num is an inline glyph

### DIFF
--- a/indigo_api/static/xsl/fo/_hier.xsl
+++ b/indigo_api/static/xsl/fo/_hier.xsl
@@ -232,7 +232,7 @@
                   </xsl:call-template>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:value-of select="akn:num"/>
+                  <xsl:apply-templates select="akn:num"/>
                 </xsl:otherwise>
               </xsl:choose>
             </fo:block>
@@ -302,7 +302,7 @@
                   </xsl:call-template>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:value-of select="akn:num"/>
+                  <xsl:apply-templates select="akn:num"/>
                 </xsl:otherwise>
               </xsl:choose>
               <!-- bullets for li -->

--- a/indigo_api/static/xsl/fo/_tables.xsl
+++ b/indigo_api/static/xsl/fo/_tables.xsl
@@ -56,7 +56,7 @@
         <xsl:if test="self::akn:th">
           <xsl:attribute name="font-weight">bold</xsl:attribute>
           <xsl:attribute name="text-align">center</xsl:attribute>
-          <xsl:attribute name="keep-with-next">1</xsl:attribute>
+          <xsl:attribute name="keep-with-next">always</xsl:attribute>
         </xsl:if>
         <!-- honour alignment -->
         <xsl:if test="@style='right'">

--- a/indigo_api/static/xsl/fo/_tables.xsl
+++ b/indigo_api/static/xsl/fo/_tables.xsl
@@ -56,7 +56,7 @@
         <xsl:if test="self::akn:th">
           <xsl:attribute name="font-weight">bold</xsl:attribute>
           <xsl:attribute name="text-align">center</xsl:attribute>
-          <xsl:attribute name="keep-with-next">always</xsl:attribute>
+          <xsl:attribute name="keep-with-next">1</xsl:attribute>
         </xsl:if>
         <!-- honour alignment -->
         <xsl:if test="@style='right'">


### PR DESCRIPTION
closes https://lawsafrica.sentry.io/issues/5343192673 again

<img width="224" alt="image" src="https://github.com/user-attachments/assets/b17d8640-1be1-4370-9ba5-b6511d35c03a" />

<img width="620" alt="image" src="https://github.com/user-attachments/assets/3f403fdc-6259-405f-89c7-755a636517dc" />

<img width="627" alt="image" src="https://github.com/user-attachments/assets/e839627f-a5f7-4526-85ad-c4508b01af3e" />

<img width="610" alt="image" src="https://github.com/user-attachments/assets/1867b73c-adb9-41b5-bedf-9cb1535d023d" />
