### PR TITLE
fix: raise ValidationError when cleaning Work without country (#2526)

### DIFF
--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -605,6 +605,11 @@ class Work(WorkMixin, models.Model):
         except ValueError:
             raise ValidationError(_("Invalid FRBR URI"))
 
+        # country is required to build the frbr_uri prefix; surface a ValidationError
+        # rather than letting RelatedObjectDoesNotExist bubble up
+        if self.country_id is None:
+            raise ValidationError({'country': _("This field is required.")})
+
         # Assume frbr_uri starts with /akn; `rest` is everything after the country/locality, e.g.
         # in `/akn/za-wc/act/2000/12`, `rest` is `act/2000/12`.
         rest = frbr_uri.split('/', 3)[3]

--- a/indigo_api/tests/test_work.py
+++ b/indigo_api/tests/test_work.py
@@ -42,6 +42,13 @@ class WorkTestCase(TestCase):
         work = Work(frbr_uri='', country=country)
         self.assertRaises(ValidationError, work.full_clean)
 
+    def test_clean_without_country(self):
+        # clean() must raise ValidationError, not RelatedObjectDoesNotExist
+        work = Work(frbr_uri='/akn/za/act/2024/1')
+        with self.assertRaises(ValidationError) as cm:
+            work.clean()
+        self.assertIn('country', cm.exception.message_dict)
+
     def test_possible_expression_dates_basic(self):
         self.work.publication_date = datetime.date(2018, 2, 23)
         amendment = Amendment(amended_work=self.work, amending_work_id=2, date='2019-09-13', created_by_user_id=1)


### PR DESCRIPTION
Fixes #2526. `Work.clean()` accessed `self.country.code` directly, so a Work submitted without a country raised `RelatedObjectDoesNotExist` and surfaced as a 500 in Sentry; now it raises a `ValidationError` keyed to the `country` field so Django renders it as a normal form error. Adds a regression test that fails on master and passes after the fix.