### PR TITLE
upgrade law-widgets to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fortawesome/fontawesome-free": "^5.2.0",
         "@lawsafrica/bluebell-monaco": "^4.8.2",
         "@lawsafrica/indigo-akn": "^5.6.0",
-        "@lawsafrica/law-widgets": "^2.0.1",
+        "@lawsafrica/law-widgets": "^2.2.1",
         "bootstrap-select": "^1.13.18",
         "bower": "^1.8.8",
         "canopy": "^0.4.1",
@@ -712,18 +712,18 @@
       }
     },
     "node_modules/@lawsafrica/law-widget-styles": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lawsafrica/law-widget-styles/-/law-widget-styles-2.0.0.tgz",
-      "integrity": "sha512-rAWssqTILBWnYTVxm7Jgz19ocQM8bsIS2RwDNnHA2zU96R6AOEOf1o7hTALb7UON3l74jcy8qkmQrEZiYFqdTw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@lawsafrica/law-widget-styles/-/law-widget-styles-2.2.0.tgz",
+      "integrity": "sha512-xI1qQmcEM4qZ4E2GxqI6oKPx7zDlysk2Uj/qF1i6HwqBkRjb2U1JV0g4Ggh97BFN8kHmcoyJYp08a16WQzvpIA==",
       "dev": true
     },
     "node_modules/@lawsafrica/law-widgets": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lawsafrica/law-widgets/-/law-widgets-2.0.1.tgz",
-      "integrity": "sha512-NkcLmnFegQ9Q0w9FqKZsH/N5ZJQfySeLFmSR+99WoWwZ9brIUNrHkC07EuMSYNKkwztLlAGjOzqTIg1NlHj1VQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@lawsafrica/law-widgets/-/law-widgets-2.2.1.tgz",
+      "integrity": "sha512-Ve2XkvHqiBi239B2huYsQABCtGO4h33AXesNpo5BEPazUvRDyXNOcKZcOr0ROEC4hJ0f36FEnSrr7c3+eo9iZg==",
       "dev": true,
       "dependencies": {
-        "@lawsafrica/law-widget-styles": "^2.0.0"
+        "@lawsafrica/law-widget-styles": "^2.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7069,18 +7069,18 @@
       }
     },
     "@lawsafrica/law-widget-styles": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@lawsafrica/law-widget-styles/-/law-widget-styles-2.0.0.tgz",
-      "integrity": "sha512-rAWssqTILBWnYTVxm7Jgz19ocQM8bsIS2RwDNnHA2zU96R6AOEOf1o7hTALb7UON3l74jcy8qkmQrEZiYFqdTw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@lawsafrica/law-widget-styles/-/law-widget-styles-2.2.0.tgz",
+      "integrity": "sha512-xI1qQmcEM4qZ4E2GxqI6oKPx7zDlysk2Uj/qF1i6HwqBkRjb2U1JV0g4Ggh97BFN8kHmcoyJYp08a16WQzvpIA==",
       "dev": true
     },
     "@lawsafrica/law-widgets": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lawsafrica/law-widgets/-/law-widgets-2.0.1.tgz",
-      "integrity": "sha512-NkcLmnFegQ9Q0w9FqKZsH/N5ZJQfySeLFmSR+99WoWwZ9brIUNrHkC07EuMSYNKkwztLlAGjOzqTIg1NlHj1VQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@lawsafrica/law-widgets/-/law-widgets-2.2.1.tgz",
+      "integrity": "sha512-Ve2XkvHqiBi239B2huYsQABCtGO4h33AXesNpo5BEPazUvRDyXNOcKZcOr0ROEC4hJ0f36FEnSrr7c3+eo9iZg==",
       "dev": true,
       "requires": {
-        "@lawsafrica/law-widget-styles": "^2.0.0"
+        "@lawsafrica/law-widget-styles": "^2.2.0"
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@fortawesome/fontawesome-free": "^5.2.0",
     "@lawsafrica/bluebell-monaco": "^4.8.2",
     "@lawsafrica/indigo-akn": "^5.6.0",
-    "@lawsafrica/law-widgets": "^2.0.1",
+    "@lawsafrica/law-widgets": "^2.2.1",
     "bootstrap-select": "^1.13.18",
     "bower": "^1.8.8",
     "canopy": "^0.4.1",


### PR DESCRIPTION
in particular this ensures that diffs involving `intro` and `wrapUp` render correctly as block elements