### PR TITLE
fixes plain-text provision target resolution

### DIFF
--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -743,6 +743,13 @@ class ProvisionRefsMatcher(CitationMatcher):
             # find the first citation after the end of this match, but don't cross the end of a sentence or look too far.
             for c in citations:
                 if c.start > match.end():
+                    # Plain-text "of X" lookups should bind to a cited document/work, not to a later provision-level
+                    # citation such as "section 57(1)", which would incorrectly become the target root.
+                    try:
+                        if c.href and FrbrUri.parse(c.href).portion:
+                            continue
+                    except ValueError:
+                        continue
                     # don't cross the end of a sentence or look too far ahead
                     if not ('. ' in match.string[match.end():c.start] or c.start - match.end() > self.max_ref_to_target):
                         frbr_uri = c.href
@@ -787,9 +794,11 @@ class ProvisionRefsMatcher(CitationMatcher):
                             self.target_root_cache[frbr_uri] = (None, elements[0])
             else:
                 try:
-                    # we normalise the FRBR URI to the work level
+                    # Normalise to the base expression/work URI before using it as the root for nested references.
                     uri = FrbrUri.parse(frbr_uri)
-                    self.target_root_cache[frbr_uri] = (frbr_uri, self.find_document_root(uri))
+                    uri.portion = None
+                    base_uri = uri.expression_uri() if uri.language else uri.work_uri(False)
+                    self.target_root_cache[frbr_uri] = (base_uri, self.find_document_root(uri))
                 except ValueError:
                     # bad FRBR URI
                     pass

--- a/indigo/analysis/refs/provisions.py
+++ b/indigo/analysis/refs/provisions.py
@@ -797,7 +797,7 @@ class ProvisionRefsMatcher(CitationMatcher):
                     # Normalise to the base expression/work URI before using it as the root for nested references.
                     uri = FrbrUri.parse(frbr_uri)
                     uri.portion = None
-                    base_uri = uri.expression_uri() if uri.language else uri.work_uri(False)
+                    base_uri = uri.expression_uri() if uri.expression_date else uri.work_uri(False)
                     self.target_root_cache[frbr_uri] = (base_uri, self.find_document_root(uri))
                 except ValueError:
                     # bad FRBR URI

--- a/indigo/tests/test_provision_refs.py
+++ b/indigo/tests/test_provision_refs.py
@@ -1962,10 +1962,16 @@ class ProvisionRefsMatcherTestCase(TestCase):
         ], self.finder.citations)
 
     def test_markup_text_does_not_bind_earlier_of_reference_to_later_provision_citation(self):
-        self.frbr_uri = FrbrUri.parse("/akn/tz/act/1984/13/eng@2019-11-30")
+        self._assert_text_does_not_bind_to_later_provision("/akn/tz/act/1984/13/eng@2019-11-30")
+
+    def test_markup_text_does_not_bind_earlier_of_reference_to_later_provision_citation_for_work_uri(self):
+        self._assert_text_does_not_bind_to_later_provision("/akn/tz/act/1984/13")
+
+    def _assert_text_does_not_bind_to_later_provision(self, frbr_uri):
+        self.frbr_uri = FrbrUri.parse(frbr_uri)
         finder = ProvisionRefsFinderENG()
         finder.this_target = (
-            "/akn/tz/act/1984/13/eng@2019-11-30",
+            frbr_uri,
             AkomaNtosoDocument(document_fixture(
                 xml='<section eId="part_V__sec_57"><num>57.</num><subsection eId="part_V__sec_57__subsec_1"><num>(1)</num></subsection></section><section eId="part_V__sec_60"><num>60.</num><subsection eId="part_V__sec_60__subsec_2"><num>(2)</num></subsection><subsection eId="part_V__sec_60__subsec_4"><num>(4)</num></subsection></section>'
             )).root
@@ -1976,9 +1982,10 @@ class ProvisionRefsMatcherTestCase(TestCase):
         finder.setup(self.frbr_uri, text=text)
         finder.citations = []
         finder.extract_paged_text_matches()
+        section_base = frbr_uri
         self.assertEqual([
-            ExtractedCitation("57(1)", 47, 52, "/akn/tz/act/1984/13/eng@2019-11-30/~part_V__sec_57__subsec_1", 0,
+            ExtractedCitation("57(1)", 47, 52, f"{section_base}/~part_V__sec_57__subsec_1", 0,
                               " the First Schedule; sections ", " and 60(2)"),
-            ExtractedCitation("60(2)", 57, 62, "/akn/tz/act/1984/13/eng@2019-11-30/~part_V__sec_60__subsec_2", 0,
+            ExtractedCitation("60(2)", 57, 62, f"{section_base}/~part_V__sec_60__subsec_2", 0,
                               " Schedule; sections 57(1) and ", ""),
         ], finder.citations)

--- a/indigo/tests/test_provision_refs.py
+++ b/indigo/tests/test_provision_refs.py
@@ -7,7 +7,7 @@ from lxml import etree
 from cobalt import AkomaNtosoDocument, FrbrUri
 from docpipe.matchers import ExtractedCitation
 
-from indigo.analysis.refs.provisions import ProvisionRefsResolver, ProvisionRef, ProvisionRefsMatcher, parse_provision_refs, MainProvisionRef
+from indigo.analysis.refs.provisions import ProvisionRefsResolver, ProvisionRef, ProvisionRefsMatcher, ProvisionRefsFinderENG, parse_provision_refs, MainProvisionRef
 from indigo.xmlutils import parse_html_str
 from indigo_api.tests.fixtures import document_fixture, component_fixture
 
@@ -1960,3 +1960,25 @@ class ProvisionRefsMatcherTestCase(TestCase):
         self.assertEqual([
             ExtractedCitation("Act No. 1 of 2009", 30, 38, "/akn/za/act/2009/1", 0, 'of Act No. ', '.' ),
         ], self.finder.citations)
+
+    def test_markup_text_does_not_bind_earlier_of_reference_to_later_provision_citation(self):
+        self.frbr_uri = FrbrUri.parse("/akn/tz/act/1984/13/eng@2019-11-30")
+        finder = ProvisionRefsFinderENG()
+        finder.this_target = (
+            "/akn/tz/act/1984/13/eng@2019-11-30",
+            AkomaNtosoDocument(document_fixture(
+                xml='<section eId="part_V__sec_57"><num>57.</num><subsection eId="part_V__sec_57__subsec_1"><num>(1)</num></subsection></section><section eId="part_V__sec_60"><num>60.</num><subsection eId="part_V__sec_60__subsec_2"><num>(2)</num></subsection><subsection eId="part_V__sec_60__subsec_4"><num>(4)</num></subsection></section>'
+            )).root
+        )
+        finder.target_root_cache = {}
+
+        text = "paragraph 4(1) of the First Schedule; sections 57(1) and 60(2)"
+        finder.setup(self.frbr_uri, text=text)
+        finder.citations = []
+        finder.extract_paged_text_matches()
+        self.assertEqual([
+            ExtractedCitation("57(1)", 47, 52, "/akn/tz/act/1984/13/eng@2019-11-30/~part_V__sec_57__subsec_1", 0,
+                              " the First Schedule; sections ", " and 60(2)"),
+            ExtractedCitation("60(2)", 57, 62, "/akn/tz/act/1984/13/eng@2019-11-30/~part_V__sec_60__subsec_2", 0,
+                              " Schedule; sections 57(1) and ", ""),
+        ], finder.citations)


### PR DESCRIPTION
## what changed

- skips provision-level citations when resolving plain-text `of ...` targets
- normalizes absolute target URIs before appending nested provision fragments
- adds a self-contained regression test in `indigo/tests/test_provision_refs.py`

## why it changed

A plain-text reference like `paragraph 4(1) of the First Schedule; sections 57(1) and 60(2)` could incorrectly bind the earlier `of ...` reference to the later `57(1)` citation. That produced a bogus third citation for `4` and could generate malformed nested hrefs.

## user impact

Citator/provision matching no longer fabricates an extra citation when an earlier plain-text `of ...` reference is followed by later provision citations in the same fragment.

## root cause

The plain-text forward target lookup considered later citations indiscriminately, including provision-level hrefs. Once a provision href was selected as the target root, the matcher appended another `~/eId` segment and produced an invalid nested provision URI.

## validation

- `python3 manage.py test indigo.tests.test_provision_refs.ProvisionRefsMatcherTestCase.test_markup_text_does_not_bind_earlier_of_reference_to_later_provision_citation`
- `python3 manage.py test indigo.tests.test_provision_refs.ProvisionRefsMatcherTestCase.test_markup_text indigo.tests.test_provision_refs.ProvisionRefsMatcherTestCase.test_markup_text_thereof indigo.tests.test_provision_refs.ProvisionRefsMatcherTestCase.test_markup_text_does_not_bind_earlier_of_reference_to_later_provision_citation`

fixes https://github.com/laws-africa/indigo-lawsafrica/issues/1784
