### PR TITLE
add start_page field to PublicationDocument and expose it via APIs and work forms

### DIFF
--- a/indigo_api/migrations/0060_publicationdocument_start_page.py
+++ b/indigo_api/migrations/0060_publicationdocument_start_page.py
@@ -1,0 +1,23 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("indigo_api", "0059_alter_annotation_created_by_user_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="publicationdocument",
+            name="start_page",
+            field=models.PositiveIntegerField(
+                blank=True,
+                help_text="The page in the publication document where this work starts.",
+                null=True,
+                validators=[django.core.validators.MinValueValidator(1)],
+                verbose_name="start page",
+            ),
+        ),
+    ]

--- a/indigo_api/models/works.py
+++ b/indigo_api/models/works.py
@@ -8,6 +8,7 @@ from django.db.models.signals import m2m_changed
 from django.db import models, IntegrityError, transaction
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
+from django.core.validators import MinValueValidator
 from django.contrib.auth.models import User
 from django.dispatch import receiver
 from django.urls import reverse
@@ -891,6 +892,13 @@ class PublicationDocument(models.Model):
     size = models.IntegerField(_("file size"), null=True)
     filename = models.CharField(_("file name"), max_length=255)
     mime_type = models.CharField(_("file MIME type"), max_length=255)
+    start_page = models.PositiveIntegerField(
+        _("start page"),
+        null=True,
+        blank=True,
+        validators=[MinValueValidator(1)],
+        help_text=_("The page in the publication document where this work starts."),
+    )
     created_at = models.DateTimeField(_("created at"), auto_now_add=True)
     updated_at = models.DateTimeField(_("updated at"), auto_now=True)
 

--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -184,7 +184,7 @@ class PublicationDocumentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = PublicationDocument
-        fields = ('url', 'filename', 'mime_type', 'size', 'trusted_url')
+        fields = ('url', 'filename', 'mime_type', 'size', 'trusted_url', 'start_page')
         read_only_fields = fields
 
     def get_url(self, instance):

--- a/indigo_api/tests/test_work.py
+++ b/indigo_api/tests/test_work.py
@@ -4,7 +4,16 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.core.exceptions import ValidationError
 
-from indigo_api.models import Document, Work, Country, Amendment, ArbitraryExpressionDate, Commencement
+from indigo_api.models import (
+    Amendment,
+    ArbitraryExpressionDate,
+    Commencement,
+    Country,
+    Document,
+    PublicationDocument,
+    Work,
+)
+from indigo_api.serializers import PublicationDocumentSerializer
 
 
 class WorkTestCase(TestCase):
@@ -48,6 +57,23 @@ class WorkTestCase(TestCase):
         with self.assertRaises(ValidationError) as cm:
             work.clean()
         self.assertIn('country', cm.exception.message_dict)
+
+    def test_publication_document_start_page_validation(self):
+        field = PublicationDocument._meta.get_field("start_page")
+
+        self.assertIsNone(field.clean(None, None))
+        self.assertEqual(1, field.clean(1, None))
+        self.assertEqual(36, field.clean(36, None))
+
+        for value in (0, -1):
+            with self.subTest(value=value), self.assertRaises(ValidationError):
+                field.clean(value, None)
+
+    def test_publication_document_serializer_includes_start_page(self):
+        publication_document = self.work.publication_document
+        publication_document.start_page = 36
+
+        self.assertEqual(36, PublicationDocumentSerializer(publication_document).data["start_page"])
 
     def test_possible_expression_dates_basic(self):
         self.work.publication_date = datetime.date(2018, 2, 23)

--- a/indigo_app/forms/works.py
+++ b/indigo_app/forms/works.py
@@ -33,6 +33,7 @@ class WorkForm(forms.ModelForm):
             'title', 'frbr_uri', 'assent_date', 'parent_work', 'commenced',
             'repealed_by', 'repealed_date', 'repealed_verb', 'repealed_note', 'publication_name', 'publication_number', 'publication_date',
             'publication_document_trusted_url', 'publication_document_size', 'publication_document_mime_type',
+            'publication_document_start_page',
             'stub', 'principal', 'taxonomy_topics', 'as_at_date_override', 'consolidation_note_override', 'country', 'locality',
             'disclaimer',
         )
@@ -58,6 +59,12 @@ class WorkForm(forms.ModelForm):
     publication_document_trusted_url = forms.URLField(required=False)
     publication_document_size = forms.IntegerField(required=False)
     publication_document_mime_type = forms.CharField(required=False)
+    publication_document_start_page = forms.IntegerField(
+        label=_("Start page"),
+        required=False,
+        min_value=1,
+        help_text=_("The page in the publication document where this work starts."),
+    )
 
     repealed_verb = forms.ChoiceField(required=False, choices=Work.REPEALED_VERB_CHOICES)
 
@@ -86,6 +93,10 @@ class WorkForm(forms.ModelForm):
             self.fields['frbr_date'].initial = self.instance.date
             self.fields['frbr_number'].initial = self.instance.number
             self.fields['frbr_actor'].initial = self.instance.actor
+            try:
+                self.fields['publication_document_start_page'].initial = self.instance.publication_document.start_page
+            except PublicationDocument.DoesNotExist:
+                pass
 
         self.fields['frbr_doctype'].choices = [
             (y, x)
@@ -319,6 +330,7 @@ class WorkForm(forms.ModelForm):
     def save_publication_document(self):
         pub_doc_file = self.cleaned_data['publication_document_file']
         pub_doc_url = self.cleaned_data['publication_document_trusted_url']
+        start_page = self.cleaned_data['publication_document_start_page']
 
         try:
             existing = self.instance.publication_document
@@ -340,6 +352,7 @@ class WorkForm(forms.ModelForm):
             pub_doc.file = pub_doc_file
             pub_doc.size = pub_doc_file.size
             pub_doc.mime_type = pub_doc_file.content_type
+            pub_doc.start_page = start_page
             pub_doc.save()
 
         elif pub_doc_url:
@@ -352,7 +365,12 @@ class WorkForm(forms.ModelForm):
             pub_doc.trusted_url = pub_doc_url
             pub_doc.size = self.cleaned_data['publication_document_size']
             pub_doc.mime_type = self.cleaned_data['publication_document_mime_type']
+            pub_doc.start_page = start_page
             pub_doc.save()
+
+        elif existing and existing.start_page != start_page:
+            existing.start_page = start_page
+            existing.save()
 
     @cached_property
     def taxonomy_toc(self):

--- a/indigo_app/templates/indigo_api/work/_publication_document.html
+++ b/indigo_app/templates/indigo_api/work/_publication_document.html
@@ -42,6 +42,26 @@
 </div>
 
 <div class="mb-3 row">
+  <label class="col-2 col-form-label" for="{{ form.publication_document_start_page.id_for_label }}">
+    {{ form.publication_document_start_page.label }}
+  </label>
+  <div class="col-4">
+    <input type="number"
+           class="form-control{% if form.publication_document_start_page.errors %} is-invalid{% endif %}"
+           id="{{ form.publication_document_start_page.id_for_label }}"
+           name="{{ form.publication_document_start_page.html_name }}"
+           value="{{ form.publication_document_start_page.value|default_if_none:'' }}"
+           min="1">
+    {% for error in form.publication_document_start_page.errors %}
+      <div class="invalid-feedback">{{ error }}</div>
+    {% endfor %}
+    {% if form.publication_document_start_page.help_text %}
+      <div class="form-text">{{ form.publication_document_start_page.help_text }}</div>
+    {% endif %}
+  </div>
+</div>
+
+<div class="mb-3 row">
   <label class="col-2">{% trans "Upload publication document" %}:</label>
   <div class="col">
     <input

--- a/indigo_app/templates/indigo_app/place/_work_detail_overview.html
+++ b/indigo_app/templates/indigo_app/place/_work_detail_overview.html
@@ -20,7 +20,7 @@
               <span class="text-muted">({{ work.publication_document.size|filesizeformat }})</span>
               {% if work.publication_document.start_page %}
                 <span class="text-muted">
-                  {% blocktrans trimmed with start_page=work.publication_document.start_page %}, starting on page {{ start_page }}{% endblocktrans %}
+                  {% blocktrans trimmed with start_page=work.publication_document.start_page %}starting on page {{ start_page }}{% endblocktrans %}
                 </span>
               {% endif %}
             </div>

--- a/indigo_app/templates/indigo_app/place/_work_detail_overview.html
+++ b/indigo_app/templates/indigo_app/place/_work_detail_overview.html
@@ -18,6 +18,11 @@
               <a href="{% url 'work_publication_document' frbr_uri=work.frbr_uri filename=work.publication_document.filename %}"
                  target="_blank" rel="noopener">{{ work.publication_document.filename }}</a>
               <span class="text-muted">({{ work.publication_document.size|filesizeformat }})</span>
+              {% if work.publication_document.start_page %}
+                <span class="text-muted">
+                  {% blocktrans trimmed with start_page=work.publication_document.start_page %}, starting on page {{ start_page }}{% endblocktrans %}
+                </span>
+              {% endif %}
             </div>
           {% endif %}
         </dd>

--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -32,6 +32,29 @@ class WorksTest(testcases.TestCase):
         response = self.client.get('/works/akn/za-cpt/act/2005/1/')
         self.assertEqual(response.status_code, 200)
 
+    def test_attach_publication_document_preserves_start_page(self):
+        response = self.client.post(
+            "/places/za/work/form/attach-publication?form=0&frbr_uri=/akn/za/act/2014/10",
+            {
+                "work-publication_document_start_page": "36",
+                "pubdoc-TOTAL_FORMS": "1",
+                "pubdoc-INITIAL_FORMS": "0",
+                "pubdoc-MIN_NUM_FORMS": "0",
+                "pubdoc-MAX_NUM_FORMS": "1000",
+                "pubdoc-0-name": "Gazette",
+                "pubdoc-0-trusted_url": "https://example.com/gazette.pdf",
+                "pubdoc-0-size": "1234",
+                "pubdoc-0-mimetype": "application/pdf",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            'name="work-publication_document_start_page"',
+        )
+        self.assertContains(response, 'value="36"')
+
     def test_related_page(self):
         response = self.client.get('/works/akn/za/act/2014/10/related/')
         self.assertEqual(response.status_code, 200)
@@ -425,8 +448,21 @@ class WorksWebTest(WebTest):
         form['work-frbr_number'] = '5'
         form['work-publication_date'] = '2019-02-01'
         form['work-publication_document_file'] = Upload('pub.pdf', b'data', 'application/pdf')
+        form['work-publication_document_start_page'] = 36
         response = form.submit()
         self.assertRedirects(response, '/works/akn/za/act/2019/5/', fetch_redirect_response=False)
+        self.assertEqual(36, Work.objects.get(frbr_uri='/akn/za/act/2019/5').publication_document.start_page)
+
+    def test_update_publication_document_start_page(self):
+        work = Work.objects.get(frbr_uri='/akn/za/act/2014/10')
+        form = self.app.get('/works%s/edit/' % work.frbr_uri).forms['edit-work-form']
+        form['work-publication_document_start_page'] = 36
+
+        response = form.submit()
+
+        self.assertRedirects(response, '/works%s/' % work.frbr_uri, fetch_redirect_response=False)
+        work.publication_document.refresh_from_db()
+        self.assertEqual(36, work.publication_document.start_page)
 
     def test_publication_date_updates_documents(self):
         """ Changing the work's publication date should also updated documents

--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -32,6 +32,22 @@ class WorksTest(testcases.TestCase):
         response = self.client.get('/works/akn/za-cpt/act/2005/1/')
         self.assertEqual(response.status_code, 200)
 
+    def test_publication_document_start_page_on_detail_page(self):
+        work = Work.objects.get(frbr_uri='/akn/za/act/2014/10')
+
+        response = self.client.get('/works/akn/za/act/2014/10/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, work.publication_document.filename)
+        self.assertNotContains(response, "starting on page")
+
+        work.publication_document.start_page = 36
+        work.publication_document.save(update_fields=["start_page"])
+
+        response = self.client.get('/works/akn/za/act/2014/10/')
+
+        self.assertContains(response, "starting on page 36")
+
     def test_attach_publication_document_preserves_start_page(self):
         response = self.client.post(
             "/places/za/work/form/attach-publication?form=0&frbr_uri=/akn/za/act/2014/10",

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -1233,6 +1233,12 @@ class WorkFormPublicationDocumentView(PlaceViewBase, TemplateView):
         publication_document_trusted_url = forms.URLField(required=False, widget=forms.HiddenInput())
         publication_document_size = forms.IntegerField(required=False, widget=forms.HiddenInput())
         publication_document_mime_type = forms.CharField(required=False, widget=forms.HiddenInput())
+        publication_document_start_page = forms.IntegerField(
+            label=_("Start page"),
+            required=False,
+            min_value=1,
+            help_text=_("The page in the publication document where this work starts."),
+        )
         delete_publication_document = forms.CharField(required=False, widget=forms.HiddenInput())
         prefix = 'work'
 
@@ -1242,6 +1248,7 @@ class WorkFormPublicationDocumentView(PlaceViewBase, TemplateView):
                 'publication_document_trusted_url',
                 'publication_document_size',
                 'publication_document_mime_type',
+                'publication_document_start_page',
                 'delete_publication_document',
                 'publication_document_file',
             )
@@ -1261,20 +1268,26 @@ class WorkFormPublicationDocumentView(PlaceViewBase, TemplateView):
             if work:
                 context["work"] = work
         initial = {}
+        if context.get("work") and hasattr(context["work"], "publication_document"):
+            initial["publication_document_start_page"] = context["work"].publication_document.start_page
+        posted_start_page = self.request.POST.get("work-publication_document_start_page")
+        if posted_start_page is not None:
+            initial["publication_document_start_page"] = posted_start_page
         if form_id:
             FindPubDocFormset = formset_factory(FindPubDocForm)
             formset = FindPubDocFormset(prefix="pubdoc", data=self.request.POST)
             if formset.is_valid():
                 selected_form = formset.forms[int(form_id)]
-                initial = {
+                initial.update({
                     'publication_document_trusted_url': selected_form.cleaned_data['trusted_url'],
                     'publication_document_size': selected_form.cleaned_data['size'],
                     'publication_document_mime_type': selected_form.cleaned_data['mimetype'],
                     'delete_publication_document': 'on',
-                }
+                })
 
         if self.request.method == 'DELETE':
             initial['delete_publication_document'] = 'on'
+            initial['publication_document_start_page'] = None
 
         context["form"] = self.Form(initial=initial)
         return context

--- a/indigo_content_api/tests/v2/test_content_api.py
+++ b/indigo_content_api/tests/v2/test_content_api.py
@@ -553,11 +553,15 @@ class ContentAPIV2TestMixin:
                      'http://' + self.api_host + self.api_path + '/akn/za/act/2014/10/eng@2014-02-12/media.json')
 
     def test_published_publication_document_trusted_url(self):
+        work = Work.objects.get(frbr_uri='/akn/za/act/1880/1')
+        work.publication_document.start_page = 36
+        work.publication_document.save()
         response = self.client.get(self.api_path + '/akn/za/act/1880/1/eng@1880-10-12.json')
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(response.data['publication_document']['url'], 'https://example.com/foo.pdf')
         self.assertTrue(response.data['publication_document']['has_trusted_url'])
+        self.assertEqual(response.data['publication_document']['start_page'], 36)
 
     def test_published_publication_document(self):
         response = self.client.get(self.api_path + '/akn/za/act/2014/10/eng@2014-02-12.json')
@@ -566,6 +570,7 @@ class ContentAPIV2TestMixin:
         self.assertEqual(response.data['publication_document']['url'],
                      f'http://{self.api_host}{self.api_path}/akn/za/act/2014/10/media/publication/za-act-2014-10-publication-document.pdf')
         self.assertFalse(response.data['publication_document']['has_trusted_url'])
+        self.assertIsNone(response.data['publication_document']['start_page'])
 
     def test_published_work_before_1900(self):
         response = self.client.get(self.api_path + '/akn/za/act/1880/1.html')

--- a/indigo_content_api/v2/serializers.py
+++ b/indigo_content_api/v2/serializers.py
@@ -66,7 +66,7 @@ class PublicationDocumentSerializer(PublicationDocumentSerializerBase):
     class Meta:
         model = PublicationDocument
         # Don't include the trusted_url field (but do include whether the URL is trusted as a boolean)
-        fields = ('url', 'filename', 'mime_type', 'size', 'has_trusted_url')
+        fields = ('url', 'filename', 'mime_type', 'size', 'has_trusted_url', 'start_page')
 
     @extend_schema_field(OpenApiTypes.URI)
     def get_url(self, instance):


### PR DESCRIPTION
this pr as well solve the issue #2513  whereby it  adds start page metadata to publication documents so Indigo can record where a work starts inside a larger source PDF, such as a government gazette. The value is exposed through the existing publication document API and can be edited in the publication document workflow, and allowing  LII sites to open the full source PDF at the relevant or useful page while keeping the complete file available incase they need to reffer to other pages.
<img width="1126" height="356" alt="Screenshot 2026-08-03 at 2 23 57 PM" src="https://github.com/user-attachments/assets/4cf4c7a7-9239-4e45-8620-65abbfc1ff33" />
<img width="1237" height="551" alt="Screenshot 2026-08-03 at 2 23 48 PM" src="https://github.com/user-attachments/assets/05f9f8e1-ace6-46aa-8155-f8ff8faa749e" />


