### PR TITLE
ignore a:act[@contains] when diffing

### DIFF
--- a/indigo_lib/differ.py
+++ b/indigo_lib/differ.py
@@ -89,6 +89,10 @@ class AKNHTMLDiffer:
         for elem in root.xpath(xpath, namespaces={'a': root.nsmap[None]}):
             elem.attrib.pop('eId')
 
+        # remove certain attributes that can differ between docs and confuse the differ
+        for elem in root.xpath('./a:*[@contains]', namespaces={'a': root.nsmap[None]}):
+            elem.attrib.pop('contains')
+
         return root
 
     def count_differences(self, diff_tree):

--- a/indigo_lib/tests/test_differ.py
+++ b/indigo_lib/tests/test_differ.py
@@ -149,7 +149,9 @@ class AKNHTMLDifferTestCase(TestCase):
 
     def test_preprocess_xml(self):
         xml = self.differ.preprocess_xml_str("""
-<section xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" eId="chp_3__sec_4">
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+<act name="act" contains="singleVersion">
+<section eId="chp_3__sec_4">
   <num>4</num>
   <heading>Heading</heading>
   <content>
@@ -157,10 +159,14 @@ class AKNHTMLDifferTestCase(TestCase):
     <p refersTo="#term-Court" eId="chp_3__sec_4__p_2">"<def refersTo="#term-Court" eId="chp_3__sec_4__p_2__def_1">Court</def>" means a provincial or local division of the Supreme Court of South Africa or any judge thereof;</p>
     <p eId="chp_3__sec_4__p_3"><remark status="editorial">[definition of "court" amended by <ref href="/akn/za/act/1996/49" eId="chp_3__sec_4__p_3__ref_1">Act 49 of 1996</ref>]</remark></p>
   </content>
-</section>""")
+</section>
+</act>
+</akomaNtoso>""")
 
         self.assertEqual("""
-<section xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" eId="chp_3__sec_4">
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+<act name="act">
+<section eId="chp_3__sec_4">
   <num>4</num>
   <heading>Heading</heading>
   <content>
@@ -168,7 +174,9 @@ class AKNHTMLDifferTestCase(TestCase):
     <p refersTo="#term-Court" eId="chp_3__sec_4__p_2">"<def refersTo="#term-Court">Court</def>" means a provincial or local division of the Supreme Court of South Africa or any judge thereof;</p>
     <p eId="chp_3__sec_4__p_3"><remark status="editorial">[definition of "court" amended by <ref href="/akn/za/act/1996/49">Act 49 of 1996</ref>]</remark></p>
   </content>
-</section>""".strip(),
+</section>
+</act>
+</akomaNtoso>""".strip(),
             xml.decode('utf-8').strip()
         )
 


### PR DESCRIPTION
this can change between expressions (first expression doesn't have it, older expressions do), is meaningless, and confuses the differ

our recent differ changes started diffing more `data-` attributes than before, so suddenly this started interfering (it becomes `data-contains`).