### PR TITLE
Bearer authentication

### DIFF
--- a/indigo_content_api/authn.py
+++ b/indigo_content_api/authn.py
@@ -1,0 +1,7 @@
+from rest_framework.authentication import TokenAuthentication
+
+
+class BearerAuthentication(TokenAuthentication):
+    """The preferred authentication method, which is more common than Token authentication.
+    """
+    keyword = 'Bearer'

--- a/indigo_content_api/v2/views.py
+++ b/indigo_content_api/v2/views.py
@@ -20,6 +20,7 @@ from indigo_app.views.works import publication_document_response
 from .serializers import MediaAttachmentSerializer, PublishedDocumentSerializer, TaxonomyTopicSerializer, \
     PublishedDocUrlMixin, PublishedDocumentCommencementsSerializer, \
     TimelineSerializer, TOCSerializer, PlaceSerializer
+from ..authn import BearerAuthentication
 
 FORMAT_RE = re.compile(r'\.([a-z0-9]+)$')
 
@@ -34,7 +35,7 @@ class PublishedDocumentPermission(BasePermission):
 class ContentAPIBase(object):
     """ Base class for Content API views, with common settings.
     """
-    authentication_classes = (SessionAuthentication, TokenAuthentication)
+    authentication_classes = (SessionAuthentication, BearerAuthentication, TokenAuthentication)
     permission_classes = (IsAuthenticated, PublishedDocumentPermission)
 
 


### PR DESCRIPTION
This is more common than Token and many tools default to using Bearer auth when given an API key token