### PR TITLE
don't use 'refs-cap' citation matcher when linking references

### DIFF
--- a/indigo/analysis/refs/base.py
+++ b/indigo/analysis/refs/base.py
@@ -193,6 +193,7 @@ class SubtypeNumberCitationMatcherENG(DocumentPatternMatcherMixin, CitationMatch
         return f'/akn/{place}/act/{subtype}/{match.groups["year"]}/{match.groups["num"].lower()}'
 
 
+# TODO: no longer used in LINK_REFERENCES_PLUGINS; either update and add back in, or nuke
 @plugins.register('refs-cap')
 class RefsFinderCapENG(DocumentPatternMatcherMixin, CitationMatcher):
     """ Finds references to works with cap numbers, of the form:

--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -168,7 +168,7 @@ INDIGO = {
 
     # Plugins to use for linking references. The internal-refs must come after work-level plugins.
     'LINK_REFERENCES_PLUGINS': [
-        'refs-act-numbers', 'refs-act-names', 'refs-subtype-numbers', 'refs-aliases', 'refs-cap', 'internal-refs'
+        'refs-act-numbers', 'refs-act-names', 'refs-subtype-numbers', 'refs-aliases', 'internal-refs'
     ],
 
     # should we use pyodide to parse documents on the client?


### PR DESCRIPTION
closes #2373 