### PR TITLE
button to open provision editor on current provision

### DIFF
--- a/indigo_app/static/javascript/indigo/views/document.js
+++ b/indigo_app/static/javascript/indigo/views/document.js
@@ -171,6 +171,7 @@
       this.sentenceCaseView = new Indigo.DocumentSentenceCaseView({model: this.documentContent});
       this.revisionsView = new Indigo.DocumentRevisionsView({document: this.document, documentContent: this.documentContent});
       this.tocView = new Indigo.DocumentTOCView({model: this.documentContent, document: this.document});
+      this.tocView.selection.on('change', this.onTocSelectionChanged, this);
 
       this.sourceEditorView = new Indigo.SourceEditorView({
         model: this.document,
@@ -352,6 +353,23 @@
     onPaneToggled: function (e) {
       if (e.originalEvent.detail.pane === 'document-secondary-pane') {
         this.secondaryPaneToggle.classList.toggle('active', e.originalEvent.detail.visible);
+      }
+    },
+
+    onTocSelectionChanged: function (selection) {
+      // update provision editor link
+      const a = this.el.querySelector('.document-toolbar-wrapper .open-provision-editor');
+      if (a) {
+        a.disabled = true;
+        a.classList.toggle('disabled', true);
+
+        if (selection.get('element') && selection.get('element').getAttribute('eId')) {
+          const eId = selection.get('element').getAttribute('eId');
+          const href = `/documents/${this.document.get('id')}/provision/${eId}`;
+          a.setAttribute('href', href);
+          a.disabled = false;
+          a.classList.remove('disabled');
+        }
       }
     }
   });

--- a/indigo_app/templates/indigo_api/document/_toolbar.html
+++ b/indigo_app/templates/indigo_api/document/_toolbar.html
@@ -26,6 +26,7 @@
 
   <div class="btn-group btn-group-sm me-2">
     <button type="button" class="btn btn-outline-secondary show-structure" data-bs-toggle="buttons" title="{% trans "Outline Akoma Ntoso Structure" %}"><i class="fas fa-sitemap"></i> {% trans "Structure" %}</button>
+    <a href="#" disabled class="btn btn-outline-secondary disabled open-provision-editor" title="{% trans "View only this provision" %}"><i class="fas fa-search-plus"></i> {% trans "Edit provision" %}</a>
   </div>
 
   <div class="btn-group btn-group-sm me-2 document-analysis-menu">


### PR DESCRIPTION
<img width="1206" height="420" alt="image" src="https://github.com/user-attachments/assets/c081bdce-00f8-461e-b95d-639c009f25f9" />

this makes it easy to jump to editing just the current provision in the provision editor.