### PR TITLE
Optimistic concurrency, leases when editing documents

### DIFF
--- a/indigo/settings.py
+++ b/indigo/settings.py
@@ -113,7 +113,6 @@ MIDDLEWARE = (
     'allauth.account.middleware.AccountMiddleware',
     'django_htmx.middleware.HtmxMiddleware',
     'indigo_app.middleware.HtmxMessagesMiddleware',
-    'indigo_app.middleware.UnloadPermissionsPolicyMiddleware',
 )
 
 ROOT_URLCONF = 'indigo.urls'

--- a/indigo_api/exceptions.py
+++ b/indigo_api/exceptions.py
@@ -1,0 +1,75 @@
+from allauth.account.utils import user_display
+from django.utils.translation import gettext as _
+from rest_framework import serializers
+from rest_framework.exceptions import APIException
+
+
+def serialize_user(user):
+    """The small, stable user representation included in conflict responses."""
+    return {
+        'id': user.id,
+        'display_name': user_display(user),
+        'username': user.username,
+    }
+
+
+class DocumentChanged(APIException):
+    status_code = 409
+    default_code = 'document_changed'
+
+    def __init__(self, document, expected_updated_at):
+        current_updated_at = serializers.DateTimeField().to_representation(document.updated_at)
+        expected_updated_at = serializers.DateTimeField().to_representation(expected_updated_at)
+        updated_by_user = document.updated_by_user
+        updated_by_name = user_display(updated_by_user) if updated_by_user else None
+
+        if updated_by_name:
+            detail = _(
+                'This document was changed by %(user)s after you opened it. '
+                'Your changes have not been saved.'
+            ) % {'user': updated_by_name}
+        else:
+            detail = _(
+                'This document was changed after you opened it. '
+                'Your changes have not been saved.'
+            )
+
+        payload = {
+            'code': self.default_code,
+            'detail': detail,
+            'expected_updated_at': expected_updated_at,
+            'current_updated_at': current_updated_at,
+            'updated_by_user': serialize_user(updated_by_user) if updated_by_user else None,
+        }
+        super().__init__(detail, self.default_code)
+        # APIException recursively converts values to ErrorDetail strings. Keep
+        # this conflict response as structured JSON (notably the numeric user id).
+        self.detail = payload
+
+
+class DocumentLocked(APIException):
+    status_code = 409
+    default_code = 'document_locked'
+
+    def __init__(self, lease):
+        detail = _('Saving is currently reserved by %(user)s. You can continue editing.') % {
+            'user': user_display(lease.user),
+        }
+        super().__init__(detail, self.default_code)
+        self.detail = {
+            'code': self.default_code,
+            'detail': detail,
+            'holder': serialize_user(lease.user),
+            'acquired_at': serializers.DateTimeField().to_representation(lease.acquired_at),
+            'expires_at': serializers.DateTimeField().to_representation(lease.expires_at),
+        }
+
+
+class EditLeaseLost(APIException):
+    status_code = 409
+    default_code = 'edit_lease_lost'
+
+    def __init__(self):
+        detail = _('Your saving access has expired or was replaced. Your changes have not been saved.')
+        super().__init__(detail, self.default_code)
+        self.detail = {'code': self.default_code, 'detail': detail}

--- a/indigo_api/migrations/0061_documenteditlease.py
+++ b/indigo_api/migrations/0061_documenteditlease.py
@@ -1,0 +1,33 @@
+import uuid
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('indigo_api', '0060_publicationdocument_start_page'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DocumentEditLease',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('token', models.UUIDField(default=uuid.uuid4, editable=False, unique=True, verbose_name='token')),
+                ('client_id', models.UUIDField(verbose_name='client id')),
+                ('document_updated_at', models.DateTimeField(verbose_name='document updated at')),
+                ('acquired_at', models.DateTimeField(auto_now_add=True, verbose_name='acquired at')),
+                ('renewed_at', models.DateTimeField(auto_now=True, verbose_name='renewed at')),
+                ('expires_at', models.DateTimeField(verbose_name='expires at')),
+                ('document', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='edit_lease', to='indigo_api.document', verbose_name='document')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='document_edit_leases', to=settings.AUTH_USER_MODEL, verbose_name='user')),
+            ],
+            options={
+                'verbose_name': 'document edit lease',
+                'verbose_name_plural': 'document edit leases',
+            },
+        ),
+    ]

--- a/indigo_api/migrations/0062_documenteditlease_activity_nonce.py
+++ b/indigo_api/migrations/0062_documenteditlease_activity_nonce.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('indigo_api', '0061_documenteditlease'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='documenteditlease',
+            name='activity_nonce',
+            field=models.CharField(blank=True, max_length=10, null=True, verbose_name='activity nonce'),
+        ),
+    ]

--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -921,6 +921,8 @@ class DocumentEditLease(models.Model):
     token = models.UUIDField(_("token"), default=uuid.uuid4, unique=True, editable=False)
     # unique client-side ID for de-duplication of sessions for the same user
     client_id = models.UUIDField(_("client id"))
+    # page-specific presence identifier whose activity badge represents this lease
+    activity_nonce = models.CharField(_("activity nonce"), max_length=10, blank=True, null=True)
     # links in with optimistic concurrency control to ensure the lease is for the latest version of the document
     document_updated_at = models.DateTimeField(_("document updated at"))
     acquired_at = models.DateTimeField(_("acquired at"), auto_now_add=True)

--- a/indigo_api/models/documents.py
+++ b/indigo_api/models/documents.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import datetime
+import uuid
 
 from actstream import action
 from django.conf import settings
@@ -907,3 +908,38 @@ class DocumentActivity(models.Model):
     def vacuum(cls):
         threshold = timezone.now() - datetime.timedelta(seconds=cls.DEAD_SECS)
         cls.objects.filter(updated_at__lte=threshold).delete()
+
+
+class DocumentEditLease(models.Model):
+    """An exclusive, expiring lease to edit a particular document version."""
+    document = models.OneToOneField(
+        Document, on_delete=models.CASCADE, related_name='edit_lease', verbose_name=_("document"),
+    )
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name='document_edit_leases', verbose_name=_("user"),
+    )
+    token = models.UUIDField(_("token"), default=uuid.uuid4, unique=True, editable=False)
+    # unique client-side ID for de-duplication of sessions for the same user
+    client_id = models.UUIDField(_("client id"))
+    # links in with optimistic concurrency control to ensure the lease is for the latest version of the document
+    document_updated_at = models.DateTimeField(_("document updated at"))
+    acquired_at = models.DateTimeField(_("acquired at"), auto_now_add=True)
+    renewed_at = models.DateTimeField(_("renewed at"), auto_now=True)
+    expires_at = models.DateTimeField(_("expires at"))
+
+    # a lease is lost if not renewed after this time
+    LEASE_SECS = 90
+    # clients must renew at this frequency
+    RENEW_AFTER_SECS = 20
+
+    class Meta:
+        verbose_name = _("document edit lease")
+        verbose_name_plural = _("document edit leases")
+
+    @property
+    def is_expired(self):
+        return self.expires_at <= timezone.now()
+
+    def renew(self, now=None):
+        now = now or timezone.now()
+        self.expires_at = now + datetime.timedelta(seconds=self.LEASE_SECS)

--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -215,6 +215,7 @@ class UserSerializer(serializers.ModelSerializer):
 class DocumentEditLeaseRequestSerializer(serializers.Serializer):
     expected_updated_at = serializers.DateTimeField()
     client_id = serializers.UUIDField()
+    activity_nonce = serializers.CharField(max_length=10, required=False)
     token = serializers.UUIDField(required=False)
 
 
@@ -230,7 +231,7 @@ class DocumentEditLeaseSerializer(serializers.ModelSerializer):
     class Meta:
         model = DocumentEditLease
         fields = (
-            'token', 'client_id', 'document_updated_at', 'holder',
+            'token', 'client_id', 'activity_nonce', 'document_updated_at', 'holder',
             'acquired_at', 'renewed_at', 'expires_at', 'renew_after_seconds',
         )
         read_only_fields = fields

--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -218,6 +218,11 @@ class DocumentEditLeaseRequestSerializer(serializers.Serializer):
     token = serializers.UUIDField(required=False)
 
 
+class DocumentEditLeaseReleaseSerializer(serializers.Serializer):
+    client_id = serializers.UUIDField()
+    token = serializers.UUIDField()
+
+
 class DocumentEditLeaseSerializer(serializers.ModelSerializer):
     holder = UserSerializer(source='user', read_only=True)
     renew_after_seconds = serializers.IntegerField(source='RENEW_AFTER_SECS', read_only=True)

--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -7,10 +7,11 @@ from actstream.signals import action
 from allauth.account.utils import user_display
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.utils.translation import gettext as _
 from lxml import etree
 from lxml.etree import LxmlError
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import APIException, ValidationError
 from rest_framework.reverse import reverse
 from typing import List
 
@@ -210,6 +211,40 @@ class UserSerializer(serializers.ModelSerializer):
         return user_display(user)
 
 
+class DocumentChanged(APIException):
+    status_code = 409
+    default_code = 'document_changed'
+
+    def __init__(self, document, expected_updated_at):
+        current_updated_at = serializers.DateTimeField().to_representation(document.updated_at)
+        expected_updated_at = serializers.DateTimeField().to_representation(expected_updated_at)
+        updated_by_user = document.updated_by_user
+        updated_by_name = user_display(updated_by_user) if updated_by_user else None
+
+        if updated_by_name:
+            detail = _(
+                'This document was changed by %(user)s after you opened it. '
+                'Your changes have not been saved.'
+            ) % {'user': updated_by_name}
+        else:
+            detail = _(
+                'This document was changed after you opened it. '
+                'Your changes have not been saved.'
+            )
+
+        payload = {
+            'code': self.default_code,
+            'detail': detail,
+            'expected_updated_at': expected_updated_at,
+            'current_updated_at': current_updated_at,
+            'updated_by_user': UserSerializer(updated_by_user).data if updated_by_user else None,
+        }
+        super().__init__(detail, self.default_code)
+        # APIException recursively converts values to ErrorDetail strings. Keep
+        # this conflict response as structured JSON (notably the numeric user id).
+        self.detail = payload
+
+
 class VersionSerializer(serializers.ModelSerializer):
     date = serializers.DateTimeField(source='revision.date_created')
     comment = serializers.CharField(source='revision.comment')
@@ -222,8 +257,8 @@ class VersionSerializer(serializers.ModelSerializer):
 
 
 class DocumentSerializer(serializers.HyperlinkedModelSerializer):
+    # A write-only field for setting the entire XML content of the document. """
     content = serializers.CharField(required=False, write_only=True)
-    """ A write-only field for setting the entire XML content of the document. """
 
     frbr_uri = serializers.CharField(read_only=True, help_text="FRBR URI that uniquely identifies this work.")
 
@@ -268,12 +303,15 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
     updated_by_user = UserSerializer(read_only=True)
     created_by_user = UserSerializer(read_only=True)
 
+    # the "updated_at" field that the client has, for optimistic concurrency checks
+    expected_updated_at = serializers.DateTimeField(required=False, write_only=True)
+
     class Meta:
         model = Document
         fields = (
             # readonly, url is part of the rest framework
             'id', 'url',
-            'content', 'title', 'draft',
+            'content', 'expected_updated_at', 'title', 'draft',
             'created_at', 'updated_at', 'updated_by_user', 'created_by_user',
 
             # frbr_uri components
@@ -317,6 +355,10 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
         ]
 
     def validate(self, attrs):
+        expected_updated_at = attrs.pop('expected_updated_at', None)
+        if expected_updated_at and expected_updated_at != self.instance.updated_at:
+            raise DocumentChanged(self.instance, expected_updated_at)
+
         if attrs.get('content'):
             # validate the content
             try:

--- a/indigo_api/serializers.py
+++ b/indigo_api/serializers.py
@@ -11,14 +11,15 @@ from django.utils.translation import gettext as _
 from lxml import etree
 from lxml.etree import LxmlError
 from rest_framework import serializers
-from rest_framework.exceptions import APIException, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse
 from typing import List
 
 from cobalt import StructuredDocument, FrbrUri
 from cobalt.akn import AKN_NAMESPACES, DEFAULT_VERSION
-from indigo_api.models import Document, Attachment, Annotation, DocumentActivity, Work, Amendment, Language, \
+from indigo_api.models import Document, Attachment, Annotation, DocumentActivity, DocumentEditLease, Work, Amendment, Language, \
     PublicationDocument, Task, Commencement
+from indigo_api.exceptions import DocumentChanged, EditLeaseLost
 from indigo_api.signals import document_published
 
 log = logging.getLogger(__name__)
@@ -211,38 +212,23 @@ class UserSerializer(serializers.ModelSerializer):
         return user_display(user)
 
 
-class DocumentChanged(APIException):
-    status_code = 409
-    default_code = 'document_changed'
+class DocumentEditLeaseRequestSerializer(serializers.Serializer):
+    expected_updated_at = serializers.DateTimeField()
+    client_id = serializers.UUIDField()
+    token = serializers.UUIDField(required=False)
 
-    def __init__(self, document, expected_updated_at):
-        current_updated_at = serializers.DateTimeField().to_representation(document.updated_at)
-        expected_updated_at = serializers.DateTimeField().to_representation(expected_updated_at)
-        updated_by_user = document.updated_by_user
-        updated_by_name = user_display(updated_by_user) if updated_by_user else None
 
-        if updated_by_name:
-            detail = _(
-                'This document was changed by %(user)s after you opened it. '
-                'Your changes have not been saved.'
-            ) % {'user': updated_by_name}
-        else:
-            detail = _(
-                'This document was changed after you opened it. '
-                'Your changes have not been saved.'
-            )
+class DocumentEditLeaseSerializer(serializers.ModelSerializer):
+    holder = UserSerializer(source='user', read_only=True)
+    renew_after_seconds = serializers.IntegerField(source='RENEW_AFTER_SECS', read_only=True)
 
-        payload = {
-            'code': self.default_code,
-            'detail': detail,
-            'expected_updated_at': expected_updated_at,
-            'current_updated_at': current_updated_at,
-            'updated_by_user': UserSerializer(updated_by_user).data if updated_by_user else None,
-        }
-        super().__init__(detail, self.default_code)
-        # APIException recursively converts values to ErrorDetail strings. Keep
-        # this conflict response as structured JSON (notably the numeric user id).
-        self.detail = payload
+    class Meta:
+        model = DocumentEditLease
+        fields = (
+            'token', 'client_id', 'document_updated_at', 'holder',
+            'acquired_at', 'renewed_at', 'expires_at', 'renew_after_seconds',
+        )
+        read_only_fields = fields
 
 
 class VersionSerializer(serializers.ModelSerializer):
@@ -305,13 +291,14 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
 
     # the "updated_at" field that the client has, for optimistic concurrency checks
     expected_updated_at = serializers.DateTimeField(required=False, write_only=True)
+    edit_lease_token = serializers.UUIDField(required=False, write_only=True)
 
     class Meta:
         model = Document
         fields = (
             # readonly, url is part of the rest framework
             'id', 'url',
-            'content', 'expected_updated_at', 'title', 'draft',
+            'content', 'expected_updated_at', 'edit_lease_token', 'title', 'draft',
             'created_at', 'updated_at', 'updated_by_user', 'created_by_user',
 
             # frbr_uri components
@@ -356,8 +343,26 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
 
     def validate(self, attrs):
         expected_updated_at = attrs.pop('expected_updated_at', None)
+        edit_lease_token = attrs.pop('edit_lease_token', None)
         if expected_updated_at and expected_updated_at != self.instance.updated_at:
             raise DocumentChanged(self.instance, expected_updated_at)
+
+        if edit_lease_token:
+            if not expected_updated_at:
+                raise ValidationError({'expected_updated_at': _('This field is required when saving with an edit lease.')})
+            try:
+                lease = DocumentEditLease.objects.select_related('user').get(
+                    document=self.instance,
+                    user=self.context['request'].user,
+                    token=edit_lease_token,
+                )
+            except DocumentEditLease.DoesNotExist:
+                raise EditLeaseLost()
+            if lease.is_expired:
+                raise EditLeaseLost()
+            if lease.document_updated_at != expected_updated_at:
+                raise DocumentChanged(self.instance, expected_updated_at)
+            self.edit_lease = lease
 
         if attrs.get('content'):
             # validate the content
@@ -406,6 +411,12 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
 
         # save as a revision
         document.save_with_revision(user)
+
+        edit_lease = getattr(self, 'edit_lease', None)
+        if edit_lease:
+            edit_lease.document_updated_at = document.updated_at
+            edit_lease.renew()
+            edit_lease.save(update_fields=('document_updated_at', 'expires_at', 'renewed_at'))
 
         # reload it to ensure we have an id for new documents
         document = Document.objects.get(pk=document.id)
@@ -638,6 +649,7 @@ class AnnotationSerializer(serializers.ModelSerializer):
 class DocumentActivitySerializer(serializers.ModelSerializer):
     user = UserSerializer(read_only=True)
     document_updated_at = serializers.SerializerMethodField()
+    has_edit_lease = serializers.BooleanField(read_only=True)
 
     class Meta:
         model = DocumentActivity
@@ -647,6 +659,7 @@ class DocumentActivitySerializer(serializers.ModelSerializer):
             'updated_at',
             'nonce',
             'is_asleep',
+            'has_edit_lease',
             'document_updated_at',
         )
         read_only_fields = ('created_at', 'updated_at')

--- a/indigo_api/tests/test_document_api.py
+++ b/indigo_api/tests/test_document_api.py
@@ -168,6 +168,35 @@ class DocumentAPITest(APITestCase):
         self.assertEqual(renewed.status_code, 200)
         self.assertEqual(renewed.data['token'], response.data['token'])
 
+    def test_release_edit_lease(self):
+        response, _ = self.acquire_edit_lease()
+
+        released = self.client.post('/api/documents/10/edit-lease/release', {
+            'client_id': response.data['client_id'],
+            'token': response.data['token'],
+        })
+
+        self.assertEqual(released.status_code, 204)
+        self.assertFalse(DocumentEditLease.objects.filter(document_id=10).exists())
+
+        # Repeated releases are harmless.
+        released = self.client.post('/api/documents/10/edit-lease/release', {
+            'client_id': response.data['client_id'],
+            'token': response.data['token'],
+        })
+        self.assertEqual(released.status_code, 204)
+
+    def test_release_does_not_delete_another_clients_lease(self):
+        response, _ = self.acquire_edit_lease()
+
+        released = self.client.post('/api/documents/10/edit-lease/release', {
+            'client_id': str(uuid.uuid4()),
+            'token': response.data['token'],
+        })
+
+        self.assertEqual(released.status_code, 204)
+        self.assertTrue(DocumentEditLease.objects.filter(document_id=10).exists())
+
     def test_document_activity_identifies_edit_lease_holder(self):
         user = User.objects.get(username='email@example.com')
         user.user_permissions.add(*Permission.objects.filter(

--- a/indigo_api/tests/test_document_api.py
+++ b/indigo_api/tests/test_document_api.py
@@ -94,6 +94,54 @@ class DocumentAPITest(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('<p>in γνωρίζω body</p>', response.data['content'])
 
+    def test_update_with_matching_expected_updated_at(self):
+        document = self.client.get('/api/documents/1').data
+
+        response = self.client.patch('/api/documents/1', {
+            'expected_updated_at': document['updated_at'],
+            'title': 'Updated safely',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['title'], 'Updated safely')
+        self.assertNotEqual(response.data['updated_at'], document['updated_at'])
+
+    def test_stale_update_does_not_overwrite_document(self):
+        original = self.client.get('/api/documents/1').data
+        first_response = self.client.patch('/api/documents/1', {
+            'expected_updated_at': original['updated_at'],
+            'title': 'First editor won',
+        })
+        self.assertEqual(first_response.status_code, 200)
+        revisions_after_first_save = self.client.get('/api/documents/1/revisions').data
+
+        stale_response = self.client.patch('/api/documents/1', {
+            'expected_updated_at': original['updated_at'],
+            'title': 'Stale editor overwrote it',
+            'content': document_fixture('stale content'),
+        })
+
+        self.assertEqual(stale_response.status_code, 409)
+        self.assertEqual(stale_response.data['code'], 'document_changed')
+        self.assertEqual(stale_response.data['expected_updated_at'], original['updated_at'])
+        self.assertEqual(
+            stale_response.data['current_updated_at'],
+            first_response.data['updated_at'],
+        )
+        self.assertEqual(
+            stale_response.data['updated_by_user']['id'],
+            first_response.data['updated_by_user']['id'],
+        )
+
+        current = self.client.get('/api/documents/1').data
+        self.assertEqual(current['title'], 'First editor won')
+        content = self.client.get('/api/documents/1/content').data['content']
+        self.assertNotIn('stale content', content)
+        self.assertEqual(
+            self.client.get('/api/documents/1/revisions').data,
+            revisions_after_first_save,
+        )
+
     def test_revert_a_revision(self):
         id = 1
         response = self.client.patch('/api/documents/%s' % id, {'content': document_fixture('hello in there')})

--- a/indigo_api/tests/test_document_api.py
+++ b/indigo_api/tests/test_document_api.py
@@ -151,6 +151,7 @@ class DocumentAPITest(APITestCase):
         data = {
             'expected_updated_at': document['updated_at'],
             'client_id': str(uuid.uuid4()),
+            'activity_nonce': str(uuid.uuid4())[:10],
         }
         data.update(overrides)
         return self.client.post(f'/api/documents/{document_id}/edit-lease', data), document
@@ -159,14 +160,20 @@ class DocumentAPITest(APITestCase):
         response, document = self.acquire_edit_lease()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['document_updated_at'], document['updated_at'])
+        self.assertEqual(
+            response.data['activity_nonce'],
+            DocumentEditLease.objects.get(document_id=10).activity_nonce,
+        )
 
         renewed = self.client.post('/api/documents/10/edit-lease', {
             'expected_updated_at': document['updated_at'],
             'client_id': response.data['client_id'],
+            'activity_nonce': 'new-page',
             'token': response.data['token'],
         })
         self.assertEqual(renewed.status_code, 200)
         self.assertEqual(renewed.data['token'], response.data['token'])
+        self.assertEqual(renewed.data['activity_nonce'], 'new-page')
 
     def test_release_edit_lease(self):
         response, _ = self.acquire_edit_lease()
@@ -206,13 +213,16 @@ class DocumentAPITest(APITestCase):
         response = self.client.post(activity_url, {'nonce': 'lease-test'})
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.data['results'][0]['has_edit_lease'])
+        self.client.post(activity_url, {'nonce': 'other-tab'})
 
-        lease, _ = self.acquire_edit_lease(10)
+        lease, _ = self.acquire_edit_lease(10, activity_nonce='lease-test')
         self.assertEqual(lease.status_code, 200)
         response = self.client.post(activity_url, {'nonce': 'lease-test'})
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.data['results'][0]['has_edit_lease'])
+        activities = {activity['nonce']: activity for activity in response.data['results']}
+        self.assertTrue(activities['lease-test']['has_edit_lease'])
+        self.assertFalse(activities['other-tab']['has_edit_lease'])
 
     def test_second_client_cannot_acquire_active_lease(self):
         first, document = self.acquire_edit_lease()

--- a/indigo_api/tests/test_document_api.py
+++ b/indigo_api/tests/test_document_api.py
@@ -1,14 +1,18 @@
 import tempfile
 from unittest.mock import patch
 import datetime
+import uuid
 
 from rest_framework.test import APITestCase
+from rest_framework import serializers
+from django.contrib.auth.models import Permission, User
 from django.test.utils import override_settings
 from django.core.files.base import ContentFile
+from django.utils import timezone
 
 from indigo_api.tests.fixtures import *  # noqa
 from indigo_api.exporters import PDFExporter
-from indigo_api.models import Work, Attachment, Country, Document
+from indigo_api.models import Work, Attachment, Country, Document, DocumentEditLease
 from indigo_app.tests.utils import TEST_STORAGES
 
 
@@ -141,6 +145,119 @@ class DocumentAPITest(APITestCase):
             self.client.get('/api/documents/1/revisions').data,
             revisions_after_first_save,
         )
+
+    def acquire_edit_lease(self, document_id=10, **overrides):
+        document = self.client.get(f'/api/documents/{document_id}').data
+        data = {
+            'expected_updated_at': document['updated_at'],
+            'client_id': str(uuid.uuid4()),
+        }
+        data.update(overrides)
+        return self.client.post(f'/api/documents/{document_id}/edit-lease', data), document
+
+    def test_acquire_and_renew_edit_lease(self):
+        response, document = self.acquire_edit_lease()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['document_updated_at'], document['updated_at'])
+
+        renewed = self.client.post('/api/documents/10/edit-lease', {
+            'expected_updated_at': document['updated_at'],
+            'client_id': response.data['client_id'],
+            'token': response.data['token'],
+        })
+        self.assertEqual(renewed.status_code, 200)
+        self.assertEqual(renewed.data['token'], response.data['token'])
+
+    def test_document_activity_identifies_edit_lease_holder(self):
+        user = User.objects.get(username='email@example.com')
+        user.user_permissions.add(*Permission.objects.filter(
+            codename__in=('add_documentactivity', 'view_documentactivity'),
+        ))
+        activity_url = '/api/documents/10/activity'
+        response = self.client.post(activity_url, {'nonce': 'lease-test'})
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data['results'][0]['has_edit_lease'])
+
+        lease, _ = self.acquire_edit_lease(10)
+        self.assertEqual(lease.status_code, 200)
+        response = self.client.post(activity_url, {'nonce': 'lease-test'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['results'][0]['has_edit_lease'])
+
+    def test_second_client_cannot_acquire_active_lease(self):
+        first, document = self.acquire_edit_lease()
+        self.assertEqual(first.status_code, 200)
+
+        second, _ = self.acquire_edit_lease(
+            expected_updated_at=document['updated_at'],
+            client_id=str(uuid.uuid4()),
+        )
+        self.assertEqual(second.status_code, 409)
+        self.assertEqual(second.data['code'], 'document_locked')
+        self.assertEqual(second.data['holder']['id'], first.data['holder']['id'])
+
+    def test_stale_client_cannot_acquire_or_reacquire_lease(self):
+        lease_response, document = self.acquire_edit_lease()
+        lease = DocumentEditLease.objects.get(document_id=10)
+        lease.expires_at = timezone.now() - datetime.timedelta(seconds=1)
+        lease.save(update_fields=('expires_at',))
+
+        self.client.patch('/api/documents/10', {'title': 'Changed elsewhere'})
+        stale = self.client.post('/api/documents/10/edit-lease', {
+            'expected_updated_at': document['updated_at'],
+            'client_id': lease_response.data['client_id'],
+            'token': lease_response.data['token'],
+        })
+        self.assertEqual(stale.status_code, 409)
+        self.assertEqual(stale.data['code'], 'document_changed')
+
+    def test_current_client_can_reacquire_expired_lease(self):
+        lease_response, document = self.acquire_edit_lease()
+        lease = DocumentEditLease.objects.get(document_id=10)
+        lease.expires_at = timezone.now() - datetime.timedelta(seconds=1)
+        lease.save(update_fields=('expires_at',))
+
+        reacquired = self.client.post('/api/documents/10/edit-lease', {
+            'expected_updated_at': document['updated_at'],
+            'client_id': lease_response.data['client_id'],
+            'token': lease_response.data['token'],
+        })
+        self.assertEqual(reacquired.status_code, 200)
+        self.assertEqual(reacquired.data['token'], lease_response.data['token'])
+        self.assertGreater(DocumentEditLease.objects.get(document_id=10).expires_at, timezone.now())
+
+    def test_save_with_lease_advances_lease_version(self):
+        lease_response, document = self.acquire_edit_lease()
+
+        saved = self.client.patch('/api/documents/10', {
+            'expected_updated_at': document['updated_at'],
+            'edit_lease_token': lease_response.data['token'],
+            'title': 'Saved under lease',
+        })
+        self.assertEqual(saved.status_code, 200)
+
+        lease = DocumentEditLease.objects.get(document_id=10)
+        self.assertEqual(lease.document_updated_at, Document.objects.get(pk=10).updated_at)
+        self.assertEqual(
+            serializers.DateTimeField().to_representation(lease.document_updated_at),
+            saved.data['updated_at'],
+        )
+
+    def test_save_with_expired_lease_is_rejected(self):
+        lease_response, document = self.acquire_edit_lease()
+        lease = DocumentEditLease.objects.get(document_id=10)
+        lease.expires_at = timezone.now() - datetime.timedelta(seconds=1)
+        lease.save(update_fields=('expires_at',))
+
+        response = self.client.patch('/api/documents/10', {
+            'expected_updated_at': document['updated_at'],
+            'edit_lease_token': lease_response.data['token'],
+            'title': 'Must not save',
+        })
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.data['code'], 'edit_lease_lost')
+        self.assertNotEqual(Document.objects.get(pk=10).title, 'Must not save')
 
     def test_revert_a_revision(self):
         id = 1
@@ -351,6 +468,46 @@ class DocumentAPITest(APITestCase):
         response = self.client.put(data['url'], {'filename': '/with/slashes.txt'})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['filename'], 'withslashes.txt')
+
+    def test_attachment_mutation_with_edit_lease(self):
+        document = self.client.get('/api/documents/10').data
+        lease, _ = self.acquire_edit_lease(10)
+        tmp_file = tempfile.NamedTemporaryFile(suffix='.txt')
+        tmp_file.write(b'leased attachment')
+        tmp_file.seek(0)
+
+        response = self.client.post(
+            '/api/documents/10/attachments',
+            {'file': tmp_file, 'filename': 'leased.txt'},
+            format='multipart',
+            HTTP_X_EDIT_LEASE_TOKEN=lease.data['token'],
+            HTTP_X_EXPECTED_UPDATED_AT=document['updated_at'],
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(Attachment.objects.filter(document_id=10, filename='leased.txt').exists())
+
+    def test_attachment_mutation_rejects_expired_edit_lease(self):
+        document = self.client.get('/api/documents/10').data
+        lease, _ = self.acquire_edit_lease(10)
+        DocumentEditLease.objects.filter(document_id=10).update(
+            expires_at=timezone.now() - datetime.timedelta(seconds=1),
+        )
+        tmp_file = tempfile.NamedTemporaryFile(suffix='.txt')
+        tmp_file.write(b'should not be saved')
+        tmp_file.seek(0)
+
+        response = self.client.post(
+            '/api/documents/10/attachments',
+            {'file': tmp_file, 'filename': 'rejected.txt'},
+            format='multipart',
+            HTTP_X_EDIT_LEASE_TOKEN=lease.data['token'],
+            HTTP_X_EXPECTED_UPDATED_AT=document['updated_at'],
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.data['code'], 'edit_lease_lost')
+        self.assertFalse(Attachment.objects.filter(document_id=10, filename='rejected.txt').exists())
 
     @patch.object(PDFExporter, 'render', return_value='pdf-content')
     def test_document_pdf(self, mock):

--- a/indigo_api/urls.py
+++ b/indigo_api/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     re_path(r'documents/(?P<document_id>[0-9]+)/media/(?P<filename>.*)$', attachments.AttachmentMediaView.as_view(), name='document-media'),
     path('documents/<int:document_id>/activity', documents.DocumentActivityViewSet.as_view({
         'get': 'list', 'post': 'create', 'delete': 'destroy'}), name='document-activity'),
+    path('documents/<int:document_id>/edit-lease', documents.DocumentEditLeaseView.as_view(), name='document-edit-lease'),
     path('documents/<int:document_id>/diff', documents.DocumentDiffView.as_view(), name='document-diff'),
     path('documents/<int:document_id>/parse', documents.ParseView.as_view(), name='document-parse'),
     path('documents/<int:document_id>/render/coverpage', documents.RenderCoverpageView.as_view(), name='document-render-coverpage'),

--- a/indigo_api/urls.py
+++ b/indigo_api/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('documents/<int:document_id>/activity', documents.DocumentActivityViewSet.as_view({
         'get': 'list', 'post': 'create', 'delete': 'destroy'}), name='document-activity'),
     path('documents/<int:document_id>/edit-lease', documents.DocumentEditLeaseView.as_view(), name='document-edit-lease'),
+    path('documents/<int:document_id>/edit-lease/release', documents.DocumentEditLeaseReleaseView.as_view(), name='document-edit-lease-release'),
     path('documents/<int:document_id>/diff', documents.DocumentDiffView.as_view(), name='document-diff'),
     path('documents/<int:document_id>/parse', documents.ParseView.as_view(), name='document-parse'),
     path('documents/<int:document_id>/render/coverpage', documents.RenderCoverpageView.as_view(), name='document-render-coverpage'),

--- a/indigo_api/views/attachments.py
+++ b/indigo_api/views/attachments.py
@@ -1,16 +1,20 @@
 from django.http import HttpResponse
 from django.shortcuts import get_list_or_404
 
-from rest_framework import viewsets
+from django.db import transaction
+from django.utils import timezone
+from rest_framework import serializers, viewsets
 from rest_framework.views import APIView
 from rest_framework.generics import get_object_or_404
 from rest_framework.decorators import action
 
-from ..models import Document, Attachment, Work, PublicationDocument
+from ..models import Document, DocumentEditLease, Attachment, Work, PublicationDocument
+from ..exceptions import DocumentChanged, EditLeaseLost
 from ..serializers import AttachmentSerializer
 from ..authz import ModelPermissions, RelatedDocumentPermissions
 from .documents import DocumentResourceView
 from .misc import DEFAULT_PERMS
+from indigo.view_mixins import AtomicWriteViewSetMixin
 from docpipe.soffice import soffice_convert
 import os
 
@@ -56,7 +60,7 @@ def download_attachment(attachment):
     return response
 
 
-class AttachmentViewSet(DocumentResourceView, viewsets.ModelViewSet):
+class AttachmentViewSet(AtomicWriteViewSetMixin, DocumentResourceView, viewsets.ModelViewSet):
     queryset = Attachment.objects
     serializer_class = AttachmentSerializer
     permission_classes = DEFAULT_PERMS + (ModelPermissions, RelatedDocumentPermissions)
@@ -75,6 +79,45 @@ class AttachmentViewSet(DocumentResourceView, viewsets.ModelViewSet):
 
     def filter_queryset(self, queryset):
         return queryset.filter(document=self.document).all()
+
+    def check_edit_lease(self):
+        token = self.request.headers.get('X-Edit-Lease-Token')
+        expected_updated_at = self.request.headers.get('X-Expected-Updated-At')
+        # Preserve compatibility for non-editor API clients. The Indigo editor
+        # always supplies both headers for attachment mutations.
+        if not token and not expected_updated_at:
+            return
+        if not token or not expected_updated_at:
+            raise serializers.ValidationError('Both edit lease headers are required.')
+
+        token = serializers.UUIDField().run_validation(token)
+        expected_updated_at = serializers.DateTimeField().run_validation(expected_updated_at)
+        document = Document.objects.select_for_update().get(pk=self.document.pk)
+        if expected_updated_at != document.updated_at:
+            raise DocumentChanged(document, expected_updated_at)
+        try:
+            lease = DocumentEditLease.objects.get(
+                document=document,
+                user=self.request.user,
+                token=token,
+                expires_at__gt=timezone.now(),
+                document_updated_at=expected_updated_at,
+            )
+        except DocumentEditLease.DoesNotExist:
+            raise EditLeaseLost()
+        return lease
+
+    def perform_create(self, serializer):
+        self.check_edit_lease()
+        return super().perform_create(serializer)
+
+    def perform_update(self, serializer):
+        self.check_edit_lease()
+        return super().perform_update(serializer)
+
+    def perform_destroy(self, instance):
+        self.check_edit_lease()
+        return super().perform_destroy(instance)
 
 
 class AttachmentMediaView(DocumentResourceView, APIView):

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -98,7 +98,12 @@ class DocumentViewSet(AtomicWriteViewSetMixin,
     filter_fields = DOCUMENT_FILTER_FIELDS
 
     def get_queryset(self):
-        return super().get_queryset().permitted_to(self.request.user)
+        queryset = super().get_queryset().permitted_to(self.request.user)
+        if self.request.method in ('PUT', 'PATCH'):
+            # AtomicWriteViewSetMixin wraps updates in a transaction. Lock the
+            # row so concurrent saves cannot both pass the version check.
+            queryset = queryset.select_for_update()
+        return queryset
 
     def perform_destroy(self, instance):
         if not instance.draft:

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -45,7 +45,7 @@ from ..models import Document, Annotation, DocumentActivity, DocumentEditLease, 
 from ..renderers import AkomaNtosoRenderer, PDFRenderer, EPUBRenderer, HTMLRenderer, ZIPRenderer
 from ..serializers import DocumentSerializer, RenderSerializer, ParseSerializer, DocumentAPISerializer, \
     VersionSerializer, AnnotationSerializer, DocumentActivitySerializer, DocumentEditLeaseRequestSerializer, \
-    DocumentEditLeaseSerializer, TaskSerializer
+    DocumentEditLeaseReleaseSerializer, DocumentEditLeaseSerializer, TaskSerializer
 from ..utils import filename_candidates, find_best_static, adiff_html_str
 
 log = logging.getLogger(__name__)
@@ -362,7 +362,7 @@ class DocumentActivityViewSet(AtomicWriteViewSetMixin,
 
 
 class DocumentEditLeaseView(DocumentResourceView, APIView):
-    """Acquire, renew, and release a document editing lease."""
+    """Acquire and renew a document editing lease."""
     permission_classes = DEFAULT_PERMS + (RelatedDocumentPermissions,)
 
     @transaction.atomic
@@ -400,6 +400,30 @@ class DocumentEditLeaseView(DocumentResourceView, APIView):
         lease.renew(now)
         lease.save()
         return Response(DocumentEditLeaseSerializer(lease).data)
+
+
+class DocumentEditLeaseReleaseView(DocumentResourceView, APIView):
+    """Best-effort release of a document editing lease."""
+    permission_classes = DEFAULT_PERMS + (RelatedDocumentPermissions,)
+
+    @transaction.atomic
+    def post(self, request, document_id):
+        serializer = DocumentEditLeaseReleaseSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        # Lock the document to serialize release with acquisition and saving.
+        document = Document.objects.select_for_update().get(pk=self.document.pk)
+        DocumentEditLease.objects.filter(
+            document=document,
+            user=request.user,
+            token=data['token'],
+            client_id=data['client_id'],
+        ).delete()
+        # Releasing is deliberately idempotent. A stale or duplicate request
+        # must never release a newer client's lease.
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class ParseView(DocumentResourceView, APIView):
     """ Parse text into Akoma Ntoso, returning Akoma Ntoso XML.

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -330,6 +330,7 @@ class DocumentActivityViewSet(AtomicWriteViewSetMixin,
         active_lease = DocumentEditLease.objects.filter(
             document_id=OuterRef('document_id'),
             user_id=OuterRef('user_id'),
+            activity_nonce=OuterRef('nonce'),
             expires_at__gt=timezone.now(),
         )
         return self.document.activities.select_related('user').annotate(
@@ -397,6 +398,8 @@ class DocumentEditLeaseView(DocumentResourceView, APIView):
             lease.document_updated_at = document.updated_at
             lease.acquired_at = now
 
+        if 'activity_nonce' in data:
+            lease.activity_nonce = data['activity_nonce']
         lease.renew(now)
         lease.save()
         return Response(DocumentEditLeaseSerializer(lease).data)

--- a/indigo_api/views/documents.py
+++ b/indigo_api/views/documents.py
@@ -2,12 +2,14 @@ import copy
 import datetime
 import json
 import logging
+import uuid
 
 from actstream import action
 from asgiref.sync import sync_to_async
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
+from django.db.models import Exists, OuterRef
 from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.templatetags.static import static
@@ -38,10 +40,12 @@ from indigo_app.views.base import AsyncDispatchMixin, AbstractAuthedIndigoView
 from .misc import DEFAULT_PERMS
 from ..authz import DocumentPermissions, AnnotationPermissions, DocumentReadPermissions, ModelPermissions, RelatedDocumentPermissions, \
     RevisionPermissions
-from ..models import Document, Annotation, DocumentActivity, Task
+from ..exceptions import DocumentChanged, DocumentLocked, EditLeaseLost
+from ..models import Document, Annotation, DocumentActivity, DocumentEditLease, Task
 from ..renderers import AkomaNtosoRenderer, PDFRenderer, EPUBRenderer, HTMLRenderer, ZIPRenderer
 from ..serializers import DocumentSerializer, RenderSerializer, ParseSerializer, DocumentAPISerializer, \
-    VersionSerializer, AnnotationSerializer, DocumentActivitySerializer, TaskSerializer
+    VersionSerializer, AnnotationSerializer, DocumentActivitySerializer, DocumentEditLeaseRequestSerializer, \
+    DocumentEditLeaseSerializer, TaskSerializer
 from ..utils import filename_candidates, find_best_static, adiff_html_str
 
 log = logging.getLogger(__name__)
@@ -318,16 +322,19 @@ class DocumentActivityViewSet(AtomicWriteViewSetMixin,
                               mixins.ListModelMixin,
                               mixins.CreateModelMixin,
                               viewsets.GenericViewSet):
-    """ API endpoint to see who's working in a document.
-
-    Because this "locks" a document, only users who have permission to edit the document
-    can create an activity object.
-    """
+    """API endpoint showing who currently has a document open."""
     serializer_class = DocumentActivitySerializer
     permission_classes = DEFAULT_PERMS + (ModelPermissions, RelatedDocumentPermissions)
 
     def get_queryset(self):
-        return self.document.activities.prefetch_related('user').all()
+        active_lease = DocumentEditLease.objects.filter(
+            document_id=OuterRef('document_id'),
+            user_id=OuterRef('user_id'),
+            expires_at__gt=timezone.now(),
+        )
+        return self.document.activities.select_related('user').annotate(
+            has_edit_lease=Exists(active_lease),
+        )
 
     def filter_queryset(self, queryset):
         # only return entries that aren't stale
@@ -353,6 +360,46 @@ class DocumentActivityViewSet(AtomicWriteViewSetMixin,
             activity.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+
+class DocumentEditLeaseView(DocumentResourceView, APIView):
+    """Acquire, renew, and release a document editing lease."""
+    permission_classes = DEFAULT_PERMS + (RelatedDocumentPermissions,)
+
+    @transaction.atomic
+    def post(self, request, document_id):
+        serializer = DocumentEditLeaseRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        now = timezone.now()
+
+        document = Document.objects.select_for_update().get(pk=self.document.pk)
+        if data['expected_updated_at'] != document.updated_at:
+            raise DocumentChanged(document, data['expected_updated_at'])
+
+        lease = DocumentEditLease.objects.select_related('user').filter(document=document).first()
+        token = data.get('token')
+
+        if lease and not lease.is_expired:
+            if not token or lease.token != token or lease.user_id != request.user.id:
+                raise DocumentLocked(lease)
+            if lease.client_id != data['client_id'] or lease.document_updated_at != data['expected_updated_at']:
+                raise EditLeaseLost()
+        elif lease and token and lease.token == token and lease.user_id == request.user.id:
+            # Reacquire an expired lease only when it is still this client's row.
+            lease.client_id = data['client_id']
+            lease.document_updated_at = document.updated_at
+            lease.acquired_at = now
+        else:
+            lease = lease or DocumentEditLease(document=document)
+            lease.user = request.user
+            lease.token = uuid.uuid4()
+            lease.client_id = data['client_id']
+            lease.document_updated_at = document.updated_at
+            lease.acquired_at = now
+
+        lease.renew(now)
+        lease.save()
+        return Response(DocumentEditLeaseSerializer(lease).data)
 
 class ParseView(DocumentResourceView, APIView):
     """ Parse text into Akoma Ntoso, returning Akoma Ntoso XML.

--- a/indigo_app/middleware.py
+++ b/indigo_app/middleware.py
@@ -72,25 +72,3 @@ class LogContextMiddleware:
             return self.get_response(request)
         finally:
             clear_log_context()
-
-
-class UnloadPermissionsPolicyMiddleware:
-    """Temporarily opt back into Chrome's deprecated ``unload`` event.
-
-    The document activity lock currently releases its per-tab activity in an
-    unload handler. Keep that mechanism working while it is replaced with a
-    lease and save-time optimistic concurrency checks.
-    """
-    directive = "unload=(self)"
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
-        policy = response.get("Permissions-Policy", "")
-        directives = [item.strip() for item in policy.split(",") if item.strip()]
-        directives = [item for item in directives if not item.startswith("unload=")]
-        directives.append(self.directive)
-        response["Permissions-Policy"] = ", ".join(directives)
-        return response

--- a/indigo_app/static/javascript/indigo/models.js
+++ b/indigo_app/static/javascript/indigo/models.js
@@ -282,11 +282,15 @@
       this.document.attributes.provision_eid = Indigo.Preloads.provisionEid;
       // send our updated_at for optimistic concurrency checks
       this.document.attributes.expected_updated_at = this.document.get('updated_at');
+      if (this.document.editLease && this.document.editLease.token) {
+        this.document.attributes.edit_lease_token = this.document.editLease.token;
+      }
       const result = this.document.save();
       // don't re-parse the content in the response to the save() call
       delete this.document.attributes.content;
       delete this.document.attributes.provision_eid;
       delete this.document.attributes.expected_updated_at;
+      delete this.document.attributes.edit_lease_token;
 
       // Only mark the content as saved once the server has accepted it. In
       // particular, keep it dirty when optimistic concurrency returns a 409.
@@ -639,7 +643,9 @@
   });
 
   Indigo.Attachment = Backbone.Model.extend({
-    initialize: function() {
+    initialize: function(attributes, options) {
+      options = options || {};
+      this.document = options.collection && options.collection.document;
       this.on('sync', this.clearFile, this);
     },
 
@@ -648,6 +654,13 @@
     },
 
     sync: function(method, model, options) {
+      options.headers = options.headers || {};
+      const document = model.document || (model.collection && model.collection.document);
+      const editLease = document && document.editLease;
+      if (editLease && editLease.token) {
+        options.headers['X-Edit-Lease-Token'] = editLease.token;
+        options.headers['X-Expected-Updated-At'] = document.get('updated_at');
+      }
       if (method === 'create' && model.get('file')) {
         // override params passed in for create to allow us to inject the file
         //

--- a/indigo_app/static/javascript/indigo/models.js
+++ b/indigo_app/static/javascript/indigo/models.js
@@ -280,11 +280,17 @@
       // serialise the xml from the live DOM
       this.document.attributes.content = this.wrapInAkn(this.toXml());
       this.document.attributes.provision_eid = Indigo.Preloads.provisionEid;
+      // send our updated_at for optimistic concurrency checks
+      this.document.attributes.expected_updated_at = this.document.get('updated_at');
       const result = this.document.save();
       // don't re-parse the content in the response to the save() call
       delete this.document.attributes.content;
-      this.document.setClean();
-      this.trigger('sync');
+      delete this.document.attributes.provision_eid;
+      delete this.document.attributes.expected_updated_at;
+
+      // Only mark the content as saved once the server has accepted it. In
+      // particular, keep it dirty when optimistic concurrency returns a 409.
+      result.done(() => this.trigger('sync'));
 
       return result;
     },

--- a/indigo_app/static/javascript/indigo/views/document.js
+++ b/indigo_app/static/javascript/indigo/views/document.js
@@ -127,6 +127,7 @@
       let self = this;
 
       this.$saveBtn = $('.document-workspace-buttons .btn.save');
+      this.$leaseStatus = $('.edit-lease-status');
       this.$menu = $('.document-toolbar-menu');
       this.secondaryPaneToggle = this.el.querySelector('.document-toolbar-wrapper .document-secondary-pane-toggle');
       this.dirty = false;
@@ -148,6 +149,7 @@
       this.document = new Indigo.Document(Indigo.Preloads.document);
       this.document.work = new Indigo.Work(Indigo.Preloads.work);
       this.document.issues = new Backbone.Collection();
+      this.editLease = new Indigo.DocumentEditLease({document: this.document});
 
       this.document.on('sync', this.setClean, this);
       this.document.on('change', this.setDirty, this);
@@ -179,6 +181,7 @@
         model: this.document,
         tocView: this.tocView,
       });
+      this.listenTo(this.editLease, 'state', this.updateSaveControls);
       this.sourceEditorView.editorReady.then(function() {
         // select the appropriate element in the toc
         // TODO: there's a race condition here: the TOC might not be built yet
@@ -208,6 +211,8 @@
       // preload content and pretend this document is unchanged
       this.documentContent.set('content', Indigo.Preloads.documentContent);
       this.document.trigger('sync');
+      this.updateSaveControls();
+      this.leaseAcquisitionOnDirty = true;
 
       // make menu peers behave like real menus on hover
       $('.menu .btn-link').on('mouseover', function(e) {
@@ -232,8 +237,13 @@
 
     setDirty: function() {
       this.dirty = true;
-      this.$saveBtn.prop('disabled', false);
-      this.$menu.find('.save').removeClass('disabled');
+      // A dirty model is the single signal that saving access is needed. This
+      // also covers new or plugin-provided mutation paths without coupling
+      // individual editing components to the lease.
+      if (this.leaseAcquisitionOnDirty && this.editLease.state === 'viewing' && !this.editLease.pending) {
+        this.editLease.acquire();
+      }
+      this.updateSaveControls();
     },
 
     setClean: function() {
@@ -247,6 +257,7 @@
             .addClass('fa-save');
         this.$menu.find('.save').addClass('disabled');
       }
+      this.updateSaveControls();
     },
 
     draftChanged: function() {
@@ -259,14 +270,18 @@
       this.$menu.find('.delete-document').toggleClass('disabled', !draft);
     },
 
-    saveAndPublish: function() {
+    saveAndPublish: function(e) {
+      e.preventDefault();
+      if (!this.editLease.held) return;
       if (Indigo.user.hasPerm('indigo_api.publish_document') && confirm($t('Publish this document to users?'))) {
         this.document.set('draft', false);
         this.save();
       }
     },
 
-    saveAndUnpublish: function() {
+    saveAndUnpublish: function(e) {
+      e.preventDefault();
+      if (!this.editLease.held) return;
       if (Indigo.user.hasPerm('indigo_api.publish_document') && confirm($t('Hide this document from users?'))) {
         this.document.set('draft', true);
         this.save();
@@ -275,6 +290,7 @@
 
     save: async function() {
       if (!this.sourceEditorView.confirmAndDiscardChanges()) return;
+      if (!await this.editLease.prepareToSave()) return;
 
       this.$saveBtn
         .prop('disabled', true)
@@ -292,24 +308,47 @@
           window.location.reload();
         }
       } catch (xhr) {
-        if (xhr && xhr.status === 409) {
-          const detail = xhr.responseJSON && xhr.responseJSON.detail;
-          const updatedAt = xhr.responseJSON && xhr.responseJSON.current_updated_at;
-          const updatedAtDetail = updatedAt
-            ? `<p>${$t('Last saved:')} ${new Date(updatedAt).toLocaleString()}</p>`
-            : null;
-          Indigo.errorView.show(
-            detail || $t('This document has changed since you opened it. Your changes have not been saved.'),
-            updatedAtDetail
-          );
+        const code = xhr && xhr.responseJSON && xhr.responseJSON.code;
+        if (code === 'document_changed' || code === 'edit_lease_lost') {
+          this.editLease.lose(xhr.responseJSON);
         }
-
-        this.$saveBtn
-          .prop('disabled', false)
-          .find('.fa')
+        this.$saveBtn.find('.fa')
           .removeClass('fa-pulse fa-spinner')
           .addClass('fa-save');
+      } finally {
+        this.editLease.saveFinished();
+        this.updateSaveControls();
       }
+    },
+
+    updateSaveControls: function(state, details) {
+      if (state) {
+        this.leaseState = state;
+        if (details !== undefined) this.leaseStateDetails = details;
+      }
+      const leaseReady = this.editLease.held;
+      const canSave = this.dirty && leaseReady;
+      const leaseState = this.leaseState || this.editLease.state;
+      const leaseDetails = this.leaseStateDetails || {};
+      let status = '';
+      if (leaseState === 'acquiring' && !leaseDetails.holder) {
+        status = $t('Acquiring saving access…');
+      } else if (leaseState === 'locked' || (leaseState === 'acquiring' && leaseDetails.holder)) {
+        const holder = leaseDetails.holder && leaseDetails.holder.display_name;
+        status = holder
+          ? $t('Saving is currently reserved by ') + holder + '. ' + $t('You can continue editing.')
+          : $t('Saving is currently reserved by another editor. You can continue editing.');
+      } else if (leaseState === 'lost' || leaseState === 'viewing') {
+        status = this.dirty ? $t('Saving is currently unavailable. Retrying…') : '';
+      } else if (leaseState === 'stale') {
+        status = $t('The document has changed. Refresh before saving.');
+      }
+      this.$saveBtn.prop('disabled', !canSave);
+      if (this.$leaseStatus.text() !== status) this.$leaseStatus.text(status);
+      this.$leaseStatus.toggleClass('d-none', !status);
+      $('.save-and-publish, .save-and-unpublish')
+        .toggleClass('edit-lease-disabled', !leaseReady)
+        .attr('aria-disabled', leaseReady ? null : 'true');
     },
 
     delete: function() {

--- a/indigo_app/static/javascript/indigo/views/document.js
+++ b/indigo_app/static/javascript/indigo/views/document.js
@@ -291,7 +291,19 @@
         if (this.sourceEditorView.aknTextEditor.reloadOnSave) {
           window.location.reload();
         }
-      } catch {
+      } catch (xhr) {
+        if (xhr && xhr.status === 409) {
+          const detail = xhr.responseJSON && xhr.responseJSON.detail;
+          const updatedAt = xhr.responseJSON && xhr.responseJSON.current_updated_at;
+          const updatedAtDetail = updatedAt
+            ? `<p>${$t('Last saved:')} ${new Date(updatedAt).toLocaleString()}</p>`
+            : null;
+          Indigo.errorView.show(
+            detail || $t('This document has changed since you opened it. Your changes have not been saved.'),
+            updatedAtDetail
+          );
+        }
+
         this.$saveBtn
           .prop('disabled', false)
           .find('.fa')

--- a/indigo_app/static/javascript/indigo/views/document.js
+++ b/indigo_app/static/javascript/indigo/views/document.js
@@ -150,6 +150,11 @@
       this.document.work = new Indigo.Work(Indigo.Preloads.work);
       this.document.issues = new Backbone.Collection();
       this.editLease = new Indigo.DocumentEditLease({document: this.document});
+      window.addEventListener('pageshow', (event) => {
+        if (event.persisted && this.isDirty() && this.editLease.state === 'viewing') {
+          this.editLease.acquire();
+        }
+      });
 
       this.document.on('sync', this.setClean, this);
       this.document.on('change', this.setDirty, this);
@@ -291,6 +296,7 @@
     save: async function() {
       if (!this.sourceEditorView.confirmAndDiscardChanges()) return;
       if (!await this.editLease.prepareToSave()) return;
+      let saved = false;
 
       this.$saveBtn
         .prop('disabled', true)
@@ -302,6 +308,7 @@
         // this saves the content and the document properties together
         await Indigo.deferredToAsync(this.documentContent.save());
         await Indigo.deferredToAsync(this.attachmentsView.save());
+        saved = true;
 
         // TODO: a better way of reloading the page (will redirect to provision chooser for now)
         if (this.sourceEditorView.aknTextEditor.reloadOnSave) {
@@ -317,6 +324,7 @@
           .addClass('fa-save');
       } finally {
         this.editLease.saveFinished();
+        if (saved) this.editLease.release();
         this.updateSaveControls();
       }
     },

--- a/indigo_app/static/javascript/indigo/views/document.js
+++ b/indigo_app/static/javascript/indigo/views/document.js
@@ -149,7 +149,11 @@
       this.document = new Indigo.Document(Indigo.Preloads.document);
       this.document.work = new Indigo.Work(Indigo.Preloads.work);
       this.document.issues = new Backbone.Collection();
-      this.editLease = new Indigo.DocumentEditLease({document: this.document});
+      const activityNonce = Math.floor(Math.random() * (1000000 - 1000) + 1000).toString();
+      this.editLease = new Indigo.DocumentEditLease({
+        document: this.document,
+        activityNonce: activityNonce,
+      });
       window.addEventListener('pageshow', (event) => {
         if (event.persisted && this.isDirty() && this.editLease.state === 'viewing') {
           this.editLease.acquire();
@@ -202,7 +206,10 @@
       });
       this.annotationsView.listenTo(this.sourceEditorView, 'rendered', this.annotationsView.renderAnnotations);
 
-      this.activityView = new Indigo.DocumentActivityView({document: this.document});
+      this.activityView = new Indigo.DocumentActivityView({
+        document: this.document,
+        nonce: activityNonce,
+      });
       this.issuesView = new Indigo.DocumentIssuesView({
         document: this.document,
         documentContent: this.documentContent,

--- a/indigo_app/static/javascript/indigo/views/document_activity.js
+++ b/indigo_app/static/javascript/indigo/views/document_activity.js
@@ -24,7 +24,7 @@
 
       if (this.document.get('id')) {
         this.loop();
-        $(window).on('unload', _.bind(this.windowUnloaded, this));
+        window.addEventListener('pagehide', () => this.pageHidden());
       }
     },
 
@@ -114,7 +114,7 @@
     },
 
     getFinishedSessions: function(document_id) {
-      // look for finished sessions recorded by other tabs with their dying gasps (see windowUnloaded)
+      // look for finished sessions recorded by other tabs with their dying gasps (see pageHidden)
       var finished = {};
 
       for (var i = 0; i < localStorage.length; i++) {
@@ -140,7 +140,7 @@
       return finished;
     },
 
-    windowUnloaded: function() {
+    pageHidden: function() {
       if (!Indigo.user.id) return;
 
       // store a note that this session is finished, in case we can't send this message before the window closes
@@ -150,15 +150,18 @@
         'nonce': this.nonce,
       }));
 
-      $.ajax({
-        type: 'delete',
-        url: this.document.url() + '/activity',
-        data: {nonce: this.nonce},
-        global: false,
-        async: false,
-      }).then(function() {
-        localStorage.removeItem(key);
-      });
+      window.fetch(this.document.url() + '/activity', {
+        method: 'DELETE',
+        credentials: 'same-origin',
+        keepalive: true,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+          'X-CSRFToken': Indigo.csrfToken,
+        },
+        body: new URLSearchParams({nonce: this.nonce}).toString(),
+      }).then(function(response) {
+        if (response.ok) localStorage.removeItem(key);
+      }).catch(function() {});
     },
   });
 

--- a/indigo_app/static/javascript/indigo/views/document_activity.js
+++ b/indigo_app/static/javascript/indigo/views/document_activity.js
@@ -15,8 +15,6 @@
       this.template = Handlebars.compile($(this.template).html());
 
       this.document = options.document;
-      this.locked = false;
-      this.outdated = false;
       this.collection = new Backbone.Collection([], {
         model: Indigo.DocumentActivity,
         comparator: 'created_at',
@@ -80,12 +78,6 @@
         self.collection.set(resp.results);
         self.collection.sort();
 
-        // we're locked if we're not the first item in the collection
-        // once locked, page must be refreshed before editing can happen
-        self.locked = self.locked || !self.collection.at(0).get('is_self');
-        // we're outdated if the document_updated_at for an entry (they're all the same) is later than
-        // what we think the updated-at should be
-        self.outdated = self.document.get('updated_at') < self.collection.at(0).get('document_updated_at');
         self.render();
       }).fail(function(xhr, error) {
         if (xhr.status >= 100) {
@@ -99,24 +91,23 @@
     },
 
     render: function() {
-      var self = this,
-          items = this.collection.toJSON(),
-          saveButtonGroup = document.querySelector('.document-workspace-buttons .save-btn-group');
-
-      if (this.locked) {
-        saveButtonGroup.innerHTML =
-          items[0].is_self ?
-            (`<div>${$t('You must refresh before making changes.')}<br><a href="#" onclick="window.location.reload();">${$t('Refresh')}</a>`) :
-            ($t('Editing has been locked by ') + items[0].user.display_name + '.</div>');
-      } else if (this.outdated) {
-        saveButtonGroup.innerHTML = `<div>${$t('The document has changed. You must refresh before making changes.')}<br><a href="#" onclick="window.location.reload();">${$t('Refresh')}</a>`;
-      }
+      var items = this.collection.toJSON();
 
       // exclude us
       items = _.filter(items, function(a) { return !a.is_self; });
       items.forEach(function(a) {
         a.user.colour = a.nonce.charCodeAt(0) % 8;
+        a.has_edit_lease = items.length > 0 && a.has_edit_lease;
       });
+
+      // Heartbeats update timestamps and lease renewals update state, but
+      // neither normally changes what is visible. Avoid replacing the badges
+      // unless their rendered content has actually changed.
+      const renderKey = JSON.stringify(items.map(function(a) {
+        return [a.nonce, a.user.id, a.user.display_name, a.is_asleep, a.has_edit_lease];
+      }));
+      if (renderKey === this.renderKey) return;
+      this.renderKey = renderKey;
 
       this.$el.html(this.template({activity: items}));
     },
@@ -167,6 +158,213 @@
       }).then(function() {
         localStorage.removeItem(key);
       });
+    },
+  });
+
+  /** Manage the exclusive, versioned lease used while editing a document. */
+  Indigo.DocumentEditLease = Backbone.Model.extend({
+    initialize: function(options) {
+      this.document = options.document;
+      this.document.editLease = this;
+      this.held = false;
+      this.pending = null;
+      this.renewTimer = null;
+      this.acquireRetryTimer = null;
+      this.saving = false;
+      this.state = 'viewing';
+      this.storageKey = 'indigo-document-edit-lease-' + this.document.get('id');
+
+      const stored = sessionStorage.getItem(this.storageKey);
+      if (stored) {
+        try {
+          const data = JSON.parse(stored);
+          this.token = data.token;
+          this.clientId = data.client_id;
+        } catch (e) {
+          sessionStorage.removeItem(this.storageKey);
+        }
+      }
+      this.clientId = this.clientId || this.newId();
+      this.pageId = this.newId();
+      this.setupTabCoordination();
+
+      // A refresh may resume its lease. A newly opened document has no stored
+      // token and therefore remains a presence-only viewer.
+      if (this.token) {
+        if (this.tabChannel) {
+          this.duplicateLeasePage = false;
+          this.tabChannel.postMessage({
+            type: 'probe',
+            client_id: this.clientId,
+            page_id: this.pageId,
+          });
+          window.setTimeout(() => {
+            if (!this.duplicateLeasePage) this.acquire();
+          }, 150);
+        } else {
+          this.acquire();
+        }
+      }
+      document.addEventListener('visibilitychange', () => {
+        if (this.held && document.visibilityState === 'visible') this.acquire(true);
+      });
+    },
+
+    newId: function() {
+      if (window.crypto && window.crypto.randomUUID) return window.crypto.randomUUID();
+      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        const r = Math.random() * 16 | 0;
+        return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+      });
+    },
+
+    setupTabCoordination: function() {
+      if (!window.BroadcastChannel) return;
+      this.tabChannel = new window.BroadcastChannel(
+        'indigo-document-edit-lease-' + this.document.get('id')
+      );
+      this.tabChannel.onmessage = (event) => {
+        const message = event.data || {};
+        if (message.type === 'probe' && this.held && message.client_id === this.clientId) {
+          this.tabChannel.postMessage({
+            type: 'active',
+            client_id: this.clientId,
+            page_id: message.page_id,
+          });
+        } else if (message.type === 'active' && message.page_id === this.pageId) {
+          this.duplicateLeasePage = true;
+          this.held = false;
+          this.clearStoredLease();
+        }
+      };
+    },
+
+    url: function() {
+      return this.document.url() + '/edit-lease';
+    },
+
+    setState: function(state, details) {
+      this.state = state;
+      if (details !== undefined) this.stateDetails = details;
+      this.trigger('state', state, details);
+    },
+
+    acquire: function(force) {
+      if (this.held && !force && !this.pending) return $.Deferred().resolve(this.toJSON());
+      if (this.pending) return this.pending;
+
+      const data = {
+        expected_updated_at: this.document.get('updated_at'),
+        client_id: this.clientId,
+      };
+      if (this.token) data.token = this.token;
+
+      this.setState(this.held ? 'renewing' : 'acquiring');
+      this.pending = $.ajax({
+        type: 'post',
+        url: this.url(),
+        data: data,
+        global: false,
+      });
+      this.pending.done((response) => {
+        this.set(response);
+        this.token = response.token;
+        this.clientId = response.client_id;
+        // Base the local deadline on the lease duration rather than the
+        // browser clock, which may differ from the server clock.
+        this.expiresAt = Date.now() + (
+          new Date(response.expires_at).getTime() - new Date(response.renewed_at).getTime()
+        );
+        this.held = true;
+        window.clearTimeout(this.acquireRetryTimer);
+        this.setState('editing', response);
+        sessionStorage.setItem(this.storageKey, JSON.stringify({
+          token: this.token,
+          client_id: this.clientId,
+        }));
+        this.scheduleRenewal(response.renew_after_seconds);
+      });
+      this.pending.fail((xhr) => this.handleFailure(xhr));
+      this.pending.always(() => {
+        this.pending = null;
+      });
+      return this.pending;
+    },
+
+    scheduleRenewal: function(seconds) {
+      window.clearTimeout(this.renewTimer);
+      this.renewTimer = window.setTimeout(() => {
+        if (this.saving) {
+          this.scheduleRenewal(5);
+        } else {
+          this.acquire(true);
+        }
+      }, (seconds || 20) * 1000);
+    },
+
+    prepareToSave: async function() {
+      if (this.pending) {
+        try {
+          await Indigo.deferredToAsync(this.pending);
+        } catch (e) {
+          return false;
+        }
+      }
+      if (!this.held) return false;
+      this.saving = this.held;
+      window.clearTimeout(this.renewTimer);
+      return this.held;
+    },
+
+    saveFinished: function() {
+      this.saving = false;
+      if (this.held) this.scheduleRenewal(this.get('renew_after_seconds'));
+    },
+
+    handleFailure: function(xhr) {
+      const response = xhr.responseJSON || {};
+      if (xhr.status === 0 && this.held && Date.now() < this.expiresAt) {
+        Indigo.offlineNoticeView.setOffline();
+        this.scheduleRenewal(5);
+        return;
+      }
+      if (response.code === 'document_locked') {
+        this.held = false;
+        this.clearStoredLease();
+        this.setState('locked', response);
+        const expiresAt = new Date(response.expires_at).getTime();
+        const retryAfter = Math.max(1000, Math.min(10000, expiresAt - Date.now() + 250));
+        this.scheduleAcquisitionRetry(retryAfter);
+      } else if (response.code === 'document_changed' || response.code === 'edit_lease_lost') {
+        this.lose(response);
+      } else if (this.held) {
+        response.detail = $t('Saving is unavailable because the editing lease could not be renewed.');
+        this.lose(response);
+      } else {
+        this.setState('viewing', response);
+        this.scheduleAcquisitionRetry(5000);
+      }
+    },
+
+    scheduleAcquisitionRetry: function(milliseconds) {
+      window.clearTimeout(this.acquireRetryTimer);
+      this.acquireRetryTimer = window.setTimeout(() => {
+        if (!this.held && this.state !== 'stale') this.acquire();
+      }, milliseconds);
+    },
+
+    lose: function(response) {
+      this.held = false;
+      this.saving = false;
+      window.clearTimeout(this.renewTimer);
+      this.clearStoredLease();
+      this.setState(response && response.code === 'document_changed' ? 'stale' : 'lost', response);
+      if (!response || response.code !== 'document_changed') this.scheduleAcquisitionRetry(1000);
+    },
+
+    clearStoredLease: function() {
+      this.token = null;
+      sessionStorage.removeItem(this.storageKey);
     },
   });
 })(window);

--- a/indigo_app/static/javascript/indigo/views/document_activity.js
+++ b/indigo_app/static/javascript/indigo/views/document_activity.js
@@ -208,6 +208,7 @@
       document.addEventListener('visibilitychange', () => {
         if (this.held && document.visibilityState === 'visible') this.acquire(true);
       });
+      window.addEventListener('pagehide', () => this.release({keepalive: true}));
     },
 
     newId: function() {
@@ -319,6 +320,58 @@
     saveFinished: function() {
       this.saving = false;
       if (this.held) this.scheduleRenewal(this.get('renew_after_seconds'));
+    },
+
+    release: function(options) {
+      options = options || {};
+      if (!this.held || !this.token || this.saving) return;
+
+      const token = this.token;
+      const clientId = this.clientId;
+      const data = {
+        token: token,
+        client_id: clientId,
+      };
+      const released = () => {
+        // Do not clear a lease that may have been reacquired in the meantime.
+        if (this.token !== token || this.clientId !== clientId) return;
+        this.held = false;
+        window.clearTimeout(this.renewTimer);
+        window.clearTimeout(this.acquireRetryTimer);
+        this.clearStoredLease();
+        this.setState('viewing');
+      };
+
+      if (options.keepalive) {
+        // pagehide gives fetch only a brief opportunity to finish. Clear the
+        // local claim immediately; expiry remains the server-side fallback.
+        released();
+        window.fetch(this.url() + '/release', {
+          method: 'POST',
+          credentials: 'same-origin',
+          keepalive: true,
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'X-CSRFToken': Indigo.csrfToken,
+          },
+          body: new URLSearchParams(data).toString(),
+        }).catch(function() {});
+        return;
+      }
+
+      // While the page is alive, retain the local lease unless the server
+      // confirms release so a transient failure cannot lock this client out.
+      const request = $.ajax({
+        type: 'post',
+        url: this.url() + '/release',
+        data: data,
+        global: false,
+      });
+      request.done(released);
+      request.fail(() => {
+        if (this.held) this.scheduleRenewal(this.get('renew_after_seconds'));
+      });
+      return request;
     },
 
     handleFailure: function(xhr) {

--- a/indigo_app/static/javascript/indigo/views/document_activity.js
+++ b/indigo_app/static/javascript/indigo/views/document_activity.js
@@ -15,6 +15,7 @@
       this.template = Handlebars.compile($(this.template).html());
 
       this.document = options.document;
+      this.nonce = options.nonce;
       this.collection = new Backbone.Collection([], {
         model: Indigo.DocumentActivity,
         comparator: 'created_at',
@@ -165,6 +166,7 @@
   Indigo.DocumentEditLease = Backbone.Model.extend({
     initialize: function(options) {
       this.document = options.document;
+      this.activityNonce = options.activityNonce;
       this.document.editLease = this;
       this.held = false;
       this.pending = null;
@@ -258,6 +260,7 @@
         expected_updated_at: this.document.get('updated_at'),
         client_id: this.clientId,
       };
+      if (this.activityNonce) data.activity_nonce = this.activityNonce;
       if (this.token) data.token = this.token;
 
       this.setState(this.held ? 'renewing' : 'acquiring');

--- a/indigo_app/static/stylesheets/_documents.scss
+++ b/indigo_app/static/stylesheets/_documents.scss
@@ -96,6 +96,11 @@
   }
 }
 
+.edit-lease-disabled {
+  pointer-events: none;
+  opacity: 0.65;
+}
+
 /* headers with help buttons */
 a.help,
 button.btn-link.help {
@@ -429,6 +434,15 @@ body.document-editor-view {
 }
 
 #document-activity-view {
+  min-height: 25px;
+
+  ul {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 0;
+    padding-left: 0;
+  }
+
   li {
     list-style: none;
     float: left;
@@ -452,6 +466,16 @@ body.document-editor-view {
   .user-5 { background-color: #e6ab02; }
   .user-6 { background-color: #a6761d; }
   .user-7 { background-color: #666666; }
+}
+
+.document-activity-column {
+  max-width: 32rem;
+  text-align: right;
+
+  .edit-lease-status {
+    display: block;
+    line-height: 1.2;
+  }
 }
 
 .cheatsheet {

--- a/indigo_app/templates/indigo_api/document/_activity.html
+++ b/indigo_app/templates/indigo_api/document/_activity.html
@@ -3,8 +3,9 @@
   {% verbatim %}
   <ul>
     {{#each activity}}
-    <li class="{{#if is_asleep }}is-asleep{{/if}} user-{{ user.colour }}" title="{{ user.display_name }} is also editing">
+    <li class="{{#if is_asleep }}is-asleep{{/if}} user-{{ user.colour }}" title="{{ user.display_name }} also has this document open">
       <i class="fas fa-user"></i> {{ user.display_name }}
+      {{#if has_edit_lease}}<i class="fas fa-pencil-alt ms-1" title="Saving access"></i>{{/if}}
     </li>
     {{/each}}
   </ul>

--- a/indigo_app/templates/indigo_api/document/show.html
+++ b/indigo_app/templates/indigo_api/document/show.html
@@ -30,7 +30,10 @@
         </div>
 
         <div class="d-flex">
-          {% include 'indigo_api/document/_activity.html' %}
+          <div class="document-activity-column me-2">
+            {% include 'indigo_api/document/_activity.html' %}
+            <small class="edit-lease-status text-muted d-none"></small>
+          </div>
 
           <div class="document-workspace-buttons mt-1">
             {% block save-buttons %}

--- a/indigo_app/tests/test_authed_urls.py
+++ b/indigo_app/tests/test_authed_urls.py
@@ -52,6 +52,8 @@ api/documents/(?P<document_id>[0-9]+)/parse\Z
 api/documents/(?P<document_id>[0-9]+)/diff\Z
 api/documents/(?P<document_id>[0-9]+)/media/(?P<filename>.*)$
 api/documents/(?P<document_id>[0-9]+)/activity/edits\Z
+api/documents/(?P<document_id>[0-9]+)/edit\-lease\Z
+api/documents/(?P<document_id>[0-9]+)/edit\-lease/release\Z
 api/publications/(?P<country>[a-z]{2})(-(?P<locality>[^/]+))?/find$
 """.split()
 


### PR DESCRIPTION
This overhauls the old document locking functionality.

## optimistic concurrency

First, it introduces an optimistic concurrency model so that it's harder to overwrite old data accidentally. A document is only saved if the `updated_at` the client has is the same as what the server's current version shows.

This also means that an editor doesn't always have to refresh the page to make changes after someone else started editing, but didn't make changes.

## edit leases

Second, it adds a concept of an edit lease, which is stronger than a lock. When a user makes a change to a document, the app tries to acquire the edit lease for the document. If it succeeds, the user can then click the save button to save their changes. If it fails, the user can continue editing but a warning is shown. It will keep trying to acquire the lease. 

After a save, or when the tab is closed on the user navigates away, the lease is released.