### PR TITLE
Fix finding definitions sections

### DIFF
--- a/indigo/analysis/terms/base.py
+++ b/indigo/analysis/terms/base.py
@@ -80,6 +80,9 @@ class BaseTermsFinder(LocaleBasedMatcher):
         self.defn_hier_xpath = etree.XPath(
             '|'.join(f'//a:{x}' for x in self.defn_hier),
             namespaces=self.nsmap)
+        self.defn_hier_xpath_scoped = etree.XPath(
+            '|'.join(f'.//a:{x}' for x in self.defn_hier),
+            namespaces=self.nsmap)
         self.heading_xpath = etree.XPath('a:heading', namespaces=self.nsmap)
         self.defn_containers_xpath = etree.XPath('.//a:p|.//a:listIntroduction', namespaces=self.nsmap)
         self.text_xpath = etree.XPath('//a:body//text()', namespaces=self.nsmap)
@@ -165,6 +168,10 @@ class BaseTermsFinder(LocaleBasedMatcher):
 
     def contains_definition_block_container(self, element):
         # returns True for the first blockContainer that has 'definition' as one of its classes
+        # but returns False if a subelement is better suited, e.g. section 23N(1) rather than section 23
+        for option in self.defn_hier_xpath_scoped(element):
+            if self.contains_definition_block_container(option):
+                return False
         for block_container in element.xpath('.//a:blockContainer[@class]', namespaces=self.nsmap):
             if 'definition' in block_container.get('class', '').split():
                 return True

--- a/indigo_za/tests/test_terms_eng.py
+++ b/indigo_za/tests/test_terms_eng.py
@@ -473,3 +473,231 @@ class TermsFinderENGTestCase(APITestCase):
     </body>
   
 ''', etree.tostring(doc.doc.body, pretty_print=True).decode('utf-8'))
+
+    def test_definition_sections_simple(self):
+        doc = Document(work=self.work, content=document_fixture(xml="""
+<chapter eId="chp_1">
+  <num>1</num>
+  <heading>Interpretation and objects</heading>
+  <section eId="chp_1__sec_1">
+    <num>1.</num>
+    <heading>Definitions</heading>
+  </section>
+  <section eId="chp_1__sec_2">
+    <num>2.</num>
+    <heading>Objects of Act</heading>
+  </section>
+  <section eId="chp_1__sec_3">
+    <num>3.</num>
+    <heading>Application of Act</heading>
+  </section>
+</chapter>
+<chapter eId="chp_2">
+  <num>2</num>
+  <heading>Agricultural land management</heading>
+  <section eId="chp_2__sec_4">
+    <num>4.</num>
+    <heading>Principles</heading>
+  </section>
+  <section eId="chp_2__sec_5">
+    <num>5.</num>
+    <heading>Agricultural land evaluation and classification</heading>
+  </section>
+  <part eId="chp_2__part_3">
+    <num>3</num>
+    <heading>Provincial agricultural sector plans</heading>
+    <section eId="chp_2__part_3__sec_6">
+      <num>6.</num>
+      <heading>Preparation of provincial agricultural sector plans</heading>
+    </section>
+    <section eId="chp_2__part_3__sec_7">
+      <num>7.</num>
+      <heading>Purpose of provincial agricultural sector plans</heading>
+    </section>
+  </part>
+</chapter>"""))
+
+        self.maxDiff = None
+        root = etree.fromstring(doc.content.encode('utf-8'))
+        self.finder.setup(root)
+        self.assertEqual(['chp_1__sec_1', 'chp_1'], [(section.get('eId')) for section in self.finder.definition_sections(root)])
+
+    def test_definition_sections_block_containers(self):
+        doc = Document(work=self.work, content=document_fixture(xml="""
+<section eId="sec_23N">
+  <num>23N.</num>
+  <heading>Limitation of <term refersTo="#term-interest" eId="sec_23N__term_1">interest</term> deductions in respect of reorganisation and acquisition transactions</heading>
+  <subsection eId="sec_23N__subsec_1">
+    <num>(1)</num>
+    <content>
+      <p eId="sec_23N__subsec_1__p_1">For the purposes of this section—</p>
+      <blockContainer refersTo="#term-acquired_company" class="definition" eId="sec_23N__subsec_1__blockContainer_1">
+        <blockList eId="sec_23N__subsec_1__blockContainer_1__list_1">
+          <listIntroduction eId="sec_23N__subsec_1__blockContainer_1__list_1__intro_1">“<def refersTo="#term-acquired_company" eId="sec_23N__subsec_1__blockContainer_1__list_1__intro_1__def_1">acquired company</def>” means—</listIntroduction>
+          <item eId="sec_23N__subsec_1__blockContainer_1__list_1__item_a">
+            <num>(a)</num>
+            <p eId="sec_23N__subsec_1__blockContainer_1__list_1__item_a__p_1">a transferor <term refersTo="#term-company" eId="sec_23N__subsec_1__blockContainer_1__list_1__item_a__p_1__term_1">company</term> or a liquidating <term refersTo="#term-company" eId="sec_23N__subsec_1__blockContainer_1__list_1__item_a__p_1__term_2">company</term> that disposes of assets pursuant to a <term refersTo="#term-reorganisation_transaction" eId="sec_23N__subsec_1__blockContainer_1__list_1__item_a__p_1__term_3">reorganisation transaction</term>; or</p>
+          </item>
+          <item eId="sec_23N__subsec_1__blockContainer_1__list_1__item_b">
+            <num>(b)</num>
+            <p eId="sec_23N__subsec_1__blockContainer_1__list_1__item_b__p_1">a <term refersTo="#term-company" eId="sec_23N__subsec_1__blockContainer_1__list_1__item_b__p_1__term_1">company</term> in which equity shares are acquired by another <term refersTo="#term-company" eId="sec_23N__subsec_1__blockContainer_1__list_1__item_b__p_1__term_2">company</term> in terms of an <term refersTo="#term-acquisition_transaction" eId="sec_23N__subsec_1__blockContainer_1__list_1__item_b__p_1__term_3">acquisition transaction</term>;</p>
+          </item>
+        </blockList>
+      </blockContainer>
+    </content>
+  </subsection>
+  <subsection eId="sec_23N__subsec_4">
+    <num>(4)</num>
+    <intro>
+      <p eId="sec_23N__subsec_4__intro__p_1">The percentage contemplated in subsection <ref href="#chp_II__part_I__sec_23N__subsec_3__para_b" eId="sec_23N__subsec_4__intro__p_1__ref_1">(3)(b)</ref> must be determined in accordance with the formula—</p>
+      <p eId="sec_23N__subsec_4__intro__p_2">in which formula—</p>
+    </intro>
+    <paragraph eId="sec_23N__subsec_4__para_a">
+      <num>(a)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_a__p_1">“A” represents the percentage to be determined;</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_b">
+      <num>(b)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_b__p_1">“B” represents the number 40;</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_c">
+      <num>(c)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_c__p_1">“C” represents the <term refersTo="#term-average_repo_rate" eId="sec_23N__subsec_4__para_c__p_1__term_1">average repo rate</term> plus 400 basis points; and</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_d">
+      <num>(d)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_d__p_1">“D” represents the number 10,</p>
+      </content>
+    </paragraph>
+    <wrapUp>
+      <p eId="sec_23N__subsec_4__wrapup__p_1">but not exceeding 60 per cent of the <term refersTo="#term-adjusted_taxable_income" eId="sec_23N__subsec_4__wrapup__p_1__term_1">adjusted taxable income</term> of that <term refersTo="#term-acquiring_company" eId="sec_23N__subsec_4__wrapup__p_1__term_2">acquiring company</term>.</p>
+    </wrapUp>
+  </subsection>
+  <subsection eId="sec_23N__subsec_5">
+    <num>(5)</num>
+    <content>
+      <p eId="sec_23N__subsec_5__p_1"><remark status="editorial">[subsection <ref href="#chp_II__part_I__sec_23N__subsec_5" eId="sec_23N__subsec_5__p_1__ref_1">(5)</ref> deleted by section 42(1)(d) of <ref href="/akn/za/act/2018/23" eId="sec_23N__subsec_5__p_1__ref_2">Act 23 of 2018</ref>; effective date 1 January 2019, applicable in respect of amounts incurred on or after that date]</remark></p>
+    </content>
+  </subsection>
+</section>"""))
+
+        self.maxDiff = None
+        root = etree.fromstring(doc.content.encode('utf-8'))
+        self.finder.setup(root)
+        self.assertEqual(['sec_23N__subsec_1'], [(section.get('eId')) for section in self.finder.definition_sections(root)])
+
+    def test_find_block_containers_not_sibling_elements(self):
+        """ If section 23N(1) explicitly contains definitions
+            because it has one or more <blockContainer class="definition"> descendants,
+            don't also mark up 'terms' in section 23N(4). Anything else in subsection (1) is fair game though.
+        """
+        doc = Document(work=self.work, content=document_fixture(xml="""
+<section eId="sec_23N">
+  <num>23N.</num>
+  <heading>Limitation of interest deductions in respect of reorganisation and acquisition transactions</heading>
+  <subsection eId="sec_23N__subsec_1">
+    <num>(1)</num>
+    <content>
+      <p eId="sec_23N__subsec_1__p_1">For the purposes of this section—</p>
+      <blockContainer class="definition" eId="sec_23N__subsec_1__blockContainer_1">
+        <p eId="sec_23N__subsec_1__blockContainer_1__p_1">“average repo rate” in relation to a year of assessment means the average of all ruling repo rates determined by using the daily repo rates during that year of assessment;</p>
+      </blockContainer>
+    </content>
+  </subsection>
+  <subsection eId="sec_23N__subsec_4">
+    <num>(4)</num>
+    <intro>
+      <p eId="sec_23N__subsec_4__intro__p_1">The percentage contemplated in subsection (3)(b) must be determined in accordance with the formula—</p>
+      <p eId="sec_23N__subsec_4__intro__p_2">in which formula—</p>
+    </intro>
+    <paragraph eId="sec_23N__subsec_4__para_a">
+      <num>(a)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_a__p_1">“A” represents the percentage to be determined;</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_b">
+      <num>(b)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_b__p_1">“B” represents the number 40;</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_c">
+      <num>(c)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_c__p_1">“C” represents the average repo rate plus 400 basis points; and</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_d">
+      <num>(d)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_d__p_1">“D” represents the number 10,</p>
+      </content>
+    </paragraph>
+    <wrapUp>
+      <p eId="sec_23N__subsec_4__wrapup__p_1">but not exceeding 60 per cent of the adjusted taxable income of that acquiring company.</p>
+    </wrapUp>
+  </subsection>
+</section>"""))
+
+        self.maxDiff = None
+        self.finder.find_terms_in_document(doc)
+        self.assertMultiLineEqual('''<body xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+      
+<section eId="sec_23N">
+  <num>23N.</num>
+  <heading>Limitation of interest deductions in respect of reorganisation and acquisition transactions</heading>
+  <subsection eId="sec_23N__subsec_1">
+    <num>(1)</num>
+    <content>
+      <p eId="sec_23N__subsec_1__p_1">For the purposes of this section—</p>
+      <blockContainer class="definition" eId="sec_23N__subsec_1__blockContainer_1" refersTo="#term-average_repo_rate">
+        <p eId="sec_23N__subsec_1__blockContainer_1__p_1">“<def refersTo="#term-average_repo_rate" eId="sec_23N__subsec_1__blockContainer_1__p_1__def_1">average repo rate</def>” in relation to a year of assessment means the average of all ruling repo rates determined by using the daily repo rates during that year of assessment;</p>
+      </blockContainer>
+    </content>
+  </subsection>
+  <subsection eId="sec_23N__subsec_4">
+    <num>(4)</num>
+    <intro>
+      <p eId="sec_23N__subsec_4__intro__p_1">The percentage contemplated in subsection (3)(b) must be determined in accordance with the formula—</p>
+      <p eId="sec_23N__subsec_4__intro__p_2">in which formula—</p>
+    </intro>
+    <paragraph eId="sec_23N__subsec_4__para_a">
+      <num>(a)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_a__p_1">“A” represents the percentage to be determined;</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_b">
+      <num>(b)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_b__p_1">“B” represents the number 40;</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_c">
+      <num>(c)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_c__p_1">“C” represents the <term refersTo="#term-average_repo_rate" eId="sec_23N__subsec_4__para_c__p_1__term_1">average repo rate</term> plus 400 basis points; and</p>
+      </content>
+    </paragraph>
+    <paragraph eId="sec_23N__subsec_4__para_d">
+      <num>(d)</num>
+      <content>
+        <p eId="sec_23N__subsec_4__para_d__p_1">“D” represents the number 10,</p>
+      </content>
+    </paragraph>
+    <wrapUp>
+      <p eId="sec_23N__subsec_4__wrapup__p_1">but not exceeding 60 per cent of the adjusted taxable income of that acquiring company.</p>
+    </wrapUp>
+  </subsection>
+</section>
+    </body>
+  
+''', etree.tostring(doc.doc.body, pretty_print=True, encoding='unicode'))


### PR DESCRIPTION
Currently if section 23N(1) contains defined terms as blockContainers, the whole of section 23N is deemed a definitions section — and similarly with its parent Part, Chapter, etc. Then every node with "something" at the start is marked up as a defined term, which was not the intention. 

This way, only the subelement that most closely contains a blcokContainer.definition will be deemed a definitions section. 

I'm concerned though that we'd now be traversing the whole tree as well as each node's descendants, potentially slowing the whole show down significantly. 

Perhaps a better idea would be to reverse the result of the xpath, and skip checking any parents? So we'd start with say section 23N(4)(d), and return False for everything until we hit section 23N(1). Then skip checking section 23N itself, as well as Part II, Chapter 1, etc. Would we then still catch section 23D(1) though? I'll have a look.

Update: yes, because of the way the reversal works, section 23D is hit before its parent Part. But because the xpath result doesn't know about ancestors, we need to explicitly track which elements have already been yielded. I've updated accordingly.