### PR TITLE
block tasks the first time they're 'blocked by' another

### DIFF
--- a/indigo_app/forms/tasks.py
+++ b/indigo_app/forms/tasks.py
@@ -87,6 +87,9 @@ class TaskForm(forms.ModelForm):
                 self.output_file_form.instance.save()
             task.output_file = self.output_file_form.instance
             task.save()
+        # if a 'blocked by' task was selected for the first time, block the task too
+        if commit and task.blocked_by.exists() and task.state in Task.UNBLOCKED_STATES:
+            task.block(task.updated_by_user or task.created_by_user)
         return task
 
 


### PR DESCRIPTION
this will fix https://edit.laws.africa/places/tz/tasks/113855 where the task had to be blocked separately after a blocking task was chosen