### PR TITLE
helper redirect akn view

### DIFF
--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -37,6 +37,14 @@ class WorksTest(testcases.TestCase):
         response = self.client.get('/works/akn/za-cpt/act/2005/1/related/')
         self.assertEqual(response.status_code, 200)
 
+    def test_akn_resolver_document(self):
+        document = Document.objects.order_by('id').first()
+        expression_frbr_uri = document.expression_frbr_uri
+        response = self.client.get(expression_frbr_uri)
+        self.assertRedirects(response, f"/documents/{document.id}/", fetch_redirect_response=False)
+        response = self.client.get(document.frbr_uri)
+        self.assertRedirects(response, f"/works{document.frbr_uri}/", fetch_redirect_response=False)
+
     def test_amendments_page(self):
         response = self.client.get('/works/akn/za/act/2014/10/amendments/')
         self.assertEqual(response.status_code, 200)

--- a/indigo_app/urls.py
+++ b/indigo_app/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
 
     path('terms', TemplateView.as_view(template_name='indigo_app/terms.html'), name='terms_of_use'),
     path('help', RedirectView.as_view(url='https://indigo.readthedocs.io/en/latest/', permanent=False), name='help'),
+    re_path('^(?P<frbr_uri>akn/.+)$', works.AknResolverView.as_view(), name='akn_resolver'),
 
     path('places', places.PlaceListView.as_view(), name='places'),
     path('places/<str:place>', places.PlaceDetailView.as_view(), name='place'),


### PR DESCRIPTION
This means we can dump an FRBR URI into the address bar eg `edit.laws.africa/akn/...` and it'll redirect to the document or work.