### PR TITLE
add blocking / unblocking task perms to ConverterBadge

### DIFF
--- a/indigo_social/default_badges.py
+++ b/indigo_social/default_badges.py
@@ -112,7 +112,7 @@ class ConverterBadge(PermissionBadge):
     group_name = name + ' Badge'
     description = 'Can do conversion tasks'
     permissions = (
-        'indigo_api.change_task', 'indigo_api.submit_task', 'indigo_api.reopen_task',
+        'indigo_api.change_task', 'indigo_api.submit_task', 'indigo_api.reopen_task', 'indigo_api.block_task',
     )
 
 


### PR DESCRIPTION
https://github.com/laws-africa/indigo/blob/a3426a150e1d8ac3d5e398846836572aa0a51e2e/indigo_api/models/tasks.py#L462-L465

Currently the import is being done but the related Import task isn't being unblocked when a user with only a Converter Badge does the Conversion task.