### PR TITLE
Guard against null parent in table toggleHeading

### DIFF
--- a/indigo_app/static/javascript/indigo/views/table_editor.js
+++ b/indigo_app/static/javascript/indigo/views/table_editor.js
@@ -382,6 +382,7 @@
       cells.forEach(function(cell) {
         if (cell.tagName === 'TH' && makeHeading) return;
         if (cell.tagName === 'TD' && !makeHeading) return;
+        if (!cell.parentElement) return;
 
         cell.parentElement.replaceChild(
           self.renameNode(cell, makeHeading ? 'th' : 'td'),


### PR DESCRIPTION
Fixes #2525.

When toggling table heading cells, `cell.parentElement` can be null if the cell has been detached from the DOM mid-iteration (e.g. concurrent CKEditor mutations). The `replaceChild` call then throws:

```
TypeError: Cannot read properties of null (reading 'replaceChild')
```

Skip cells whose parent is no longer attached. Same guard pattern used elsewhere in the file.