### PR TITLE
try to avoid deadlock

### DIFF
--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -815,6 +815,6 @@ class DocumentActivity(models.Model):
         return (timezone.now() - self.updated_at).total_seconds() > self.ASLEEP_SECS
 
     @classmethod
-    def vacuum(cls, document):
+    def vacuum(cls):
         threshold = timezone.now() - datetime.timedelta(seconds=cls.DEAD_SECS)
-        cls.objects.filter(document=document, updated_at__lte=threshold).delete()
+        cls.objects.filter(updated_at__lte=threshold).delete()

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -286,11 +286,6 @@ class DocumentActivityViewSet(DocumentResourceView,
     def get_queryset(self):
         return self.document.activities.prefetch_related('user').all()
 
-    def list(self, request, *args, **kwargs):
-        # clean up old activity
-        DocumentActivity.vacuum(self.document)
-        return super(DocumentActivityViewSet, self).list(request, *args, **kwargs)
-
     def create(self, request, *args, **kwargs):
         # if they've provided additional finished nonces, clear those out
         if request.data.get('finished_nonces'):


### PR DESCRIPTION
push document activity cleanup into a background task. This ensures we clean up everything (currently it requires someone to open a document), and may help to avoid deadlock that we're seeing occasionally.

I think the deadlock is caused by the mixture of the DELETE + (SELECT FOR UPDATE) + DELETE