### PR TITLE
add temporary workaround for chrome disabling unload

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -113,6 +113,7 @@ MIDDLEWARE = (
     'allauth.account.middleware.AccountMiddleware',
     'django_htmx.middleware.HtmxMiddleware',
     'indigo_app.middleware.HtmxMessagesMiddleware',
+    'indigo_app.middleware.UnloadPermissionsPolicyMiddleware',
 )
 
 ROOT_URLCONF = 'indigo.urls'

--- a/indigo_app/middleware.py
+++ b/indigo_app/middleware.py
@@ -72,3 +72,25 @@ class LogContextMiddleware:
             return self.get_response(request)
         finally:
             clear_log_context()
+
+
+class UnloadPermissionsPolicyMiddleware:
+    """Temporarily opt back into Chrome's deprecated ``unload`` event.
+
+    The document activity lock currently releases its per-tab activity in an
+    unload handler. Keep that mechanism working while it is replaced with a
+    lease and save-time optimistic concurrency checks.
+    """
+    directive = "unload=(self)"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        policy = response.get("Permissions-Policy", "")
+        directives = [item.strip() for item in policy.split(",") if item.strip()]
+        directives = [item for item in directives if not item.startswith("unload=")]
+        directives.append(self.directive)
+        response["Permissions-Policy"] = ", ".join(directives)
+        return response


### PR DESCRIPTION
otherwise document activity locks aren't released