### PR TITLE
Skip empty extra forms in WorkFormAmendmentsView

### DIFF
--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -77,6 +77,20 @@ class WorksTest(testcases.TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(work.amendments.all()), 1)
 
+    def test_form_amendments_view_with_empty_extra_form(self):
+        # an extra unfilled form should not blow up the view (regression for KeyError: 'amended_work')
+        response = self.client.post('/works/akn/za/act/2010/1/form/amendments', {
+            'amendments_made-TOTAL_FORMS': '1',
+            'amendments_made-INITIAL_FORMS': '0',
+            'amendments_made-MIN_NUM_FORMS': '0',
+            'amendments_made-MAX_NUM_FORMS': '1000',
+            'amendments_made-0-amending_work': '',
+            'amendments_made-0-amended_work': '',
+            'amendments_made-0-date': '',
+            'amendments_made-0-id': '',
+        })
+        self.assertEqual(response.status_code, 200)
+
     def test_import_view(self):
         response = self.client.get('/works/akn/za/act/2014/10/import/')
         self.assertEqual(response.status_code, 200)

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -1418,6 +1418,9 @@ class WorkFormAmendmentsView(WorkViewBase, TemplateView):
         initial = []
         if formset.is_valid():
             for form in formset:
+                # skip empty extra forms and deleted unsaved forms
+                if not form.cleaned_data:
+                    continue
                 delete = form.cleaned_data.get('DELETE')
                 if delete:
                     if not form.cleaned_data.get('id'):
@@ -1430,8 +1433,8 @@ class WorkFormAmendmentsView(WorkViewBase, TemplateView):
                     "DELETE": form.cleaned_data["DELETE"],
                 })
             if amendment_work_id:
-                amending_works = {form.cleaned_data["amending_work"] for form in formset}
-                amended_works = {form.cleaned_data["amended_work"] for form in formset}
+                amending_works = {form.cleaned_data.get("amending_work") for form in formset if form.cleaned_data}
+                amended_works = {form.cleaned_data.get("amended_work") for form in formset if form.cleaned_data}
                 work = Work.objects.filter(pk=amendment_work_id).first()
                 if work:
                     if prefix == "amended_by":


### PR DESCRIPTION
Fixes #2524.

When the amendments formset contains an empty extra form, Django sets its `cleaned_data` to `{}`, so `form.cleaned_data["amended_work"]` raises `KeyError`. Skip such forms (same pattern already used in `WorkFormChapterNumbersView`) and use `.get()` for the dedupe sets. Regression test added in `test_works.py`.