### PR TITLE
avoid counting in the db

### DIFF
--- a/indigo/analysis/work_detail/base.py
+++ b/indigo/analysis/work_detail/base.py
@@ -65,7 +65,7 @@ class BaseWorkDetail(LocaleBasedMatcher):
         try:
             chapter_numbers = work.chapter_numbers.all()
             if chapter_numbers:
-                if work.chapter_numbers.count() == 1:
+                if chapter_numbers.count() == 1:
                     # there's only one -- easy peasy
                     return chapter_numbers.first()
                 # if any of them doesn't have a start or end date, we can't go further


### PR DESCRIPTION
Using the result from `.all()` saves going back to the db later:

```
ch = w.chapter_numbers.all()
2025-07-24 07:54:30,868 DEBUG utils none 67493 12901707776 (0.002) SELECT "indigo_api_chapternumber"."id", "indigo_api_chapternumber"."number", "indigo_api_chapternumber"."name", "indigo_api_chapternumber"."work_id", "indigo_api_chapternumber"."validity_start_date", "indigo_api_chapternumber"."validity_end_date", "indigo_api_chapternumber"."revision_name" FROM "indigo_api_chapternumber" WHERE "indigo_api_chapternumber"."work_id" = 126 ORDER BY "indigo_api_chapternumber"."validity_start_date" DESC; args=(126,); alias=default
ch.count()
Out[5]: 0

w.chapter_numbers.count()
2025-07-24 07:54:39,449 DEBUG utils none 67493 8555974528 (0.002) SELECT COUNT(*) AS "__count" FROM "indigo_api_chapternumber" WHERE "indigo_api_chapternumber"."work_id" = 126; args=(126,); alias=default
Out[6]: 0
```