### PR TITLE
bugs: handle case of no html, delete revisions with sql

### DIFF
--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -488,7 +488,7 @@ class DocumentDiffView(DocumentResourceView, View):
         remote_html, local_html = await self.prepare()
         diff = await AKNHTMLDiffer().adiff_html_str(remote_html, local_html)
         # diff is None if there is no difference, in which case just return the remote HTML
-        diff = diff or ("<div>" + remote_html + "</div>")
+        diff = diff or ("<div>" + (remote_html or '') + "</div>")
 
         return JsonResponse({
             'html_diff': diff


### PR DESCRIPTION
* handle case of no HTML when diffing
* delete old revisions with sql, rather than call_command, because the latter loads all objects into memory to delete them