### PR TITLE
 ensure main_commencement is cleared and work record updated upon commencement deletion

### DIFF
--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -662,8 +662,10 @@ class WorksWebTest(WebTest):
     def test_delete_work_commencement_clears_main_commencement(self):
         work = Work.objects.get(pk=1)
         commencement = work.main_commencement
+        url = f'/works{work.frbr_uri}/commencements/{commencement.id}'
+        csrf_token = self.app.get(url).forms[0]['csrfmiddlewaretoken'].value
 
-        response = self.app.post(f'/works{work.frbr_uri}/commencements/{commencement.id}', {'delete': ''})
+        response = self.app.post(url, {'delete': '', 'csrfmiddlewaretoken': csrf_token})
 
         self.assertRedirects(response, f'/works{work.frbr_uri}/commencements/', fetch_redirect_response=False)
         self.assertFalse(Commencement.objects.filter(pk=commencement.pk).exists())

--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -3,7 +3,7 @@ from urllib.parse import unquote
 from unittest.mock import Mock, patch
 
 import reversion
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
 from django.test import testcases, override_settings
 from django_webtest import WebTest
 from webtest import Upload
@@ -660,12 +660,14 @@ class WorksWebTest(WebTest):
         self.assertIsNone(work.main_commencement)
 
     def test_delete_work_commencement_clears_main_commencement(self):
+        user = User.objects.get(username='email@example.com')
+        user.user_permissions.add(Permission.objects.get(codename='delete_commencement'))
+        self.client.force_login(user)
         work = Work.objects.get(pk=1)
         commencement = work.main_commencement
         url = f'/works{work.frbr_uri}/commencements/{commencement.id}'
-        csrf_token = self.app.get(url).forms[0]['csrfmiddlewaretoken'].value
 
-        response = self.app.post(url, {'delete': '', 'csrfmiddlewaretoken': csrf_token})
+        response = self.client.post(url, {'delete': ''})
 
         self.assertRedirects(response, f'/works{work.frbr_uri}/commencements/', fetch_redirect_response=False)
         self.assertFalse(Commencement.objects.filter(pk=commencement.pk).exists())

--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -658,3 +658,14 @@ class WorksWebTest(WebTest):
         work.main_commencement.delete()
         work.refresh_from_db()
         self.assertIsNone(work.main_commencement)
+
+    def test_delete_work_commencement_clears_main_commencement(self):
+        work = Work.objects.get(pk=1)
+        commencement = work.main_commencement
+
+        response = self.client.post(f'/works{work.frbr_uri}/commencements/{commencement.id}', {'delete': ''})
+
+        self.assertRedirects(response, f'/works{work.frbr_uri}/commencements/', fetch_redirect_response=False)
+        self.assertFalse(Commencement.objects.filter(pk=commencement.pk).exists())
+        work.refresh_from_db()
+        self.assertIsNone(work.main_commencement)

--- a/indigo_app/tests/test_works.py
+++ b/indigo_app/tests/test_works.py
@@ -663,7 +663,7 @@ class WorksWebTest(WebTest):
         work = Work.objects.get(pk=1)
         commencement = work.main_commencement
 
-        response = self.client.post(f'/works{work.frbr_uri}/commencements/{commencement.id}', {'delete': ''})
+        response = self.app.post(f'/works{work.frbr_uri}/commencements/{commencement.id}', {'delete': ''})
 
         self.assertRedirects(response, f'/works{work.frbr_uri}/commencements/', fetch_redirect_response=False)
         self.assertFalse(Commencement.objects.filter(pk=commencement.pk).exists())

--- a/indigo_app/views/works.py
+++ b/indigo_app/views/works.py
@@ -421,7 +421,7 @@ class WorkCommencementDetailView(AbstractAuthedIndigoView, DetailView):
         work = commencement.commenced_work
         commencement.delete()
         work.updated_by_user = self.request.user
-        work.save()
+        work.save(update_fields=['updated_by_user', 'updated_at'])
         return redirect(reverse('work_commencements', kwargs={'frbr_uri': work.frbr_uri}))
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
This PR solves issue #2565 , where deleting a commencement caused a foreign-key error by saving a stale main_commencement_id.It limits the subsequent work update to the audit fields, preventing the deleted commencement ID from being restored.