### PR TITLE
Async diffs for revisions; django 5.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,9 +5,10 @@ Changelog
 19.0.0 (???)
 ------------
 
-* BREAKING: Upgrade to Django 4.2 and Python >= 3.10
+* BREAKING: Upgrade to Django 5.0 and Python >= 3.10
 * CHANGE: Taxonomies are removed. You must upgrade to 18.1.0 first and run `python manage.py migrate_taxonomies` before upgrading to this version.
 * Remove: unused charts.js library and charts code
+* Add support for running diffs asynchronously as separate processes
 
 18.1.0 (2024-03-25)
 -------------------

--- a/indigo/bulk_creator.py
+++ b/indigo/bulk_creator.py
@@ -676,7 +676,7 @@ The amendment has already been linked, so start at Step 3 of https://docs.laws.a
             pub_doc.save()
 
     def create_link_gazette_task(self, work, row):
-        existing_task = Task.objects.filter(work=work, code='link-gazette').first()
+        existing_task = Task.objects.filter(work=work, code='link-gazette').first() if work.pk else None
         if not existing_task:
             self.create_task(work, row, task_type='link-gazette')
 

--- a/indigo_api/urls.py
+++ b/indigo_api/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path, re_path
+from django.views.decorators.cache import cache_control
 from rest_framework.routers import DefaultRouter
 
 import indigo_api.views.attachments as attachments
@@ -29,6 +30,8 @@ urlpatterns = [
     path('documents/<int:document_id>/analysis/link-references', documents.LinkReferencesView.as_view(), name='link-references'),
     path('documents/<int:document_id>/analysis/mark-up-italics', documents.MarkUpItalicsTermsView.as_view(), name='mark-up-italics'),
     path('documents/<int:document_id>/analysis/sentence-case-headings', documents.SentenceCaseHeadingsView.as_view(), name='sentence-case-headings'),
+
+    path('documents/<int:document_id>/revisions/<int:pk>/diff', cache_control(public=True, max_age=24 * 3600)(documents.RevisionDiffView.as_view()), name='document-revisions-diff'),
 
     path('', include(router.urls)),
 ]

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -248,7 +248,7 @@ class RevisionDiffView(DocumentResourceView, DetailView):
     permission_classes = RevisionViewSet.permission_classes
 
     # disabled atomic requests
-    dispatch = transaction.non_atomic_requests(View.dispatch)
+    dispatch = transaction.non_atomic_requests(DetailView.dispatch)
 
     def get_queryset(self):
         return self.document.versions().defer('serialized_data')

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -252,7 +252,7 @@ class AsyncDocumentResourceViewMixin(AsyncDispatchMixin, DocumentResourceView):
                     raise PermissionDenied()
 
 
-class RevisionDiffView(AsyncDocumentResourceViewMixin, DetailView):
+class RevisionDiffView(AsyncDocumentResourceViewMixin, AbstractAuthedIndigoView, DetailView):
     """Handles diffs between two revisions of a document.
 
     This could be implemented as a detail view of RevisionViewSet, but it runs asynchronously which DRF doesn't yet

--- a/indigo_app/tests/test_authed_urls.py
+++ b/indigo_app/tests/test_authed_urls.py
@@ -52,6 +52,7 @@ api/documents/(?P<document_id>[0-9]+)/parse\Z
 api/documents/(?P<document_id>[0-9]+)/diff\Z
 api/documents/(?P<document_id>[0-9]+)/media/(?P<filename>.*)$
 api/documents/(?P<document_id>[0-9]+)/activity/edits\Z
+api/documents/(?P<document_id>[0-9]+)/revisions/(?P<pk>[0-9]+)/diff\Z
 api/publications/(?P<country>[a-z]{2})(-(?P<locality>[^/]+))?/find$
 """.split()
 

--- a/indigo_app/tests/test_authed_urls.py
+++ b/indigo_app/tests/test_authed_urls.py
@@ -52,7 +52,6 @@ api/documents/(?P<document_id>[0-9]+)/parse\Z
 api/documents/(?P<document_id>[0-9]+)/diff\Z
 api/documents/(?P<document_id>[0-9]+)/media/(?P<filename>.*)$
 api/documents/(?P<document_id>[0-9]+)/activity/edits\Z
-api/documents/(?P<document_id>[0-9]+)/revisions/(?P<pk>[0-9]+)/diff\Z
 api/publications/(?P<country>[a-z]{2})(-(?P<locality>[^/]+))?/find$
 """.split()
 

--- a/indigo_app/views/base.py
+++ b/indigo_app/views/base.py
@@ -8,7 +8,6 @@ from django.template.response import TemplateResponse
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.views import redirect_to_login
 from django.http import Http404
-from tornado.gen import is_coroutine_function
 
 from indigo_api.authz import is_maintenance_mode
 from indigo_api.models import Country, Work, AllPlace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "django>=4.2,<=5.0",
+    "django~=5.0.0",
     "boto3>=1.7",
     "urllib3<2.1",  # botocore doesn"t play well with urllib3 > 2.1 see https://github.com/boto/botocore/issues/2926
     "bluebell-akn>=3.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "django>=4.2,<5",
+    "django>=4.2",
     "boto3>=1.7",
     "urllib3<2.1",  # botocore doesn"t play well with urllib3 > 2.1 see https://github.com/boto/botocore/issues/2926
     "bluebell-akn>=3.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "django>=4.2,<5.2",
+    "django>=4.2,<=5.0",
     "boto3>=1.7",
     "urllib3<2.1",  # botocore doesn"t play well with urllib3 > 2.1 see https://github.com/boto/botocore/issues/2926
     "bluebell-akn>=3.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "django>=4.2",
+    "django>=4.2,<5.2",
     "boto3>=1.7",
     "urllib3<2.1",  # botocore doesn"t play well with urllib3 > 2.1 see https://github.com/boto/botocore/issues/2926
     "bluebell-akn>=3.1.1",


### PR DESCRIPTION
Django 5.0 is required because it supports caching for async views